### PR TITLE
Update date on licenses to 2019

### DIFF
--- a/elements/pfe-autocomplete/LICENSE.txt
+++ b/elements/pfe-autocomplete/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2018 Red Hat, Inc.
+Copyright 2019 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/elements/pfe-avatar/LICENSE.txt
+++ b/elements/pfe-avatar/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2018 Red Hat, Inc.
+Copyright 2019 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/elements/pfe-band/LICENSE.txt
+++ b/elements/pfe-band/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2018 Red Hat, Inc.
+Copyright 2019 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/elements/pfe-sass/LICENSE.txt
+++ b/elements/pfe-sass/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2018 Red Hat, Inc.
+Copyright 2019 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Minor clean-up branch updating remaining 2018 references in our component licenses to 2019.