### PR TITLE
fix pfe-card's published files

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,9 @@
+## Prerelease 29 ()
+
+Tag: [v1.0.0-prerelease.29](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.29)
+
+- [5bef4ed6](https://github.com/patternfly/patternfly-elements/commit/5bef4ed6b9f47412361cb8687f0b4618069a49ea) fix: pfe-card's published package now includes the intended assets
+
 ## Prerelease 28 ()
 
 Tag: [v1.0.0-prerelease.28](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.28)

--- a/elements/pfe-card/package.json
+++ b/elements/pfe-card/package.json
@@ -24,12 +24,6 @@
   "files": [
     "dist"
   ],
-  "files": [
-    "pfe-card.*js",
-    "pfe-card.*js.map",
-    "pfe-card--lightdom.*css",
-    "pfe-card--lightdom.*css.map"
-  ],
   "scripts": {
     "build": "../../node_modules/.bin/gulp && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}'",
     "dev": "../../node_modules/.bin/gulp dev",


### PR DESCRIPTION
---

### What has changed and why

pfe-card had two `files` properties in its package.json, which led to no files being published.  This PR corrects that.

### Testing instructions

```
cd elements/pfe-card
npm publish --dry-run
```

Verify in the output that "Tarball Contents" lists files in the `dist` directory, like so:

```
npm notice === Tarball Contents ===
npm notice 1.4kB  package.json
npm notice 1.1kB  LICENSE.txt
npm notice 4.6kB  README.md
npm notice 196B   dist/pfe-card--lightdom.css
npm notice 16.8kB dist/pfe-card--lightdom.css.map
npm notice 180B   dist/pfe-card--lightdom.min.css
npm notice 202B   dist/pfe-card--lightdom.min.css.map
npm notice 19.2kB dist/pfe-card.js
npm notice 24.5kB dist/pfe-card.js.map
npm notice 16.6kB dist/pfe-card.min.js
npm notice 22.9kB dist/pfe-card.min.js.map
npm notice 23.7kB dist/pfe-card.umd.js
npm notice 24.3kB dist/pfe-card.umd.js.map
npm notice 17.3kB dist/pfe-card.umd.min.js
npm notice 22.3kB dist/pfe-card.umd.min.js.map
```

Before the fix, no `dist` files were included:

```
npm notice === Tarball Contents ===
npm notice 1.4kB  package.json
npm notice 1.1kB  LICENSE.txt
npm notice 4.6kB  README.md
```

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?