### PR TITLE
Fix hugo nav scroll issue

### DIFF
--- a/docs/assets/sass/pfelements.scss
+++ b/docs/assets/sass/pfelements.scss
@@ -523,7 +523,7 @@ main {
     }
     
     .inner-toc {
-      position: sticky;
+      //position: sticky; The nav is too long for this
       top: 20px;
     }
     


### PR DESCRIPTION
### Testing instructions

```
cd /docs
hugo server -D
```
Then check localhost:1313/getting-started/
Put the mouse cursor over the side nav and try to scroll down. It should be scrollable now. 

Eventually the nav should use accordions and then we can bring back the sticky positioning.
