### PR TITLE
setting polyfills to be loaded from cdn so pages will work with netlify

### DIFF
--- a/docs/content/develop/step-2b.md
+++ b/docs/content/develop/step-2b.md
@@ -39,8 +39,8 @@ We'll also need to update `/demo/index.html` so that the user's name is passed i
     <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-cool-element.umd.js'])</script>
   </head>

--- a/elements/pfe-accordion/demo/index.html
+++ b/elements/pfe-accordion/demo/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/typebase.css/0.5.0/typebase.css">
     -->
-    <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
     <noscript>
       <link href="../../pfelement/pfelement-noscript.min.css" rel="stylesheet">
     </noscript>
@@ -16,8 +16,8 @@
 
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require([
 

--- a/elements/pfe-autocomplete/demo/index.html
+++ b/elements/pfe-autocomplete/demo/index.html
@@ -11,8 +11,8 @@
     <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require([
       '../pfe-autocomplete.umd.js'

--- a/elements/pfe-avatar/demo/index.html
+++ b/elements/pfe-avatar/demo/index.html
@@ -13,8 +13,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.2/vue.min.js"></script>
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-avatar.umd.js'])</script>
 

--- a/elements/pfe-band/demo/index.html
+++ b/elements/pfe-band/demo/index.html
@@ -17,10 +17,10 @@
     <link href="../../pfe-layouts/pfe-layouts.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
     
     <!-- Use webcomponents-loader when you are adding support for more modern browsers -->
-    <!-- <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script> -->
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script> -->
 
     <!-- IE11 test: use bundle + require with umd files -->
     <!-- Use webcomponents-bundle when supporting much older browsers like IE11 -->

--- a/elements/pfe-card/demo/index.html
+++ b/elements/pfe-card/demo/index.html
@@ -118,7 +118,7 @@
 
     <div class="demo-cards">
       <pfe-card pfe-color="lighter">
-        <img src="http://placekitten.com/200/150"/>
+        <img src="https://placekitten.com/200/150"/>
         <h2>Imaged card with no overflow</h2>
         <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit.</p>
         <pfe-cta slot="pfe-card--footer">
@@ -127,7 +127,7 @@
       </pfe-card>
 
       <pfe-card pfe-color="lighter">
-        <img pfe-overflow="top right left" src="http://placekitten.com/600/300"/>
+        <img pfe-overflow="top right left" src="https://placekitten.com/600/300"/>
         <h2>Imaged card with top & side overflow</h2>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat porro similique saepe tempora vel! Facilis, porro?</p>
         <pfe-cta slot="pfe-card--footer">
@@ -137,7 +137,7 @@
 
       <pfe-card pfe-color="lighter" class="custom-header-background">
         <h2 slot="pfe-card--header">Imaged card with side overflow + header</h2>
-        <img pfe-overflow="top right left" src="http://placekitten.com/500/250"/>
+        <img pfe-overflow="top right left" src="https://placekitten.com/500/250"/>
         <p style="margin-top: 10px;">Lorem ipsum dolor sit amet consectetur adipisicing elit. Quaerat porro similique saepe tempora vel! Facilis, porro?</p>
         <pfe-cta slot="pfe-card--footer">
           <a href="#">Learn more</a>
@@ -146,7 +146,7 @@
 
       <pfe-card pfe-color="lighter">
         <h2>Imaged card with side overflow</h2>
-        <img pfe-overflow="right left" src="http://placekitten.com/450/250"/>
+        <img pfe-overflow="right left" src="https://placekitten.com/450/250"/>
         <pfe-cta slot="pfe-card--footer">
           <a href="#">Learn more</a>
         </pfe-cta>
@@ -155,7 +155,7 @@
       <pfe-card pfe-color="lighter">
         <h2>Imaged card with side & bottom overflow</h2>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Soluta rerum tempore natus alias! Cumque illum provident corrupti voluptates.</p>
-        <img pfe-overflow="right left bottom" src="http://placekitten.com/400/250" slot="pfe-card--footer"/>
+        <img pfe-overflow="right left bottom" src="https://placekitten.com/400/250" slot="pfe-card--footer"/>
       </pfe-card>
     </div>
   </body>

--- a/elements/pfe-card/demo/index.html
+++ b/elements/pfe-card/demo/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PFElements: pfe-card Demo</title>
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 
     <!--

--- a/elements/pfe-card/demo/pfe-card.story.js
+++ b/elements/pfe-card/demo/pfe-card.story.js
@@ -88,7 +88,7 @@ stories.add(PfeCard.tag, () => {
         break;
     }
 
-    image = `<img src=\"http://placekitten.com/1000/300\" ${overflowAttr.length > 0 ? ` pfe-overflow=\"${overflowAttr.join(" ")}\"` : ""}/>`;
+    image = `<img src=\"https://placekitten.com/1000/300\" ${overflowAttr.length > 0 ? ` pfe-overflow=\"${overflowAttr.join(" ")}\"` : ""}/>`;
     if(region === "footer") {
       slots.footer.default = image;
     } else {

--- a/elements/pfe-card/test/pfe-card_test.html
+++ b/elements/pfe-card/test/pfe-card_test.html
@@ -27,12 +27,12 @@
       </pfe-card>
 
       <pfe-card id="card2">
-        <img src="http://placekitten.com/200/150"/>
+        <img src="https://placekitten.com/200/150"/>
       </pfe-card>
 
       <pfe-card id="card3">
         <h2 slot="pfe-card--header">Card 3</h2>
-        <img src="http://placekitten.com/1000/500" pfe-overflow="top right bottom left"/>
+        <img src="https://placekitten.com/1000/500" pfe-overflow="top right bottom left"/>
       </pfe-card>
 
       <pfe-card id="card4">

--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8">
     <title>PatternFly Element | pfe-content-set Demo</title>
-    <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/webcomponents-bundle.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-bundle.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>
       require([

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -9,13 +9,13 @@
     <link href="../../pfelement/pfelement-noscript.min.css" rel="stylesheet">
   </noscript-->
   <link href="../../pfe-cta/pfe-cta--lightdom.css" rel="stylesheet">
-  <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+  <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
   <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
   <link href="demo.css" rel="stylesheet">
   <!-- uncomment the es5-adapter if you're using the umd version -->
-  <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
   <!-- Use webcomponents-loader when you are adding support for more modern browsers -->
-  <!-- <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script> -->
+  <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script> -->
   <!-- IE11 test: use bundle + require with umd files -->
   <!-- Use webcomponents-bundle when supporting much older browsers like IE11 -->
   <script src="/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>

--- a/elements/pfe-datetime/demo/index.html
+++ b/elements/pfe-datetime/demo/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>PFElements: pfe-datetime Demo</title>
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-datetime.umd.js'])</script>
     <script>

--- a/elements/pfe-health-index/demo/index.html
+++ b/elements/pfe-health-index/demo/index.html
@@ -11,8 +11,8 @@
     <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-health-index.umd.js'])</script>
     <style>

--- a/elements/pfe-icon-panel/demo/index.html
+++ b/elements/pfe-icon-panel/demo/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <title>PFElements: pfe-icon-panel Demo</title>
 
-    <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-icon-panel.umd.js'])</script>
 

--- a/elements/pfe-icon/demo/index.html
+++ b/elements/pfe-icon/demo/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <title>PFElements: pfe-icon Demo</title>
 
-    <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-icon.umd.js'])</script>
 

--- a/elements/pfe-markdown/demo/index.html
+++ b/elements/pfe-markdown/demo/index.html
@@ -9,13 +9,13 @@
     </noscript>
 
     <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
-    
+
     <!-- Test using the Red Hat theme -->
     <link href="https://static.redhat.com/libs/redhat/redhat-theme/latest/advanced-theme.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.7/webcomponents-bundle.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-bundle.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-markdown.umd.min.js'])</script>
     <!-- <script type="module" src="../pfe-markdown.min.js"></script> -->

--- a/elements/pfe-number/demo/index.html
+++ b/elements/pfe-number/demo/index.html
@@ -7,8 +7,8 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.2/vue.min.js"></script>
 
         <!-- uncomment the es5-adapter if you're using the umd version -->
-        <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-        <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
         <!-- <script type=module src=../pfe-number.js></script> -->
         <script>require(['../pfe-number.umd.js'])</script>

--- a/elements/pfe-page-status/demo/index.html
+++ b/elements/pfe-page-status/demo/index.html
@@ -11,8 +11,8 @@
     <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfe-page-status.umd.js'])</script>
   </head>

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>PatternFly Elements: pfe-tabs Demo</title>
 
-    <link rel="stylesheet" href="http://overpass-30e2.kxcdn.com/overpass.css" />
+    <link rel="stylesheet" href="https://overpass-30e2.kxcdn.com/overpass.css" />
 
     <!--
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="../../../themes/cp-theme/cp-theme.css" /> -->
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require([
       '../pfe-tabs.umd.js'

--- a/elements/pfelement/demo/index.html
+++ b/elements/pfelement/demo/index.html
@@ -5,8 +5,8 @@
     <title>PFElements: pfelement Demo</title>
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-    <script src="/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-loader.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
     <script>require(['../pfelement.umd.js'])</script>
     <noscript>


### PR DESCRIPTION
## setting polyfills to be loaded from cdn so pages will work with netlify

* Integration with Netlify will help us preview PRs in the browser so we don't always have to pull the branch down locally just to see the changes

---

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* I had to switch all of the references to the polyfills to point to cdnjs since we won't have Netlify run spandx.

