### PR TITLE
Add broadcast variables to pfe-base.css

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -4,7 +4,7 @@ Tag: [v1.0.0-prerelease.32](https://github.com/patternfly/patternfly-elements/re
 
 - []() DE21128 Fix: Add support for theme hooks within surface colors mixin 
 - []() DE21423 Fix: z-index function now correctly prints variable names 
-- []() DE21491 Fix: Add default broadcast variables
+- []() DE21491 Fix: Add default broadcast variables to pfe-base.css
 
 ## Prerelease 31 ( 2019-11-25 )
 

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -4,6 +4,7 @@ Tag: [v1.0.0-prerelease.32](https://github.com/patternfly/patternfly-elements/re
 
 - []() DE21128 Fix: Add support for theme hooks within surface colors mixin 
 - []() DE21423 Fix: z-index function now correctly prints variable names 
+- []() DE21491 Fix: Add default broadcast variables
 
 ## Prerelease 31 ( 2019-11-25 )
 

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -163,7 +163,7 @@ You may choose to add attributes such as `pfe-variant`, `pfe-priority` or `pfe-c
 CSS variables are subject to the normal cascade, so consider where you want these overrides to propogate.
 
 
-#### Page-level CSS, [theme](https://static.redhat.com/libs/redhat/redhat-theme/2/advanced-theme.css) variables
+#### Page-level CSS, [theme](https://raw.githubusercontent.com/starryeyez024/patternfly-theme/prerelease-1.0/dist/advanced-theme.css) variables
 
 Theme variables will impact all components on the page where this CSS is loaded.
 

--- a/docs/content/theme/pfe-theme-slots.md
+++ b/docs/content/theme/pfe-theme-slots.md
@@ -289,7 +289,7 @@ Several functions exist in the `pfe-sass` component to make it easier to theme i
      }
      ```
 
-   *   Component color properties should almost always use [theme colors](https://static.redhat.com/libs/redhat/redhat-theme/2.0.0/advanced-theme.css) as values.  (Sidenote, there is no "light" or "dark" color, only "lighter"/ "darker", it's all relative to the base color, it can only get lighter or darker from there.
+   *   Component color properties should almost always use [theme colors](https://raw.githubusercontent.com/starryeyez024/patternfly-theme/prerelease-1.0/dist/advanced-theme.css) as values.  (Sidenote, there is no "light" or "dark" color, only "lighter"/ "darker", it's all relative to the base color, it can only get lighter or darker from there.
       *   Lightest
       *   Lighter
       *   Base

--- a/elements/pfe-styles/demo/index.html
+++ b/elements/pfe-styles/demo/index.html
@@ -40,10 +40,6 @@
         color: #1a1a1a;
       }
 
-      h1, h2, h3, h4, h5, h6, p, button {
-        color: var(--pfe-broadcasted--text, #252525);
-      }
-
       header h1 {
         margin-top: 0;
       }
@@ -52,7 +48,7 @@
       section.pfe-m-gutters {
         margin: 32px 0 !important;
       }
-
+      .white-box,
       section section {
         padding: 32px;
         background-color: #fff;
@@ -100,15 +96,10 @@
       :not(pre)>code[class*=language-], pre[class*=language-] {
         background: #f2f2f2;
       }
-      :root {
-        --pfe-theme--color--link: green;
-      }
     </style>
   </head>
   <body>
-    <div>
-      <p>basic text with a basic <a href="https://foofdsa.com">link</a> </p>
-    </div>
+
     <article>
       <header>
         <h1>Layouts</h1>
@@ -238,6 +229,26 @@
         </section>
 
       </section>
+    </article>
+    <article>
+      <header>
+        <h2>Text & link</h2>
+      </header>
+      <div class="white-box">
+
+        <h1>This is 1st level heading</h1>
+        <p>This is a test paragraph.</p>
+        <h2>This is 2nd level heading</h2>
+        <p>This is a test paragraph.</p>
+        <h3>This is 3rd level heading</h3>
+        <p>This is a test paragraph.</p>
+        <h4>This is 4th level heading</h4>
+        <p>This is a test paragraph.</p>
+        <h5>This is 5th level heading</h5>
+        <p>This is a test paragraph.</p>
+        <h6>This is 6th level heading</h6>
+        <p>This is a test paragraph with a <a href="https://foofdsa.com">link</a> </p>
+      </div>
     </article>
   </body>
 

--- a/elements/pfe-styles/demo/index.html
+++ b/elements/pfe-styles/demo/index.html
@@ -5,6 +5,7 @@
     <title>Layouts Demo</title>
 
     <link rel="stylesheet" type="text/css" href="//overpass-30e2.kxcdn.com/overpass.css">
+    <link rel="stylesheet" type="text/css" href="../dist/pfe-base.min.css">
     <link rel="stylesheet" type="text/css" href="../dist/pfe-layouts.min.css">
     <link rel="stylesheet" type="text/css" href="../dist/pfe-context.css">
     <link rel="stylesheet" type="text/css" href="../_temp/pfe-colors.css">
@@ -14,7 +15,7 @@
     </noscript>
 
     <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet" />
-  
+
     <link href="../../pfe-cta/dist/pfe-cta--lightdom.css" rel="stylesheet" />
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
@@ -26,7 +27,7 @@
       '../../pfe-cta/dist/pfe-cta.umd.js'
     ])
     </script>
-    
+
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/themes/prism.min.css">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js"></script>
@@ -36,6 +37,7 @@
       body {
         padding: 32px;
         background: #e7e7e7;
+        color: #1a1a1a;
       }
 
       h1, h2, h3, h4, h5, h6, p, button {
@@ -98,9 +100,15 @@
       :not(pre)>code[class*=language-], pre[class*=language-] {
         background: #f2f2f2;
       }
+      :root {
+        --pfe-theme--color--link: green;
+      }
     </style>
   </head>
   <body>
+    <div>
+      <p>basic text with a basic <a href="https://foofdsa.com">link</a> </p>
+    </div>
     <article>
       <header>
         <h1>Layouts</h1>

--- a/elements/pfe-styles/src/pfe-base.scss
+++ b/elements/pfe-styles/src/pfe-base.scss
@@ -1,8 +1,12 @@
+//@TODO, pull from https://github.com/patternfly/patternfly-next/blob/master/src/patternfly/_globals.scss#L90
 @import "../../pfe-sass/pfe-sass";
 $LOCAL: pfelement;
 
-body {
-  @include pfe-set-broadcast-theme(light);
+// NORMALIZE
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 html,
@@ -71,14 +75,10 @@ th {
   text-align: left;
 }
 
-// Patternfly base styles
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
+// PatternFly Styles
 
 html {
+  @include pfe-set-broadcast-theme(light);
   font-family: sans-serif;
   line-height: #{pfe-var(line-height)};
 }
@@ -111,3 +111,5 @@ button,
 a {
   cursor: pointer;
 }
+
+

--- a/elements/pfe-styles/src/pfe-base.scss
+++ b/elements/pfe-styles/src/pfe-base.scss
@@ -1,4 +1,9 @@
 @import "../../pfe-sass/pfe-sass";
+$LOCAL: pfelement;
+
+body {
+  @include pfe-set-broadcast-theme(light);
+}
 
 html,
 body,

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,6 +22,7 @@
 					<li><a href="../elements/pfe-health-index/demo">pfe-health-index</a></li>
 					<li><a href="../elements/pfe-icon/demo">pfe-icon</a></li>
 					<li><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></li>
+					<li><a href="../elements/pfe-layouts/demo">pfe-layouts</a></li>
 					<li><a href="../elements/pfe-markdown/demo">pfe-markdown</a></li>
 					<li><a href="../elements/pfe-modal/demo">pfe-modal</a></li>
 					<li><a href="../elements/pfe-navigation/demo">pfe-navigation</a></li>


### PR DESCRIPTION
* Link(s) to demo pages where this element can be viewed: http://localhost:8000/elements/pfe-styles/demo/

---

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* Added broadcast variables by default, so links pick up theme colors.  The demo file now has 
```
      :root {
        --pfe-theme--color--link: green;
      }
```
which is reflected in the green link 

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. 

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

