### PR TITLE
fix:  add the word "zindex" back to z-index variable names

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,8 +2,8 @@
 
 Tag: [v1.0.0-prerelease.32](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.32)
 
-- []() Fix: Add support for theme hooks within surface colors mixin 
-- []() Fix: z-index function now correctly prints variable names 
+- []() DE21128 Fix: Add support for theme hooks within surface colors mixin 
+- []() DE21423 Fix: z-index function now correctly prints variable names 
 
 ## Prerelease 31 ( 2019-11-25 )
 

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,7 +2,8 @@
 
 Tag: [v1.0.0-prerelease.32](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.32)
 
-- []() DE21128 Add support for theme hooks within surface colors mixin 
+- []() Fix: Add support for theme hooks within surface colors mixin 
+- []() Fix: z-index function now correctly prints variable names 
 
 ## Prerelease 31 ( 2019-11-25 )
 

--- a/elements/pfe-sass/functions/_custom-properties.scss
+++ b/elements/pfe-sass/functions/_custom-properties.scss
@@ -167,7 +167,7 @@
 @function pfe-zindex($cssvar) {
     $var-name: to-string($cssvar, "--");
     @if map-get($pfe-zindex, $var-name) != null {
-        @return pfe-get-from-map("", $var-name, $pfe-zindex);
+        @return pfe-get-from-map("zindex", $var-name, $pfe-zindex);
     }
     @else {
         @error "The key for #{$var-name} could not be found in the $pfe-zindex map.";


### PR DESCRIPTION
### What has changed and why

* The zindex function was printing variables incorrectly without the string `zindex` in the middle.  
     - Note the var names in the theme: https://static.redhat.com/libs/redhat/redhat-theme/3/advanced-theme.css

![image](https://user-images.githubusercontent.com/456863/70091266-c67f0d80-15e9-11ea-8882-92aa3c5b19e7.png)


### Testing instructions

- Compare CSS files like pfe-modal.css and pfe-navigation.css. 
- https://web-dev-drupal-webux3.dev.a1.vary.redhat.com/en/services/training/rh024-red-hat-linux-technical-overview

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update the CHANGELOG.md file with a summary of this update?

