### PR TITLE
Bug fix: issue 664 - pfe-cta link clickability in Edge & IE

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,6 +3,7 @@
 Tag: [v1.0.0-prerelease.34](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.34)
 
 - [c2833e3](https://github.com/patternfly/patternfly-elements/commit/c2833e3ef9caa87edbbc56fa22471525d453b7d3) feat: pfe-badge (#625)
+- []() fix: Restore clickability of pfe-cta links
 
 ## Prerelease 33 ( 2019-12-18 )
 

--- a/elements/pfe-cta/src/pfe-cta--lightdom.scss
+++ b/elements/pfe-cta/src/pfe-cta--lightdom.scss
@@ -16,6 +16,7 @@ $LOCAL: cta;
       display: inline;
       color:  #{pfe-local($cssvar: Color, $fallback: #{pfe-color(link)})} !important;
       z-index: 1; // IE & Edge need this for the link to be clickable
+      position: relative;
   }
 
   &:hover input,

--- a/elements/pfe-cta/src/pfe-cta--lightdom.scss
+++ b/elements/pfe-cta/src/pfe-cta--lightdom.scss
@@ -15,6 +15,7 @@ $LOCAL: cta;
       font-family: #{pfe-var(font-family)};
       display: inline;
       color:  #{pfe-local($cssvar: Color, $fallback: #{pfe-color(link)})} !important;
+      z-index: 1; // IE & Edge need this for the link to be clickable
   }
 
   &:hover input,


### PR DESCRIPTION
## Goal of this pull request

* Fix [issue 664](https://github.com/patternfly/patternfly-elements/issues/664)

---

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* Add z-index to link inside pfe-cta

### Testing instructions

1.  Test the default, primary & secondary CTA buttons in all browsers; the link should be clickable
https://web-dev-drupal-carobert.dev.a1.vary.redhat.com/en/web-components-demo#

![image](https://user-images.githubusercontent.com/456863/71738929-1984f400-2e26-11ea-9fc1-ab7088911d11.png)

([note that the padding issue is being worked on here](https://github.com/patternfly/patternfly-elements/pull/665) )

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [x] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Galaxy S9 Firefox
- [x] iPhone X Safari
- [x] iPad Pro Safari
- [x] Pixel 3 Chrome
 
### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

