### PR TITLE
fix: pfe-cta animation effect

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -8,6 +8,7 @@ Tag: [v1.0.0-prerelease.30](https://github.com/patternfly/patternfly-elements/re
 - [94ff217](https://github.com/patternfly/patternfly-elements/commit/94ff21768e3b1a8b90e284059f322e091c2d56ae) fix: pfe-content-set: wrapping the observer reconnect in a setTimeout #611
 - [0c33cd6](https://github.com/patternfly/patternfly-elements/commit/0c33cd6637473fb8765c06150811db2884e90e24) fix: ignore compiled assets when determining version bumps #613
 - [0537a54](https://github.com/patternfly/patternfly-elements/commit/0537a54c5b02f99c0b53c9199223281ded99062f) chore: making pfe-band public
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Bring back pfe-cta hover animation effect #623
 
 ## Prerelease 29 ( 2019-11-04 )
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -99,6 +99,7 @@ $pfe-cta--Color--fallback: #003366;
 
   ::slotted(:hover) {
     --pfe-cta__arrow--Padding:     0 0 0 .5rem;
+    
     color: #{pfe-local(Color--hover)} !important;
     text-decoration: #{pfe-local(TextDecoration--hover)} !important;
   }

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -98,8 +98,9 @@ $pfe-cta--Color--fallback: #003366;
   }
 
   ::slotted(:hover) {
-      color: #{pfe-local(Color--hover)} !important;
-      text-decoration: #{pfe-local(TextDecoration--hover)} !important;
+    --pfe-cta__arrow--Padding:     0 0 0 .5rem;
+    color: #{pfe-local(Color--hover)} !important;
+    text-decoration: #{pfe-local(TextDecoration--hover)} !important;
   }
 
   ::slotted(:focus) {
@@ -122,6 +123,8 @@ $pfe-cta--Color--fallback: #003366;
 }
 
 :host(:hover) {
+  --pfe-cta__arrow--Padding:     0 0 0 .5rem;
+  
   background-color: #{pfe-local(BackgroundColor--hover)};
   border-color:     #{pfe-local(BorderColor--hover)};
 


### PR DESCRIPTION
## Bring back the animation on hover for pfe-cta
---

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* Animation on hover for the default CTA was accidentally regressed; this branch brings that back

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. Compile the pfe-cta component
2. Hover over the default style CTA
3. The arrow should subtly bounce to the right

#### Browser requirements
Your component should work in all of the following environments:

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Galaxy S9 Firefox
- [x] iPhone X Safari
- [x] iPad Pro Safari
- [x] Pixel 3 Chrome

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

