### PR TITLE
fix the directory of the hugo-check.sh call

### DIFF
--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-source hugo-check.sh
+source $DIR/hugo-check.sh
 
 hugoNoisyCheck || exit 1
 


### PR DESCRIPTION
The script that calls hugo-check.sh was referring to the wrong directory, and this PR fixes that problem.   The hugo check script may have other issues on Macs, but this is only meant to fix the incorrect-directory issue.