### PR TITLE
adding one last check for a controlledPanel

### DIFF
--- a/elements/pfe-collapse/src/pfe-collapse.js
+++ b/elements/pfe-collapse/src/pfe-collapse.js
@@ -114,6 +114,11 @@ class PfeCollapseToggle extends PFElement {
 
     this.expanded = !this.expanded;
 
+    // one last try to hook up a panel
+    if (!this.controlledPanel) {
+      this._connectPanel(this.getAttribute("aria-controls"));
+    }
+
     if (this.controlledPanel) {
       this.controlledPanel.expanded = this.expanded;
 

--- a/elements/pfe-collapse/test/pfe-collapse_test.html
+++ b/elements/pfe-collapse/test/pfe-collapse_test.html
@@ -43,6 +43,10 @@
       </pfe-collapse>
     </div>
 
+    <div id="latePanel">
+      <pfe-collapse-toggle aria-controls="latePanel1">Toggle</pfe-collapse-toggle>
+    </div>
+
     <script>
       suite("<pfe-collapse>", () => {
         test("it should upgrade", () => {
@@ -260,6 +264,23 @@
             assert.equal(toggle.getAttribute("aria-expanded"), "false");
             assert.isTrue(!panel.hasAttribute("pfe-expanded"));
 
+            done();
+          });
+        });
+
+        test("it should still be able to open a panel that is added to the DOM after the toggle has been added", done => {
+          const collapseContainer = document.querySelector('#latePanel');
+          const toggle = collapseContainer.querySelector('pfe-collapse-toggle');
+          const panel = document.createElement("pfe-collapse-panel");
+          panel.id = "latePanel1";
+          panel.innerText = "Panel";
+
+          collapseContainer.appendChild(panel);
+          toggle.click();
+
+          flush(() => {
+            assert.equal(toggle.getAttribute("aria-expanded"), "true");
+            assert.isTrue(panel.hasAttribute("pfe-expanded"));
             done();
           });
         });


### PR DESCRIPTION
Fixes #522

## adding one last check for a controlledPanel

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* In certain scenarios, it's possible that the panel will be added to the DOM after the toggle has already been added. If a user were to click the toggle, it will never find the associated panel.
* This fix gives the toggle one last opportunity to find the panel

