### PR TITLE
fix pfe-avatar in ie11

### DIFF
--- a/elements/pfe-avatar/demo/index.html
+++ b/elements/pfe-avatar/demo/index.html
@@ -13,14 +13,12 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.2/vue.min.js"></script>
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <!-- <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script> -->
-    <!-- <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script> -->
-    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script> -->
-    <!-- <script>require(['../../pfelement/pfelement.umd.js', '../pfe-avatar.umd.js'], function(PFElement) { -->
-    <!--   PFElement.debugLog(true); -->
-    <!--   })</script> -->
+    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+    <script>require(['../pfe-avatar.umd.js'])</script>
 
-    <script type="module" src="../pfe-avatar.js"></script>
+    <!-- <script type="module" src="../pfe-avatar.js"></script> -->
 
     <style type="text/css" media="screen">
       /* :root {
@@ -47,7 +45,7 @@
     </ul>
 
     <script>
-      const app = new Vue({
+      var app = new Vue({
         el: "#app",
         data: {
           people: [

--- a/elements/pfe-avatar/src/hslrgb.js
+++ b/elements/pfe-avatar/src/hslrgb.js
@@ -39,36 +39,12 @@ export function hsl2rgb(_H, _S, _L) {
 
     a = 2 * L - b;
 
-    R = 255 * h2rgb(a, b, H + 1 / 3);
-    G = 255 * h2rgb(a, b, H);
-    B = 255 * h2rgb(a, b, H - 1 / 3);
+    R = Math.floor(255 * h2rgb(a, b, H + 1 / 3));
+    G = Math.floor(255 * h2rgb(a, b, H));
+    B = Math.floor(255 * h2rgb(a, b, H - 1 / 3));
   }
 
   return [R, G, B];
-}
-
-/**
- * Converts a decimal number into a hexadecimal number, left-padded to a given length.
- */
-function toHex(d, len) {
-  return ("0" + Math.round(d).toString(16)).slice(-len);
-}
-
-/**
- * Converts an HSL color to a hexadecimal color.
- */
-export function hsl2hex(_H, _S, _L) {
-  return rgb2hex(hsl2rgb(_H, _S, _L));
-}
-
-/**
- * Converts an RGB color to a hexadecimal color.
- */
-export function rgb2hex(_R, _G, _B) {
-  console.log(`converting ${_R}, ${_G}, ${_B} to hex`);
-  const ret = "#" + [_R, _G, _B].map(c => toHex(c, 2)).join("");
-  console.log(`done ${ret}`);
-  return ret;
 }
 
 /**

--- a/elements/pfe-avatar/src/hslrgb.js
+++ b/elements/pfe-avatar/src/hslrgb.js
@@ -48,7 +48,31 @@ export function hsl2rgb(_H, _S, _L) {
 }
 
 /**
- * Convert an RGBcolor to HSL .
+ * Converts a decimal number into a hexadecimal number, left-padded to a given length.
+ */
+function toHex(d, len) {
+  return ("0" + Math.round(d).toString(16)).slice(-len);
+}
+
+/**
+ * Converts an HSL color to a hexadecimal color.
+ */
+export function hsl2hex(_H, _S, _L) {
+  return rgb2hex(hsl2rgb(_H, _S, _L));
+}
+
+/**
+ * Converts an RGB color to a hexadecimal color.
+ */
+export function rgb2hex(_R, _G, _B) {
+  console.log(`converting ${_R}, ${_G}, ${_B} to hex`);
+  const ret = "#" + [_R, _G, _B].map(c => toHex(c, 2)).join("");
+  console.log(`done ${ret}`);
+  return ret;
+}
+
+/**
+ * Convert an RGBcolor to HSL.
  *
  * @param {Number} R the red component
  * @param {Number} G the green component

--- a/elements/pfe-avatar/src/pfe-avatar.js
+++ b/elements/pfe-avatar/src/pfe-avatar.js
@@ -1,6 +1,6 @@
 import PFElement from "../pfelement/pfelement.js";
 import { hash } from "./djb-hash.js";
-import { hsl2rgb, rgb2hsl } from "./hslrgb.js";
+import { hsl2rgb, rgb2hsl, rgb2hex } from "./hslrgb.js";
 
 class PfeAvatar extends PFElement {
   static get tag() {
@@ -24,6 +24,10 @@ class PfeAvatar extends PFElement {
       triangles: "triangles",
       squares: "squares"
     };
+  }
+
+  static get defaultSize() {
+    return 128;
   }
 
   static get defaultColors() {
@@ -90,7 +94,9 @@ class PfeAvatar extends PFElement {
 
   _initCanvas() {
     this._canvas = this.shadowRoot.querySelector("canvas");
-    const size = this.var("--pfe-avatar--width").replace(/px$/, "");
+    const size =
+      this.var("--pfe-avatar--width").replace(/px$/, "") ||
+      PfeAvatar.defaultSize;
     this._canvas.width = size;
     this._canvas.height = size;
 
@@ -123,7 +129,9 @@ class PfeAvatar extends PFElement {
           );
           if (pattern) {
             pattern.shift();
+            console.log("pattern", pattern);
             const color = pattern.map(c => parseInt(c, 16));
+            console.log("color", color);
             this._registerColor(color);
           } else {
             this.log(`[pfe-avatar] invalid color ${colorCode}`);
@@ -136,8 +144,8 @@ class PfeAvatar extends PFElement {
 
   static _registerColor(color) {
     PfeAvatar.colors.push({
-      color1: `rgb(${color.join(",")})`,
-      color2: `rgb(${this._adjustColor(color).join(",")})`
+      color1: rgb2hex(...color),
+      color2: rgb2hex(...this._adjustColor(color))
     });
   }
 
@@ -145,6 +153,7 @@ class PfeAvatar extends PFElement {
     const dark = 0.1;
     const l_adj = 0.1; // luminance adjustment
     const hsl = rgb2hsl(...color);
+    console.log(`${color} -> ${hsl}`);
 
     // if luminance is too dark already, then lighten the alternate color
     // instead of darkening it.

--- a/elements/pfe-avatar/src/pfe-avatar.js
+++ b/elements/pfe-avatar/src/pfe-avatar.js
@@ -1,6 +1,6 @@
 import PFElement from "../pfelement/pfelement.js";
 import { hash } from "./djb-hash.js";
-import { hsl2rgb, rgb2hsl, rgb2hex } from "./hslrgb.js";
+import { hsl2rgb, rgb2hsl } from "./hslrgb.js";
 
 class PfeAvatar extends PFElement {
   static get tag() {
@@ -129,9 +129,7 @@ class PfeAvatar extends PFElement {
           );
           if (pattern) {
             pattern.shift();
-            console.log("pattern", pattern);
             const color = pattern.map(c => parseInt(c, 16));
-            console.log("color", color);
             this._registerColor(color);
           } else {
             this.log(`[pfe-avatar] invalid color ${colorCode}`);
@@ -144,8 +142,8 @@ class PfeAvatar extends PFElement {
 
   static _registerColor(color) {
     PfeAvatar.colors.push({
-      color1: rgb2hex(...color),
-      color2: rgb2hex(...this._adjustColor(color))
+      color1: `rgb(${color.join(",")})`,
+      color2: `rgb(${this._adjustColor(color).join(",")})`
     });
   }
 
@@ -153,7 +151,6 @@ class PfeAvatar extends PFElement {
     const dark = 0.1;
     const l_adj = 0.1; // luminance adjustment
     const hsl = rgb2hsl(...color);
-    console.log(`${color} -> ${hsl}`);
 
     // if luminance is too dark already, then lighten the alternate color
     // instead of darkening it.


### PR DESCRIPTION
Fixes two problems with IE11:

 - `PFelement.var()`, used to get the current value of CSS variables, doesn't work in IE11 (or anywhere with shadyCSS I would bet).  The size of avatars is controlled with a CSS variable so the size wasn't available in IE11.  This adds a fallback of 128x128.
 - IE11 doesn't accept decimals in rgb values (at least not for canvas fillStyle).  To fix, I floored the values.  `rgb(128.555, 16, 71.0)` will now be `rgb(128, 16, 71)`.

IE11 screenshot

![win10_ie_11 0](https://user-images.githubusercontent.com/364615/62139256-fecab400-b2b6-11e9-8950-926fc664fd65.jpg)
