### PR TITLE
remove sourceMappingURL from src/pfelement.js

### DIFF
--- a/elements/pfelement/src/pfelement.js
+++ b/elements/pfelement/src/pfelement.js
@@ -270,4 +270,3 @@ class PFElement extends HTMLElement {
 autoReveal(PFElement.log);
 
 export default PFElement;
-//# sourceMappingURL=PFElement.js.map


### PR DESCRIPTION
This belongs in the compiled asset, not the source.