### PR TITLE
DE21128-broadcast-theme-hooks fix: remove double var wrapper

### DIFF
--- a/elements/pfe-sass/mixins/_custom-properties.scss
+++ b/elements/pfe-sass/mixins/_custom-properties.scss
@@ -189,7 +189,7 @@
             @include pfe-set-local(
                 ( BackgroundColor: #{pfe-color(surface--#{$color})} )
             );
-            --theme: var(#{pfe-color(surface--#{$color}--theme)}, #{$theme});
+            --theme: #{pfe-color( surface--#{$color}--theme, #{$theme} );
             @include browser-query(ie11) {
                 background-color: #{map-get($pfe-colors, surface--lightest)} !important;
                 color: #{pfe-color(text)} !important;


### PR DESCRIPTION
Rendered CSS was:
```
  --theme: var(var(--pfe-theme--color--surface--darkest--theme, dark), dark);
```
is now
```
  --theme: var(--pfe-theme--color--surface--darker--theme, dark)
```

## Steps to test 

Look for dark text on a dark background on 
http://localhost:8000/elements/pfe-accordion/demo/
or 
http://localhost:8000/elements/pfe-band/demo/