### PR TITLE
Adjust pfe-nav spacing and alignment; remove extra footer padding

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -644,69 +644,7 @@
     </pfe-card>
   </pfe-band>
 
-  <pfe-band pfe-color="darkest" pfe-aside-mobile="top" pfe-aside-height="full">
-    <header slot="pfe-band--header">
-      <h2>Darkest band with header tag</h2>
-      <p class="custom-band-summary">Header region, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
-        ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
-    </header>
-    <section class="body1 generic1 band">
-      <p>Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-        sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
-        takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
-        diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et
-        accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
-        dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
-        ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
-        rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
-      <pfe-cta priority="primary" slot="pfe-band--footer">
-        <a href="#">Learn more</a>
-      </pfe-cta>
-    </section>
-    <pfe-card color="dark" slot="pfe-band--aside">
-      <h3 slot="pfe-card--header">Aside: right full top</h3>
-      <p>Ut wisi enim ad minim veniam. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
-        tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo
-        dolores et ea rebum.</p>
-      <pfe-cta slot="pfe-card--footer" priority="tertiary">
-        <a href="#">Learn more</a>
-      </pfe-cta>
-    </pfe-card>
-  </pfe-band>
-
-  <pfe-band pfe-color="accent" pfe-aside-desktop="left" pfe-aside-mobile="top">
-    <header slot="pfe-band--header">
-      <h2>Accent band</h2>
-      <p class="custom-band-summary">Header region, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
-        ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
-    </header>
-    <p>Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
-      diam voluptua.</p>
-    <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
-      Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
-      invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
-      et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor
-      sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-      erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no
-      sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
-    <pfe-cta priority="primary">
-      <a href="#">Learn more</a>
-    </pfe-cta>
-    <pfe-card color="lightest" slot="pfe-band--aside">
-      <h3 slot="pfe-card--header">Aside: left body top</h3>
-      <p>Ut wisi enim ad minim veniam.</p>
-      <pfe-cta slot="pfe-card--footer" priority="tertiary">
-        <a href="#">Learn more</a>
-      </pfe-cta>
-    </pfe-card>
-    <footer slot="pfe-band--footer" class="custom-footnote">
-      <ol>
-        <li>Footnote ipsum accusam et justo duo dolores et ea rebum.</li>
-        <li>Footnote ipsum accusam et justo duo dolores et ea rebum.</li>
-      </ol>
-    </footer>
-  </pfe-band>
-
+  
   <pfe-band pfe-aside-desktop="left" pfe-aside-mobile="top">
     <header slot="pfe-band--header">
       <h2>Short content band</h2>
@@ -730,39 +668,7 @@
     </footer>
   </pfe-band>
 
