### PR TITLE
simplify the dotenv check in spandx.config.js

### DIFF
--- a/spandx.config.js
+++ b/spandx.config.js
@@ -1,13 +1,9 @@
 // If we have a .env file respect the LOCALHOST setting
 // If not default to localhost
 require('dotenv').config();
-let localhost = 'localhost';
-if (typeof process.env === 'object' && typeof process.env.LOCALHOST !== 'undefined') {
-  localhost = process.env.LOCALHOST;
-}
 
 module.exports = {
-  host: localhost,
+  host: process.env.LOCALHOST || "localhost",
   port: "auto",
   open: true,
   startPath: "/examples",


### PR DESCRIPTION
Turn the dotenv LOCALHOST check in spandx.config.js into a simpler one liner.