### PR TITLE
remove 'gitHead' properties from some package.jsons

### DIFF
--- a/elements/pfe-accordion/package.json
+++ b/elements/pfe-accordion/package.json
@@ -42,6 +42,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.5",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.5"
 }

--- a/elements/pfe-card/package.json
+++ b/elements/pfe-card/package.json
@@ -36,6 +36,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.0",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.0"
 }

--- a/elements/pfe-cta/package.json
+++ b/elements/pfe-cta/package.json
@@ -36,6 +36,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.0",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.0"
 }

--- a/elements/pfe-datetime/package.json
+++ b/elements/pfe-datetime/package.json
@@ -34,6 +34,5 @@
   "dependencies": {
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.2.8",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.2.8"
 }

--- a/elements/pfe-health-index/package.json
+++ b/elements/pfe-health-index/package.json
@@ -36,6 +36,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.6.3",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.6.3"
 }

--- a/elements/pfe-icon-panel/package.json
+++ b/elements/pfe-icon-panel/package.json
@@ -36,6 +36,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.0",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.0"
 }

--- a/elements/pfe-icon/package.json
+++ b/elements/pfe-icon/package.json
@@ -36,6 +36,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.0",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.0"
 }

--- a/elements/pfe-layouts/package.json
+++ b/elements/pfe-layouts/package.json
@@ -32,6 +32,5 @@
   "license": "MIT",
   "dependencies": {
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19"
-  },
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  }
 }

--- a/elements/pfe-number/package.json
+++ b/elements/pfe-number/package.json
@@ -34,6 +34,5 @@
     "@patternfly/pfelement": "^1.0.0-prerelease.19",
     "numeral": "^2.0.6"
   },
-  "generator-pfelement-version": "0.2.9",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.2.9"
 }

--- a/elements/pfe-sass/package.json
+++ b/elements/pfe-sass/package.json
@@ -40,6 +40,5 @@
       "name": "cd"
     }
   ],
-  "license": "MIT",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "license": "MIT"
 }

--- a/elements/pfe-tabs/package.json
+++ b/elements/pfe-tabs/package.json
@@ -39,6 +39,5 @@
     "@patternfly/pfe-sass": "^1.0.0-prerelease.19",
     "@patternfly/pfelement": "^1.0.0-prerelease.19"
   },
-  "generator-pfelement-version": "0.5.4",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.5.4"
 }

--- a/elements/pfelement/package.json
+++ b/elements/pfelement/package.json
@@ -39,6 +39,5 @@
     }
   ],
   "license": "MIT",
-  "generator-pfelement-version": "0.3.4",
-  "gitHead": "dfa74e0495c556ebdd1edb61c6d406621d1b6421"
+  "generator-pfelement-version": "0.3.4"
 }


### PR DESCRIPTION
## remove 'gitHead' properties from some package.jsons

---

### What has changed and why

`gitHead` is a property that gets added to package.jsons by Lerna, during `lerna publish`.  It's a temporary property that gets removed after `lerna publish` concludes.  There are some elements that were committed with `gitHead` in their package.json long ago (prerelease.4 era) and this PR removes them.