-  <pfe-band pfe-color="complement" pfe-aside-desktop="left" pfe-aside-mobile="top" pfe-aside-height="body">
-    <header slot="pfe-band--header">
-      <h2>Complement band, layout classes</h2>
-      <p class="custom-band-summary">Header region, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
-        ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
-    </header>
-    <article class="pfe-l-grid pfe-m-gutters pfe-m-all-6-col">
-      <pfe-card>
-        <h3>Lorem ipsum</h3>
-        <p>Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-          sed diam voluptua.</p>
-        <pfe-cta slot="pfe-card--footer" priority="tertiary">
-          <a href="#">Learn more</a>
-        </pfe-cta>
-      </pfe-card>
-      <pfe-card>
-        <h3>Lorem ipsum</h3>
-        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
-          est Lorem ipsum dolor sit amet.</p>
-        <pfe-cta slot="pfe-card--footer" priority="tertiary">
-          <a href="#">Learn more</a>
-        </pfe-cta>
-      </pfe-card>
-    </article>
-    <pfe-card color="dark" slot="pfe-band--aside">
-      <h3 slot="pfe-card--header">Aside: right body bottom</h3>
-      <p>Ut wisi enim ad minim veniam. At vero eos et accusam et justo duo dolores et ea rebum. Lorem ipsum dolor sit
-        amet.</p>
-      <pfe-cta slot="pfe-card--footer" priority="tertiary">
-        <a href="#">Learn more</a>
-      </pfe-cta>
-    </pfe-card>
-  </pfe-band>
+
 
   <script>
     // Listen for the toggled event and if the slot is the language slot, inject new content

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -676,7 +676,7 @@
     document.addEventListener("pfe-navigation-item:open", function (event) {
       if (event.target && event.target.slot === "language") {
         const container = event.target.querySelector(".pfe-navigation-item__tray--container");
-        const newContent = "<p>Inject new content into the " + event.detail.slot + " slot.</p>";
+        const newContent = "<p>Inject new content into the " + event.detail.slot + " slot. Adding more words and text here, to show where the tray wraps.</p>";
         if (container) {
           if (event.target.expanded) {
             setTimeout(function () {

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -381,7 +381,7 @@ pfe-navigation-item {
         }
     }
     &--footer:not(:empty) {
-        margin: 40px 0 !important;
+        margin: 40px 0 10px !important;
         border-top: 1px solid lightgray;
         padding: 40px 0 0;
 

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -447,11 +447,17 @@ pfe-navigation-item {
 // This class is added manually inside the tray on the light DOM content
 .pfe-navigation-item__tray--container {
     width: 100%;
-    @media (min-width: #{pfe-breakpoint(lg)}) {
-        max-width: #{pfe-local($cssvar: Width, $fallback: 992px)};
+
+    // stop using padding, start using max width at medium breakpoint
+    @media screen and (min-width: pfe-breakpoint(md)) {
+      padding: 0;
+      max-width: var(--pfe-navigation--Width);
     }
-    @media (min-width: #{pfe-breakpoint(xl)}) {
-        max-width: #{pfe-local($cssvar: Width, $fallback: 1140px)};
+    // Loop through the other breakpoints
+    @each $size in ("md", "lg", "xl") {
+      @media screen and (min-width: pfe-breakpoint( #{$size} ) ) {
+        --pfe-navigation--Width: calc(#{pfe-breakpoint( #{$size} )} - #{pfe-local(MaxWidth)});
+      }
     }
     input[type="text"] {
         padding: 5px 10px;

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -451,13 +451,17 @@ pfe-navigation-item {
     // stop using padding, start using max width at medium breakpoint
     @media screen and (min-width: pfe-breakpoint(md)) {
       padding: 0;
-      max-width: var(--pfe-navigation--Width);
+      max-width: #{pfe-local(Width, $fallback: 1140px)};
     }
     // Loop through the other breakpoints
     @each $size in ("md", "lg", "xl") {
       @media screen and (min-width: pfe-breakpoint( #{$size} ) ) {
         --pfe-navigation--Width: calc(#{pfe-breakpoint( #{$size} )} - #{pfe-local(MaxWidth)});
       }
+    }
+    @include browser-query(ie11) {
+        padding-top: 1.5em;
+        padding-bottom: 1.5em
     }
     input[type="text"] {
         padding: 5px 10px;

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -57,11 +57,6 @@ $variables: map-merge($variables, $nav-light-dom-variables);
         flex-direction: column;
     }
 
-    // Override grid so that CTAs do not overlap.
-    //.pfe-navigation--footer:not(:empty) {
-    //    display: block !important;
-    //}
-
     @media screen and (min-width: #{pfe-breakpoint(lg)}) {
         .pfe-navigation-item__tray--container {
             margin: 0 auto;
@@ -381,9 +376,9 @@ pfe-navigation-item {
         }
     }
     &--footer:not(:empty) {
-        margin: 40px 0 10px !important;
+        margin:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 10px !important;
         border-top: 1px solid lightgray;
-        padding: 40px 0 0;
+        padding:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 0;
 
         >*:not(:last-child) {
             margin-bottom: 32px;
@@ -540,7 +535,7 @@ pfe-navigation-main [slot="trigger"] > a {
 
     @media screen and (min-width: pfe-breakpoint("sm-desktop", $map: false) )
                   and (max-width: pfe-breakpoint("xl", $max: true) ) {
-        font-size: 14px;
+        font-size: 13px;
     }  
 }
 

--- a/elements/pfe-navigation/src/pfe-navigation-item.scss
+++ b/elements/pfe-navigation/src/pfe-navigation-item.scss
@@ -220,14 +220,14 @@ $variables: map-merge($variables, $nav-item-variables);
     
   // Chevron styles for the navigation accordion on mobile
   &::after {
-    :host([is_nested].expanded:not([parent_hidden])) & {
-      @include pfe-chevron($state: open);
-    }
-
+    // closed:
     :host([is_nested]:not(.expanded):not([parent_hidden])) & {
-      @include pfe-chevron($state: closed);
+      @include pfe-chevron($state: closed, $position: 0px);
     }
-
+    // open:
+    :host([is_nested].expanded:not([parent_hidden])) & {
+      @include pfe-chevron($state: open, $position: 4px);
+    }
     :host([is_nested]:not([parent_hidden])) & {
       --pfe-navigation__trigger-icon--Visible: visible;
       border-color: #{pfe-local(Color)};
@@ -306,7 +306,7 @@ $variables: map-merge($variables, $nav-item-variables);
     display: flex;
     visibility: visible;
     width: 100%;
-    padding-right: 48px; // ensure gap between main menu links and utility links
+    padding-right: 40px; // ensure gap between main menu links and utility links
   }
 
   :host([pfe-icon="web-mobile-menu"]:not([show_links])) &,
@@ -318,12 +318,13 @@ $variables: map-merge($variables, $nav-item-variables);
 
     background-color: #{pfe-local($cssvar: BackgroundColor, $region: tray)};
     color:            #{pfe-local($cssvar: Color, $region: tray)};
-
+    //mobile tray padding
     padding: #{pfe-local($cssvar: Padding, $region: tray)};
     width: 100%;
     max-height: calc(100vh - #{pfe-local(Height)});
     overflow-x: hidden;
     overflow-y: scroll;
+    padding-right: 9px; // OFFSET SCROLLBAR HACK
   }
 
   //  Styles for the nested elements
@@ -332,7 +333,8 @@ $variables: map-merge($variables, $nav-item-variables);
     @include pfe-accordion-props;
     @include pfe-box-sizing;
     @include pfe-panel-container;
-    padding: calc(#{pfe-local(Padding--vertical)} / 2)  calc(#{pfe-local(Padding--horizontal)} * .75);
+     //mobile tray padding
+    padding: calc(#{pfe-local(Padding--vertical)} / 2)  calc(#{pfe-local(Padding--horizontal)} * 1.75);
   }
 
   :host([is_nested].expanded:not([parent_hidden])) & {

--- a/elements/pfe-navigation/src/pfe-navigation-item.scss
+++ b/elements/pfe-navigation/src/pfe-navigation-item.scss
@@ -306,6 +306,7 @@ $variables: map-merge($variables, $nav-item-variables);
     display: flex;
     visibility: visible;
     width: 100%;
+    padding-right: 48px; // ensure gap between main menu links and utility links
   }
 
   :host([pfe-icon="web-mobile-menu"]:not([show_links])) &,

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -34,7 +34,7 @@ $nav-variables: (
 
   // Tray region
   tray: (
-    Padding: pfe-var(container-padding)
+    Padding: calc( 16px * 4)  // 64px
   ),
   
   // Logo
@@ -54,20 +54,17 @@ $variables: map-merge($variables, $nav-variables);
   }
 
   // Increase horizontal padding for above mobile breakpoints
-  @media screen and (min-width: pfe-breakpoint(sm)) {
-    --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} * 2);
-  }
+  //@media screen and (min-width: pfe-breakpoint(sm)) {
+  //  --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} * 2);
+  //}
 
   // Reduce horizontal padding at large breakpoint
-  @media screen and (min-width: pfe-breakpoint(lg)) {
-    --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} / 2);
-    --pfe-navigation__tray--Padding: calc(#{pfe-var(container-padding)} * 2);
-  }
-
-  // Increase horizontal padding at xl breakpoint
-  @media screen and (min-width: pfe-breakpoint(xl)) {
-    --pfe-navigation--Padding--horizontal: #{pfe-var(container-padding)};
-  }
+  //@media screen and (min-width: pfe-breakpoint(lg)) {
+  //  --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} / 2);
+  //}
+  //@media screen and (min-width: pfe-breakpoint(xl)) {
+  //  --pfe-navigation--Padding--horizontal: #{pfe-var(container-padding)};
+  //}
 
   display: block;
   --pfe-accordion__base--Padding: var(--pfe-theme--container-spacer, 16px);
@@ -127,7 +124,7 @@ pfe-icon {
   }
   &__container {
     width: 100%;
-    max-width: #{pfe-local(Width)};
+    //max-width: #{pfe-local(Width)};
     margin: 0 auto;
     padding: 0 #{pfe-local(Padding--horizontal)};
 
@@ -136,16 +133,27 @@ pfe-icon {
     align-items: stretch;
     justify-content: flex-start;
 
-    // Loop through the other breakpoints
-    @each $size in (md, lg) {
-      @media screen and (min-width: pfe-breakpoint(#{$size})) {
-        // Set the variable for use in the tray region too
-        --pfe-navigation--Width: calc(#{pfe-breakpoint(#{$size})});
-      }
+  // stop using padding, start using max width at medium breakpoint
+  @media screen and (min-width: pfe-breakpoint(md)) {
+    padding: 0;
+    max-width: var(--pfe-navigation--Width);
+  }
 
-      @media screen and (min-width: #{pfe-breakpoint(xl)}) {
-        --pfe-navigation--Width: 1140px;
-      }
+
+// Set the variable for use in the tray region too
+
+    @media screen and (min-width: pfe-breakpoint("md") ) {
+      --pfe-navigation--Width: calc(#{pfe-breakpoint("md")} - #{pfe-local(Padding, $region: tray)});
+    }
+    @media screen and (min-width: pfe-breakpoint("lg")) {
+      --pfe-navigation--Width: calc(#{pfe-breakpoint("lg")} - #{pfe-local(Padding, $region: tray)});
+    }
+    @media screen and (min-width: pfe-breakpoint("sm-desktop", $map: false)) {
+      --pfe-navigation--Width: calc(#{pfe-breakpoint("sm-desktop", $map: false)} - #{pfe-local(Padding, $region: tray)} );
+    }
+    @media screen and (min-width: pfe-breakpoint("xl") ) {
+      border: pink solid 1px;
+      --pfe-navigation--Width: calc(#{pfe-breakpoint("xl")} - #{pfe-local(Padding, $region: tray)} );
     }
   }
   &__overlay {

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -210,7 +210,7 @@ pfe-icon {
       @media screen and (min-width: pfe-breakpoint("sm-desktop", $map: false)) {
         flex: auto; //0 1 30%;
         margin-left: auto;
-        padding-left: 48px; // ensure gap between main menu links and utility links
+        // padding-left: 48px; // ensure gap between main menu links and utility links
     }
   }
 }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -34,7 +34,7 @@ $nav-variables: (
 
   // Tray region
   tray: (
-    Padding: calc( 16px * 4)  // 64px
+    Padding: calc( #{pfe-var(container-padding)} * 4) // 64px
   ),
   
   // Logo
@@ -52,19 +52,6 @@ $variables: map-merge($variables, $nav-variables);
   @media print {
     --pfe-navigation--Padding: calc(#{pfe-local(Padding--vertical)} / 2) #{pfe-local(Padding--horizontal)};
   }
-
-  // Increase horizontal padding for above mobile breakpoints
-  //@media screen and (min-width: pfe-breakpoint(sm)) {
-  //  --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} * 2);
-  //}
-
-  // Reduce horizontal padding at large breakpoint
-  //@media screen and (min-width: pfe-breakpoint(lg)) {
-  //  --pfe-navigation--Padding--horizontal: calc(#{pfe-var(container-padding)} / 2);
-  //}
-  //@media screen and (min-width: pfe-breakpoint(xl)) {
-  //  --pfe-navigation--Padding--horizontal: #{pfe-var(container-padding)};
-  //}
 
   display: block;
   --pfe-accordion__base--Padding: var(--pfe-theme--container-spacer, 16px);
@@ -133,27 +120,17 @@ pfe-icon {
     align-items: stretch;
     justify-content: flex-start;
 
-  // stop using padding, start using max width at medium breakpoint
-  @media screen and (min-width: pfe-breakpoint(md)) {
-    padding: 0;
-    max-width: var(--pfe-navigation--Width);
-  }
-
-
-// Set the variable for use in the tray region too
-
-    @media screen and (min-width: pfe-breakpoint("md") ) {
-      --pfe-navigation--Width: calc(#{pfe-breakpoint("md")} - #{pfe-local(Padding, $region: tray)});
+    // stop using padding, start using max width at medium breakpoint
+    @media screen and (min-width: pfe-breakpoint(md)) {
+      padding: 0;
+      max-width: var(--pfe-navigation--Width);
     }
-    @media screen and (min-width: pfe-breakpoint("lg")) {
-      --pfe-navigation--Width: calc(#{pfe-breakpoint("lg")} - #{pfe-local(Padding, $region: tray)});
-    }
-    @media screen and (min-width: pfe-breakpoint("sm-desktop", $map: false)) {
-      --pfe-navigation--Width: calc(#{pfe-breakpoint("sm-desktop", $map: false)} - #{pfe-local(Padding, $region: tray)} );
-    }
-    @media screen and (min-width: pfe-breakpoint("xl") ) {
-      border: pink solid 1px;
-      --pfe-navigation--Width: calc(#{pfe-breakpoint("xl")} - #{pfe-local(Padding, $region: tray)} );
+   // Set the variable for use in the tray region too
+    // Loop through the other breakpoints
+    @each $size in ("md", "lg", "xl") {
+      @media screen and (min-width: pfe-breakpoint( #{$size} ) ) {
+        --pfe-navigation--Width: calc(#{pfe-breakpoint( #{$size} )} - #{pfe-local(Padding, $region: tray)});
+      }
     }
   }
   &__overlay {

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -18,6 +18,9 @@ $nav-variables: (
   MaxHeight: 72px,
   MobileMenuHeight: 60px,
 
+  // Nav content width
+  MaxWidth: calc(#{pfe-var(container-padding)} * 4), // 64px
+
   // Variables for the trigger icon
   icon: none,
 
@@ -31,6 +34,7 @@ $nav-variables: (
     FontSize: 16px,
     FontWeight: 100
   ),
+
 
   // Tray region
   tray: (
@@ -129,7 +133,7 @@ pfe-icon {
     // Loop through the other breakpoints
     @each $size in ("md", "lg", "xl") {
       @media screen and (min-width: pfe-breakpoint( #{$size} ) ) {
-        --pfe-navigation--Width: calc(#{pfe-breakpoint( #{$size} )} - #{pfe-local(Padding, $region: tray)});
+        --pfe-navigation--Width: calc(#{pfe-breakpoint( #{$size} )} - #{pfe-local(MaxWidth)});
       }
     }
   }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -38,7 +38,7 @@ $nav-variables: (
 
   // Tray region
   tray: (
-    Padding: calc( #{pfe-var(container-padding)} * 4) // 64px
+    Padding: pfe-var(container-padding)
   ),
   
   // Logo

--- a/elements/pfe-sass/mixins/_components.scss
+++ b/elements/pfe-sass/mixins/_components.scss
@@ -193,10 +193,11 @@
 /// Accordion chevrons
 /// ===========================================================================
 
-@mixin pfe-chevron($state: open, $position: after, $size: .4em) {
+@mixin pfe-chevron($state: open, $position: after, $size: .4em, $position: $size) {
+
   content: "";
   position: absolute;
-  top: calc(#{pfe-var(container-spacer)} + #{$size});
+  top: calc(#{pfe-var(container-spacer)} + #{$position});
   display: block;
   border-style: #{pfe-var(surface--border-style)};
   height: #{$size};
@@ -206,7 +207,7 @@
     border-width: .1em .1em 0 0;
     border-bottom: 0;
     transform: rotate(-45deg);
-    top: calc(#{pfe-var(container-spacer)} + .6em);
+    top: calc(#{pfe-var(container-spacer)} + #{$position});
     @if $position == before {
       left: calc(#{pfe-var(container-spacer)} * 1.5);
     }


### PR DESCRIPTION
## What this Fixes:

- Remove extra padding from tray footer https://www.evernote.com/l/AA705fQDYmlBI5mMmFRJmyG7FJAtDJNXVwU
- At wide tablet breakpoint, menu icon drifts away from the other utility icons | https://www.evernote.com/l/AA6-dT5MQRdIC6YoeArb3pOD45LT045fTHI
- Width of the menu sometimes extends beyond the page content | https://www.evernote.com/l/AA48RyYWVd1B5ISWIyzQxan36qrHzjFMTts

---

## Demo:

https://web-dev-drupal-webux3.dev.a1.vary.redhat.com/fr