### PR TITLE
add 'viewport' meta tag to pfe-content-set demo

### DIFF
--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>PatternFly Element | pfe-content-set Demo</title>
     <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <!-- uncomment the es5-adapter if you're using the umd version -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/custom-elements-es5-adapter.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/webcomponents-bundle.js"></script>


### PR DESCRIPTION
This adds `<meta name="viewport" value="...">` to the pfe-content-set demo page.  Without it, the content set fails to detect the actual width of the screen in some situations (like devtools responsive mode).