### PR TITLE
fix scss compilation

### DIFF
--- a/themes/cp-theme/red-hat-sass/variables/_typography.scss
+++ b/themes/cp-theme/red-hat-sass/variables/_typography.scss
@@ -6,7 +6,7 @@
 // Base Typography
 // ========================================================================
 
-$pfe-global--FontSize:        #{$pfe-global--font-size-root}px !default;
+$pfe-global--FontSize:        $pfe-global--font-size-root + 0px !default;
 
 // Line heights
 $pfe-global--LineHeight--sm:  1.2 !default;


### PR DESCRIPTION
This changes the base font size from a string to a unit, so that it can be multiplied.