### PR TITLE
Release/v1.0.0 prerelease.33

### DIFF
--- a/elements/pfe-accordion/package.json
+++ b/elements/pfe-accordion/package.json
@@ -9,7 +9,7 @@
       "pfe-accordion-panel.js"
     ]
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -49,7 +49,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.5",

--- a/elements/pfe-autocomplete/package.json
+++ b/elements/pfe-autocomplete/package.json
@@ -4,7 +4,7 @@
     "className": "PfeAutocomplete",
     "elementName": "pfe-autocomplete"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Autocomplete element for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.5",

--- a/elements/pfe-avatar/package.json
+++ b/elements/pfe-avatar/package.json
@@ -4,7 +4,7 @@
     "className": "PfeAvatar",
     "elementName": "pfe-avatar"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Avatar for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.6.8",

--- a/elements/pfe-band/package.json
+++ b/elements/pfe-band/package.json
@@ -9,7 +9,7 @@
       "js": "src/pfe-band.js"
     }
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Band container for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-rhelement-version": "0.6.8",

--- a/elements/pfe-card/package.json
+++ b/elements/pfe-card/package.json
@@ -4,7 +4,7 @@
     "className": "PfeCard",
     "elementName": "pfe-card"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -45,7 +45,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.0",

--- a/elements/pfe-collapse/package.json
+++ b/elements/pfe-collapse/package.json
@@ -4,7 +4,7 @@
     "className": "PfeCollapse",
     "elementName": "pfe-collapse"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Collapse element for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-content-set/package.json
+++ b/elements/pfe-content-set/package.json
@@ -4,7 +4,7 @@
     "className": "PfeContentSet",
     "elementName": "pfe-content-set"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "This PatternFly Element dynamically hides and shows content; the style is determined by the available space.",
   "keywords": [
     "web-components",
@@ -44,8 +44,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-accordion": "^1.0.0-prerelease.32",
-    "@patternfly/pfe-tabs": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-accordion": "^1.0.0-prerelease.33",
+    "@patternfly/pfe-tabs": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-cta/package.json
+++ b/elements/pfe-cta/package.json
@@ -4,7 +4,7 @@
     "className": "PfeCta",
     "elementName": "pfe-cta"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.0",

--- a/elements/pfe-health-index/package.json
+++ b/elements/pfe-health-index/package.json
@@ -4,7 +4,7 @@
     "className": "PfeHealthIndex",
     "elementName": "pfe-health-index"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.6.3",

--- a/elements/pfe-icon-panel/package.json
+++ b/elements/pfe-icon-panel/package.json
@@ -4,7 +4,7 @@
     "className": "PfeIconPanel",
     "elementName": "pfe-icon-panel"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.0",

--- a/elements/pfe-icon/package.json
+++ b/elements/pfe-icon/package.json
@@ -4,7 +4,7 @@
     "className": "PfeIcon",
     "elementName": "pfe-icon"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-markdown/package.json
+++ b/elements/pfe-markdown/package.json
@@ -4,7 +4,7 @@
     "className": "PfeMarkdown",
     "elementName": "pfe-markdown"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Markdown element for PatternFly Elements",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31",
     "marked": "^0.6.1"
   },

--- a/elements/pfe-modal/package.json
+++ b/elements/pfe-modal/package.json
@@ -4,7 +4,7 @@
     "className": "PfeModal",
     "elementName": "pfe-modal"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-navigation/package.json
+++ b/elements/pfe-navigation/package.json
@@ -10,7 +10,7 @@
       "pfe-navigation--noscript.*css.map"
     ]
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -49,8 +49,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-icon": "^1.0.0-prerelease.32",
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-icon": "^1.0.0-prerelease.33",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0"

--- a/elements/pfe-page-status/package.json
+++ b/elements/pfe-page-status/package.json
@@ -4,7 +4,7 @@
     "className": "PfePageStatus",
     "elementName": "pfe-page-status"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Page element for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-progress-indicator/package.json
+++ b/elements/pfe-progress-indicator/package.json
@@ -4,7 +4,7 @@
     "className": "PfeProgressIndicator",
     "elementName": "pfe-progress-indicator"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0",

--- a/elements/pfe-sass/package.json
+++ b/elements/pfe-sass/package.json
@@ -4,7 +4,7 @@
     "className": "PfeSass",
     "elementName": "pfe-sass"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },

--- a/elements/pfe-select/package.json
+++ b/elements/pfe-select/package.json
@@ -4,7 +4,7 @@
     "className": "PfeSelect",
     "elementName": "pfe-select"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Select element for PatternFly Elements",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.1.0"

--- a/elements/pfe-styles/package.json
+++ b/elements/pfe-styles/package.json
@@ -12,7 +12,7 @@
       "pfe-layouts.*.map"
     ]
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -43,7 +43,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32"
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33"
   },
   "bugs": {
     "url": "https://github.com/patternfly/patternfly-elements/issues"

--- a/elements/pfe-tabs/package.json
+++ b/elements/pfe-tabs/package.json
@@ -9,7 +9,7 @@
       "pfe-tab-panel.js"
     ]
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "publishConfig": {
     "access": "public"
   },
@@ -46,7 +46,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "0.5.4",

--- a/elements/pfe-toast/package.json
+++ b/elements/pfe-toast/package.json
@@ -4,7 +4,7 @@
     "className": "PfeToast",
     "elementName": "pfe-toast"
   },
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "description": "Toast element for PatternFly Elements",
   "keywords": [
     "web-components",
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "^1.0.0-prerelease.32",
+    "@patternfly/pfe-sass": "^1.0.0-prerelease.33",
     "@patternfly/pfelement": "^1.0.0-prerelease.31"
   },
   "generator-pfelement-version": "1.3.0"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "elements/*",
     "themes/*"
   ],
-  "version": "1.0.0-prerelease.32",
+  "version": "1.0.0-prerelease.33",
   "ignoreChanges": [
     "elements/*/dist/**/*"
   ]


### PR DESCRIPTION
## Prerelease 33 ( 2019-12-18 )

Tag: [v1.0.0-prerelease.33](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.33)

- [5ad398](https://github.com/patternfly/patternfly-elements/commit/5ad3983b9ead73cf2db30fd0bc52aada334c6961) Disclosure accordion variant
- [3ccec6](https://github.com/patternfly/patternfly-elements/commit/3ccec6c82efc52aae67b74072b6c0b8ff1b47f23) Update pfe-cta to include broadcast variables for all variants [#659](https://github.com/patternfly/patternfly-elements/issues/658)