### PR TITLE
cleanly exit release script if any command errors

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,12 +10,8 @@ NEW_VERSION=""
 TAG_NAME=""
 RELEASE_BRANCH=""
 
-trap ctrl_c INT
-
-ctrl_c() {
-  echo "ctrl-c detected"
-  exit 1
-}
+# abort script if any command fails
+set -e
 
 log() {
   echo "[RELEASE] $1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,6 +12,12 @@ RELEASE_BRANCH=""
 
 # abort script if any command fails
 set -e
+trap ctrl_c INT
+
+ctrl_c() {
+  echo "ctrl-c detected"
+  exit 1
+}
 
 log() {
   echo "[RELEASE] $1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ TAG_NAME=""
 RELEASE_BRANCH=""
 
 # abort script if any command fails
-set -e
+set -euo pipefail
 trap ctrl_c INT
 
 ctrl_c() {


### PR DESCRIPTION
Currently when the release script is aborted (from an error, or ctrl+c, or answering 'No' to a prompt), the rest of the commands continue to execute.  That's bad, so this PR uses `set -e` to abort the whole script.  It also goes one step further and adds a few other '[strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/)' tests for better reliability.