### PR TITLE
Add support for schemas to inject properties into web components

### DIFF
--- a/scripts/gulpfile.factory.js
+++ b/scripts/gulpfile.factory.js
@@ -14,74 +14,6 @@ module.exports = function factory({
   const decomment = require("decomment");
   const sass = require("node-sass");
   const shell = require("gulp-shell");
-  const banner = require("gulp-banner");
-
-  gulp.task("merge", () => {
-    return gulp
-      .src(`./src/${elementName}.js`)
-      .pipe(
-        replace(
-          /extends\s+PFElement\s+{/g,
-          (classStatement, character, jsFile) => {
-            // extract the templateUrl and styleUrl with regex.  Would prefer to do
-            // this by require'ing rh-something.js and asking it directly, but without
-            // node.js support for ES modules, we're stuck with this.
-            const oneLineFile = jsFile
-              .slice(character)
-              .split("\n")
-              .join(" ");
-            const [
-              ,
-              templateUrl
-            ] = /get\s+templateUrl\([^)]*\)\s*{\s*return\s+"([^"]+)"/.exec(
-              oneLineFile
-            );
-
-            let html = fs
-              .readFileSync(path.join("./src", templateUrl))
-              .toString()
-              .trim();
-
-            html = decomment(html);
-
-            const [
-              ,
-              styleUrl
-            ] = /get\s+styleUrl\([^)]*\)\s*{\s*return\s+"([^"]+)"/.exec(
-              oneLineFile
-            );
-
-            const styleFilePath = path.join("./src", styleUrl);
-
-            let cssResult = sass.renderSync({
-              file: styleFilePath
-            }).css;
-
-            cssResult = stripCssComments(cssResult).trim();
-
-            return `${classStatement}
-  get html() {
-    return \`
-<style>
-${cssResult}
-</style>
-${html}\`;
-  }
-`;
-          }
-        )
-      )
-      .pipe(
-        banner(
-          `/*\n${fs
-            .readFileSync("LICENSE.txt", "utf8")
-            .split("\n")
-            .map(line => ` * ${line}\n`)
-            .join("")}*/\n\n`
-        )
-      )
-      .pipe(gulp.dest("./"));
-  });
 
   gulp.task("compile", () => {
     return gulp
@@ -96,6 +28,114 @@ ${html}\`;
         rename({
           suffix: ".umd"
         })
+      )
+      .pipe(gulp.dest("./"));
+  });
+
+  gulp.task("merge", () => {
+    return gulp
+      .src(`./src/${elementName}.js`)
+      .pipe(
+        replace(
+          /extends\s+PFElement\s+{/g,
+          (classStatement, character, jsFile) => {
+            // Extract the urls for template, style, and schema
+            // -- Would prefer to do this by require'ing and asking it directly, but without
+            //    node.js support for ES modules, we're stuck with this.
+            const oneLineFile = jsFile
+              .slice(character)
+              .split("\n")
+              .join(" ");
+
+            let url = {};
+            ["template", "style", "schema"].forEach(type => {
+              const re = new RegExp(
+                `get\\s+${type}Url\\([^)]*\\)\\s*{\\s*return\\s+"([^"]+)"`,
+                "g"
+              );
+              const parse = re.exec(oneLineFile);
+              url[type] =
+                typeof parse === "object" && parse !== null ? parse[1] : null;
+            });
+
+            // Initialize sections to empty strings
+            let html = "";
+            let cssResult = "";
+
+            // Initialize properties and slots to empty objects
+            let properties = "{}";
+            let slots = "{}";
+
+            // If the template url is defined and the file exists
+            if (
+              url.template !== null &&
+              fs.existsSync(path.join("./src", url.template))
+            ) {
+              // Add the contents of the file to the html variable
+              html = fs
+                .readFileSync(path.join("./src", url.template))
+                .toString()
+                .trim();
+              html = decomment(html);
+            }
+
+            // If the style url is defined and the file exists
+            if (
+              url.style !== null &&
+              fs.existsSync(path.join("./src", url.style))
+            ) {
+              // Add the css rendered version to the css variable
+              let rawCSS = sass.renderSync({
+                file: path.join("./src", url.style)
+              }).css;
+              rawCSS = stripCssComments(rawCSS).trim();
+              // If any CSS has been rendered, wrap it in style tags
+              if (rawCSS.toString() !== "") {
+                cssResult = `<style>${rawCSS}</style>`;
+              }
+            }
+
+            // If the schema url is defined and the file exists
+            if (
+              url.schema !== null &&
+              fs.existsSync(path.join("./src", url.schema))
+            ) {
+              // Parse the json file in it's entirety
+              let schemaObj = JSON.parse(
+                fs.readFileSync(path.join("./src", url.schema))
+              );
+              // If the schema object exists
+              if (schemaObj && typeof schemaObj === "object") {
+                // Get the attribute values and assign them to properties
+                if (schemaObj.properties.attributes) {
+                  properties = schemaObj.properties.attributes.properties;
+                  // Convert back to a string
+                  properties = JSON.stringify(properties);
+                }
+                // If the slots are defined, assign them to slots object
+                if (schemaObj.properties.slots) {
+                  slots = schemaObj.properties.slots.properties;
+                  // Convert back to a string
+                  slots = JSON.stringify(slots);
+                }
+              }
+            }
+
+            // Return the necessary functions to inject into the template
+            return `${classStatement}
+  get html() {
+    return \`${cssResult}${html}\`;
+  }
+
+  static get properties() {
+    return ${properties};
+  }
+
+  static get slots() {
+    return ${slots};
+  }`;
+          }
+        )
       )
       .pipe(gulp.dest("./"));
   });


### PR DESCRIPTION
This adds support for schema definitions in web components.  Schemas would be optionally added to the src directory of a component and use the following format:

```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Component name",
  "description": "This element does a thing.",
  "type": "object",
  "tag": "pfe-thing",
  "class": "pfe-thing",
  "category": "container",
  "properties": {
    "slots": {
      "title": "Slots",
      "description": "Definition of the supported slots",
      "type": "object",
      "properties": {
        "pfe-thing-body": {
          "title": "Body",
          "type": "array",
          "namedSlot": false,
          "maxItems": 3,
          "items": {
            "title": "Body item",
            "oneOf": [{
              "$ref": "raw"
            }]
          }
        }
      }
    },
    "attributes": {
      "title": "Attributes",
      "type": "object",
      "properties": {
        "pfe-color": {
          "title": "Background color",
          "type": "string",
          "enum": ["lightest", "lighter", "base", "darker", "darkest", "complement", "accent"],
          "default": "base",
          "observer": "_colorChanged"
        }
      }
    }
  },
  "required": ["slots", "attributes"],
  "additionalProperties": false
}
```

These schemas will be loaded onto the web component as properties via the pfelement base class which now parses the schema for information about the slots and attributes.  In addition, storybook will now be able to hook into the schema and automatically build out the slot and attribute fields without manual configuration.  Schemas will also provide us a way to understand the valid inputs of a component as well as the relationships between different components.