### PR TITLE
changelog & doc updates

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,10 +1,14 @@
-## Prerelease 37 ( TBD )
+## Prerelease 37 ( 2020-02-03 )
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-nav & pfe-cta hotfixes
+
+
+## Prerelease 37 ( 2020-01-08 )
 
 Tag: [v1.0.0-prerelease.37](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.37)
 
 - [6a41811](https://github.com/patternfly/patternfly-elements/commit/6a418112668ba580918ac4a8b4b54e8df05c1155) fix: reference error when slot is missing in pfe-navigation
 - [ff859a5](https://github.com/patternfly/patternfly-elements/commit/ff859a5c2b62ae24225f0031f69b5bc050c59470) fix: accordion accessibility improvements; aria-roles corrected
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-nav & pfe-cta hotfixes
 
 ## Prerelease 36 ( 2020-01-20 )
 

--- a/docs/content/develop/step-5.md
+++ b/docs/content/develop/step-5.md
@@ -100,7 +100,7 @@ tags = [ "develop" ]
 ```
 Greetings! 
 
-There is a new release tag for PatternFly Elements,  [v1.0.0-prerelease.36](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.36), which includes
+There is a new release tag for PatternFly Elements,  [v1.0.0-prerelease.38](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.38), which includes
 
 
 

--- a/docs/layouts/_default/list.html
+++ b/docs/layouts/_default/list.html
@@ -8,7 +8,7 @@
   <!-- Convert to a partial -->
   <nav id="main-toc">
     <section class="inner-toc">
-      <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.36</span>
+      <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.38</span>
 
       <h3><a href="/getting-started">Getting Started</a></h3>
       <ul>

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -8,7 +8,7 @@
   <!-- Convert to a partial -->
   <nav id="main-toc">
     <section class="inner-toc">
-      <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.36</span>
+      <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.38</span>
 
       <h3><a href="/getting-started">Getting Started</a></h3>
       <ul>

--- a/docs/layouts/partials/header.html
+++ b/docs/layouts/partials/header.html
@@ -40,7 +40,7 @@
 <!-- Convert to a partial -->
 <nav id="mobile-toc" class="hide">
   <section class="inner-toc">
-    <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.36</span>
+    <span class="label big" style="margin-bottom: 1.5rem;">Version 1.0.0-prerelease.38</span>
 
     <h3><a href="/getting-started">Getting Started</a></h3>
     <ul>


### PR DESCRIPTION
The release script still returns to master branch, so there are two PRs to update master with prerelease 38.

This one which updates docs & changelog, [then this one](https://github.com/patternfly/patternfly-elements/pull/715) generated by the script that updates the package files.