### PR TITLE
consider merged tags when evaluating changed components

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,7 +48,7 @@ checkoutMaster() {
 bumpVersion() {
   log "bumping version"
   OLD_VERSION=$(node -e "console.log(require('./lerna.json').version)")
-  ./node_modules/.bin/lerna version --no-git-tag-version --no-push --preid="$PRERELEASE_PREFIX" || exit 1
+  ./node_modules/.bin/lerna version --include-merged-tags --no-git-tag-version --no-push --preid="$PRERELEASE_PREFIX" || exit 1
   NEW_VERSION=$(node -e "console.log(require('./lerna.json').version)")
 }
 


### PR DESCRIPTION
Lerna is not considering tags that are introduced to `master` in a merge.  This PR changes that.

https://github.com/lerna/lerna/tree/master/commands/version#--include-merged-tags