### PR TITLE
create annotated tags

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,7 +72,8 @@ commitIgnoredFiles() {
 
 gitTag() {
   log "creating a git tag"
-  git tag $TAG_NAME || exit 1
+  # create an annotated tag (lerna only picks up on annotated tags)
+  git tag -a -m "$TAG_NAME" $TAG_NAME || exit 1
 }
 
 removeIgnoredFiles() {


### PR DESCRIPTION
Annotate tags when releasing.  This will probably fix lerna versioning.  Also, must not squash commitss when merging release PRs.