### PR TITLE
feat: Adding ability to configure the localhost domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# .env file is only necessary if you want to access the
+# dev site somewhere other than http://localhost
+LOCALHOST = 'custom.localhost.biz'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ lerna-debug.log
 npm-debug.log*
 
 # Local files
+.env
 *.local.umd.js
 *.local.js
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,16 +6151,6 @@
 			"integrity": "sha512-Wg1bImVQ8RPGutT+ySqWRDEhvSVmsvouBQiGq9NejQW33mYbttoC+lVTDR45U/ZbqegwpJT4+1UVOseNaWxvSQ==",
 			"dev": true
 		},
-		"@patternfly/pfe-sass": {
-			"version": "1.0.0-prerelease.28",
-			"resolved": "https://registry.npmjs.org/@patternfly/pfe-sass/-/pfe-sass-1.0.0-prerelease.28.tgz",
-			"integrity": "sha512-RmyU/IevisSY/PseWl2DXsaLURxU0SwP0x8sk/BJ0fGfd1i8eHOaKThXSQFxnYu3TOTHX8enxnH+RKSVvJGGfg=="
-		},
-		"@patternfly/pfelement": {
-			"version": "1.0.0-prerelease.28",
-			"resolved": "https://registry.npmjs.org/@patternfly/pfelement/-/pfelement-1.0.0-prerelease.28.tgz",
-			"integrity": "sha512-bQGsmm47t5CZDyHWTKHLN4Mvk/n1x2aAmCPAswf9xwzV/EdgB88k1fBdshs7NSbr18s7Po742Q2vKUEsrLL4jg=="
-		},
 		"@polymer/esm-amd-loader": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
@@ -16287,19 +16277,16 @@
 			}
 		},
 		"dotenv": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
 			"dev": true
 		},
 		"dotenv-defaults": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.0.tgz",
 			"integrity": "sha512-MoWCnFZ1G6ZLww0TFmXx+CFs2X3ZFhIN5AptQBNPOmrHnvqjlzZPsiAbbISDEk4RUKCVgPF8HmvixuxnaVuNZQ==",
-			"dev": true,
-			"requires": {
-				"dotenv": "^6.2.0"
-			}
+			"dev": true
 		},
 		"dotenv-expand": {
 			"version": "5.1.0",
@@ -18662,28 +18649,28 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
@@ -18694,14 +18681,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
@@ -18712,42 +18699,42 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "4.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"optional": true,
@@ -18757,28 +18744,28 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"dev": true,
 					"optional": true,
@@ -18788,14 +18775,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -18812,7 +18799,7 @@
 				},
 				"glob": {
 					"version": "7.1.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"dev": true,
 					"optional": true,
@@ -18827,14 +18814,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
@@ -18844,7 +18831,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"optional": true,
@@ -18854,7 +18841,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -18865,21 +18852,21 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
@@ -18889,14 +18876,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
@@ -18906,14 +18893,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"dev": true,
 					"optional": true,
@@ -18924,7 +18911,7 @@
 				},
 				"minizlib": {
 					"version": "1.2.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 					"dev": true,
 					"optional": true,
@@ -18934,7 +18921,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
@@ -18944,14 +18931,14 @@
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.3.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 					"dev": true,
 					"optional": true,
@@ -18963,7 +18950,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -18982,7 +18969,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -18993,14 +18980,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.6",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 					"dev": true,
 					"optional": true,
@@ -19011,7 +18998,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -19024,21 +19011,21 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
@@ -19048,21 +19035,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -19073,34 +19060,34 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.6.0",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "",
+							"resolved": false,
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -19109,23 +19096,23 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 					"dev": true,
 					"optional": true,
@@ -19135,49 +19122,49 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
@@ -19189,7 +19176,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -19199,7 +19186,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
@@ -19209,14 +19196,14 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.8",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"dev": true,
 					"optional": true,
@@ -19232,14 +19219,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
@@ -19249,14 +19236,14 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": "",
+					"resolved": false,
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"dev": true,
 					"optional": true
@@ -19634,7 +19621,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -24418,8 +24405,8 @@
 					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
+						"ansi-styles": "4.2.1",
+						"supports-color": "7.1.0"
 					}
 				},
 				"color-convert": {
@@ -24428,7 +24415,7 @@
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 					"dev": true,
 					"requires": {
-						"color-name": "~1.1.4"
+						"color-name": "1.1.4"
 					}
 				},
 				"color-name": {
@@ -24483,7 +24470,7 @@
 					"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.2"
+						"chalk": "2.4.2"
 					},
 					"dependencies": {
 						"ansi-styles": {
@@ -24492,7 +24479,7 @@
 							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 							"dev": true,
 							"requires": {
-								"color-convert": "^1.9.0"
+								"color-convert": "1.9.3"
 							}
 						},
 						"chalk": {
@@ -24501,9 +24488,9 @@
 							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 							"dev": true,
 							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
+								"ansi-styles": "3.2.1",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "5.5.0"
 							}
 						},
 						"color-convert": {
@@ -24533,7 +24520,7 @@
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 							"dev": true,
 							"requires": {
-								"has-flag": "^3.0.0"
+								"has-flag": "3.0.0"
 							}
 						}
 					}
@@ -24550,7 +24537,7 @@
 					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"ansi-regex": "5.0.0"
 					}
 				},
 				"supports-color": {
@@ -24559,7 +24546,7 @@
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"has-flag": "4.0.0"
 					}
 				}
 			}
@@ -26079,11 +26066,6 @@
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
 			}
-		},
-		"marked": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-			"integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
 		},
 		"matchdep": {
 			"version": "2.0.0",
@@ -28414,11 +28396,6 @@
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
-		},
-		"numeral": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-			"integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
 		},
 		"nwsapi": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "decomment": "^0.9.1",
     "del": "^3.0.0",
     "dialog-polyfill": "^0.4.10",
+    "dotenv": "^8.2.0",
     "generator-pfelement": "^1.4.0",
     "ghp": "^1.3.1",
     "glob": "^7.1.6",

--- a/spandx.config.js
+++ b/spandx.config.js
@@ -1,5 +1,13 @@
+// If we have a .env file respect the LOCALHOST setting
+// If not default to localhost
+require('dotenv').config();
+let localhost = 'localhost';
+if (typeof process.env === 'object' && typeof process.env.LOCALHOST !== 'undefined') {
+  localhost = process.env.LOCALHOST;
+}
+
 module.exports = {
-  host: "localhost",
+  host: localhost,
   port: "auto",
   open: true,
   startPath: "/examples",


### PR DESCRIPTION
Adding dotenv package
Defaulting localhost to 'localhost', but .env file can override that
Added example .env file
Ignoring .env file

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.
1. `npm i` to get new additions to build.
1. Checkout branch and try to run `npm start` without adding a `.env` file, should provide a server at `http://localhost:8000/examples`
2. Save `.env.example` as `.env` and add a domain of your choosing
3. Run `npm start` and you should get `http://YOURHOSTNAME:8000/examples`

