### PR TITLE
Fix overflow on component availability chart

### DIFF
--- a/docs/content/getting-started/component-status.md
+++ b/docs/content/getting-started/component-status.md
@@ -14,4 +14,4 @@ Though we have tested and verified general usability within these frameworks, PF
 
 <br/>
 
-<iframe width="785" height="538" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRfQ-5bKA57rXGt6QssqB4r7qweiCuODpQTL2qsKLMGSz582WOdaMBr1axvuQ88nu1UAo30n1EK_Qke/pubchart?oid=51483830&amp;format=interactive"></iframe>
+<iframe width="700" height="538" seamless frameborder="0" scrolling="yes" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRfQ-5bKA57rXGt6QssqB4r7qweiCuODpQTL2qsKLMGSz582WOdaMBr1axvuQ88nu1UAo30n1EK_Qke/pubchart?oid=51483830&amp;format=interactive"></iframe>


### PR DESCRIPTION
Fixing the overflowing readiness chart on the docs site; currently its too wide & doesn't scroll https://patternfly.github.io/patternfly-elements/getting-started/component-status/

Testing instructions
cd docs
hugo server -d
visit http://localhost:1313
