### PR TITLE
build: ignore compiled assets when determining version bumps

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -4,8 +4,9 @@ Tag: [v1.0.0-prerelease.30](https://github.com/patternfly/patternfly-elements/re
 
 - [a666fc4](https://github.com/patternfly/patternfly-elements/commit/a666fc4f8e6e9669ee849d01d11ca77798824cc7) pfe-band layout rendering fix for bug in IE and Edge (#470)
 - [2143c84](https://github.com/patternfly/patternfly-elements/commit/2143c84d207076c0c8016c960d6edd447e4048eb) feat: add align attribute to pass down to tabs on render (#610)
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-cta svgs removed from tab order in ie11
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-content-set: wrapping the observer reconnect in a setTimeout #611
+- [392399b](https://github.com/patternfly/patternfly-elements/commit/392399b3eb240290e67873a51122459985dbbe7f) fix: pfe-cta svgs removed from tab order in ie11
+- [94ff217](https://github.com/patternfly/patternfly-elements/commit/94ff21768e3b1a8b90e284059f322e091c2d56ae) fix: pfe-content-set: wrapping the observer reconnect in a setTimeout #611
+- []() fix: ignore compiled assets when determining version bumps #613
 
 ## Prerelease 29 ( 2019-11-04 )
 

--- a/lerna.json
+++ b/lerna.json
@@ -6,11 +6,6 @@
   ],
   "version": "1.0.0-prerelease.29",
   "ignoreChanges": [
-    "elements/*/*.css",
-    "elements/*/*.js",
-    "elements/*/*.map",
-    "elements/*/dist/*.css",
-    "elements/*/dist/*.js",
-    "elements/*/dist/*.map"
+    "elements/*/dist/**/*"
   ]
 }


### PR DESCRIPTION
## ignore compiled assets when determining version bumps

Update lerna's `ignoreChanges` patterns so that committing compiled assets doesn't trigger version bumps in every element, during every release.  After this change, we should go back to the happy path of only the elements that change getting version bumps.