### PR TITLE
Lerna ignore built

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,10 @@
     "elements/*",
     "themes/*"
   ],
-  "version": "1.0.0-prerelease.23"
+  "version": "1.0.0-prerelease.23",
+  "ignoreChanges": [
+    "elements/*/*.css",
+    "elements/*/*.js",
+    "elements/*/*.map"
+  ]
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -79,7 +79,7 @@ gitTag() {
 removeIgnoredFiles() {
   log "removing the compiled bundles from release branch (they should only exist in the tag)"
    for e in elements/*; do find $e -maxdepth 1 \( -not -name "gulpfile.js" -not -name "rollup.config.js" \) \( -name "*.js" -or -name "*.css" -or -name "*.map" \) -exec git rm -f {} \; ;done
-   git commit -am "remove bundles from $NEW_VERSION" || exit 1
+   git commit -am "remove bundles after $NEW_VERSION tag" || exit 1
 }
 
 pushToOrigin() {


### PR DESCRIPTION
This PR teaches lerna to ignore built assets when figuring out whether a component has changed. Props to @kylebuch8 for finding the setting.