### PR TITLE
Be less strict in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ TAG_NAME=""
 RELEASE_BRANCH=""
 
 # abort script if any command fails
-set -euo pipefail
+set -e
 trap ctrl_c INT
 
 ctrl_c() {


### PR DESCRIPTION
This removes the "strict mode" (`set -euo pipefail`) from release.sh, but keeps the "exit immediately if any subcommand fails" behavior (`set -e`).