### PR TITLE
add easy syntax for building/testing certain elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "scripts": {
     "start": "npm run doc-listing-inject && spandx",
     "lerna": "lerna",
-    "test": "npm run build && wct --configFile wct.conf.json test/index.html",
+    "test": "bash scripts/test.sh",
     "dev": "bash scripts/dev.sh",
-    "build": "lerna run build",
+    "build": "bash scripts/build.sh",
     "clean": "rm -rf node_modules package-lock.json {elements,themes}/*/{node_modules,package-lock.json}",
     "bootstrap": "lerna bootstrap --hoist",
     "postinstall": "npm run bootstrap",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CMD="npm run lerna -- run build --parallel --no-bail --include-filtered-dependencies"
+
+for el in "$@"; do
+  CMD="$CMD --scope \"*/$el\""
+done
+
+eval $CMD

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json"
+
+for el in "$@"; do
+  if [[ "$el" == "-p" ]]; then
+    CMD="$CMD -p"
+  else
+    CMD="$CMD \"elements/$el/test/\""
+  fi
+done
+
+eval $CMD

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,8 +3,8 @@
 CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json"
 
 for el in "$@"; do
-  if [[ "$el" == "-p" ]]; then
-    CMD="$CMD -p"
+  if [[ $el == -* ]]; then
+    CMD="$CMD $el"
   else
     CMD="$CMD \"elements/$el/test/\""
   fi


### PR DESCRIPTION
This extends #256 to `test` and `build`.  Allows running builds and tests like:

```
npm run build pfe-card pfe-cta
```

Or

```
npm test pfe-datetime
```