### PR TITLE
chore: Fix a typo in the demo files causing pfelement.min.css to 404

### DIFF
--- a/elements/pfe-card/demo/index.html
+++ b/elements/pfe-card/demo/index.html
@@ -18,7 +18,7 @@
       <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet">
     </noscript>
 
-    <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
+    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -18,7 +18,7 @@
     <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet" />
   </noscript>
 
-  <link href="../../pfelement/pfelement.min.css" rel="stylesheet" />
+  <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet" />
 
   <link href="../../pfe-cta/dist/pfe-cta--lightdom.css" rel="stylesheet" />
   <link href="demo.css" rel="stylesheet" />

--- a/elements/pfe-icon-panel/demo/index.html
+++ b/elements/pfe-icon-panel/demo/index.html
@@ -14,7 +14,7 @@
       <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet" />
     </noscript>
 
-    <link href="../../pfelement/pfelement.min.css" rel="stylesheet" />
+    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet" />
     
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />

--- a/elements/pfe-icon/demo/index.html
+++ b/elements/pfe-icon/demo/index.html
@@ -10,7 +10,7 @@
       <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet">
     </noscript>
 
-    <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
+    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -20,7 +20,7 @@
       <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet">
     </noscript>
 
-    <link href="../../pfelement/pfelement.min.css" rel="stylesheet">
+    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
 
     <!-- uncomment the es5-adapter if you're using the umd version -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>


### PR DESCRIPTION
## Fix a typo in the demo files causing pfelement.min.css to 404

* Update `pfelement/pfelement.min.css` in demo files to `pfelement/dist/pfelement.min.css`

---

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. Open the demo files and make sure that pfelement.min.css is not listed as a 404:
  - https://deploy-preview-704--happy-galileo-ea79c4.netlify.com/elements/pfe-card/demo/
  - https://deploy-preview-704--happy-galileo-ea79c4.netlify.com/elements/pfe-cta/demo/
  - https://deploy-preview-704--happy-galileo-ea79c4.netlify.com/elements/pfe-icon/demo/
  - https://deploy-preview-704--happy-galileo-ea79c4.netlify.com/elements/pfe-icon-panel/demo/
  - https://deploy-preview-704--happy-galileo-ea79c4.netlify.com/elements/pfe-tabs/demo/

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

