### PR TITLE
added fix for nav priority links rendering with arrow

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,9 @@
+## Prerelease 36 ( TBD )
+
+Tag: [v1.0.0-prerelease.36](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.36)
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: arrow from rendering on nav priority cta's when on iOS 12>
+
 ## Prerelease 35 ( 2020-01-17 )
 
 Tag: [v1.0.0-prerelease.35](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.35)

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -163,7 +163,9 @@ $variables: (
 }
 
 // Set svg to none so it won't render in nav on iOS versions 12>
-:host([pfe-priority]) svg { display:none; }
+:host([pfe-priority]) svg { 
+  display:none; 
+}
 
 
 :host([pfe-priority]) {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -162,6 +162,9 @@ $variables: (
   }
 }
 
+// Set svg to none so it won't render in nav on iOS versions 12>
+:host([pfe-priority]) svg { display:none; }
+
 
 :host([pfe-priority]) {
   --pfe-cta--Padding: #{pfe-var(container-padding)} calc(#{pfe-var(container-padding)} * 2);


### PR DESCRIPTION
## Fix bug which causes arrows to appear on primary on CTAs which load late, in nav on iOS =<12
![image](https://user-images.githubusercontent.com/456863/72752901-7952fd00-3b91-11ea-93e5-078fecf311e1.png)


* Link(s) to demo pages where this element can be viewed: https://web-dev-drupal-sshell.dev.a1.vary.redhat.com/en

---

### What has changed and why

* SVG is hidden on CTAs which have the pfe-priority attribute

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. checkout older safari versions and test the main menu to ensure no arrow is appearing. 

#### Browser requirements
Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Galaxy S9 Firefox
- [ ] iPhone X Safari
- [ ] iPad Pro Safari
- [ ] Pixel 3 Chrome
 
### Ready-for-merge Checklist

- [ ] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Did browser testing pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
- [ ] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

