### PR TITLE
fix: cascading the "on" attribute on pfe-content-set

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,7 +2,7 @@
 
 Tag: [v1.0.0-prerelease.39](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.39)
 
-- 
+- []() fix: cascading the "on" attribute on pfe-content-set #730
 
 ## Prerelease 38 ( 2020-02-03 )
 

--- a/elements/pfe-accordion/src/pfe-accordion.js
+++ b/elements/pfe-accordion/src/pfe-accordion.js
@@ -44,7 +44,7 @@ class PfeAccordion extends PFElement {
   }
 
   static get observedAttributes() {
-    return ["pfe-disclosure", "on"]
+    return ["pfe-disclosure"]
   }
 
   constructor() {

--- a/elements/pfe-accordion/src/pfe-accordion.js
+++ b/elements/pfe-accordion/src/pfe-accordion.js
@@ -44,7 +44,7 @@ class PfeAccordion extends PFElement {
   }
 
   static get observedAttributes() {
-    return ["pfe-disclosure"]
+    return ["pfe-disclosure", "on"]
   }
 
   constructor() {

--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/typebase.css/0.5.0/typebase.css">
     -->
-    
+
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-layouts.css" />
@@ -29,7 +29,8 @@
     <script>
       require([
         "../dist/pfe-content-set.umd.js",
-        "../../pfe-cta/dist/pfe-cta.umd.js"
+        "../../pfe-cta/dist/pfe-cta.umd.js",
+        "../../pfe-band/dist/pfe-band.umd.js"
       ])
     </script>
 
@@ -268,6 +269,18 @@
       </pfe-content-set>
     </section>
 
+    <section>
+      <h2>Using pfe-color to control the theme: pfe-color="darkest"</h2>
+      <pfe-band pfe-color="darkest">
+        <pfe-content-set>
+          <h2 pfe-content-set--header>Heading 1</h2>
+          <div pfe-content-set--panel>Panel 1</div>
+          <h2 pfe-content-set--header>Heading 2</h2>
+          <div pfe-content-set--panel>Panel 2</div>
+        </pfe-content-set>
+      </pfe-band>
+    </section>
+
     <hr>
 
     <h2>Align: center</h2>
@@ -286,15 +299,17 @@
     </pfe-content-set>
 
     <hr>
-    <h2>This content set's markup is incorrect.</h2>
-    <pfe-content-set>
-      <h2>Heading 1</h2>
-      <div>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
-      </div>
-      <h2>Heading 2</h2>
-      <div>Nullam quis risus eget urna mollis ornare vel eu leo. Maecenas sed diam eget risus varius blandit sit amet non magna. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</div>
-    </pfe-content-set>
+    <section>
+      <h2>This content set's markup is incorrect.</h2>
+      <pfe-content-set>
+        <h2>Heading 1</h2>
+        <div>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
+        </div>
+        <h2>Heading 2</h2>
+        <div>Nullam quis risus eget urna mollis ornare vel eu leo. Maecenas sed diam eget risus varius blandit sit amet non magna. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</div>
+      </pfe-content-set>
+    </section>
 
     <h2>Dynamically Add Headers and Panels</h2>
     <pfe-content-set id="dynamic">

--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -271,7 +271,18 @@
 
     <section>
       <h2>Using pfe-color to control the theme: pfe-color="darkest"</h2>
+      <h3>Tabs</h3>
       <pfe-band pfe-color="darkest">
+        <pfe-content-set>
+          <h2 pfe-content-set--header>Heading 1</h2>
+          <div pfe-content-set--panel>Panel 1</div>
+          <h2 pfe-content-set--header>Heading 2</h2>
+          <div pfe-content-set--panel>Panel 2</div>
+        </pfe-content-set>
+      </pfe-band>
+
+      <h3>Accordion</h3>
+      <pfe-band pfe-color="darkest" style="width: 600px">
         <pfe-content-set>
           <h2 pfe-content-set--header>Heading 1</h2>
           <div pfe-content-set--panel>Panel 1</div>

--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -55,6 +55,10 @@ class PfeContentSet extends PFElement {
       this._observer.disconnect();
     }
 
+    if (this.hasAttribute("on")) {
+      this.on.value = this.getAttribute("on");
+    }
+
     if (this.isTab) {
       this._buildTabs();
     } else {
@@ -153,7 +157,7 @@ class PfeContentSet extends PFElement {
     }
 
     // Pass the theme property down to the tabs component
-    if (this.on.value) {
+    if (this.on) {
       tabs.setAttribute("on", this.on.value);
     }
 

--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -55,10 +55,6 @@ class PfeContentSet extends PFElement {
       this._observer.disconnect();
     }
 
-    if (this.hasAttribute("on")) {
-      this.on.value = this.getAttribute("on");
-    }
-
     if (this.isTab) {
       this._buildTabs();
     } else {
@@ -66,6 +62,7 @@ class PfeContentSet extends PFElement {
     }
 
     this.render();
+    this.context_update();
 
     if (window.ShadyCSS) {
       setTimeout(() => {
@@ -101,11 +98,6 @@ class PfeContentSet extends PFElement {
 
     if (!existingAccordion) {
       fragment.appendChild(accordion);
-    }
-
-    // Pass the theme property down to the accordion component
-    if (this.on) {
-      accordion.setAttribute("on", this.on.value);
     }
 
     if (!existingAccordion) {
@@ -154,11 +146,6 @@ class PfeContentSet extends PFElement {
     // Pass the variant attribute down to the tabs component
     if (this.variant.value !== this.variant.default) {
       tabs.setAttribute("pfe-variant", this.variant.value);
-    }
-
-    // Pass the theme property down to the tabs component
-    if (this.on) {
-      tabs.setAttribute("on", this.on.value);
     }
 
     if (this.align.value) {

--- a/elements/pfe-content-set/test/pfe-content-set_test.html
+++ b/elements/pfe-content-set/test/pfe-content-set_test.html
@@ -83,6 +83,13 @@
       </pfe-content-set>
     </pfe-band>
 
+    <pfe-band id="accordionBand" pfe-color="darkest" style="width: 600px;">
+      <pfe-content-set>
+        <h2 pfe-content-set--header>Heading 1</h2>
+        <p pfe-content-set--panel>Panel 1</p>
+      </pfe-content-set>
+    </pfe-band>
+
     <script>
       suite('<pfe-content-set>', () => {
         test('it should have the proper attributes for tabs', () => {
@@ -189,7 +196,7 @@
         test("it should set the correct \"on\" attribute from a parent component that has a pfe-color attribute", done => {
           const band = document.querySelector("#band");
           const contentSet = band.querySelector("pfe-content-set");
-          const tabs = band.querySelector("pfe-tabs");
+          const tabs = contentSet.querySelector("pfe-tabs");
           const tab = tabs.querySelector("pfe-tab");
           const panel = tabs.querySelector("pfe-tab-panel");
 
@@ -198,13 +205,30 @@
           assert.equal(tab.getAttribute("on"), "dark");
           assert.equal(panel.getAttribute("on"), "dark");
 
+          const accordionBand = document.querySelector("#accordionBand");
+          const accordionContentSet = accordionBand.querySelector("pfe-content-set");
+          const accordion = accordionContentSet.querySelector("pfe-accordion");
+          const accordionHeader = accordion.querySelector("pfe-accordion-header");
+          const accordionPanel = accordion.querySelector("pfe-accordion-panel");
+
+          assert.equal(accordionContentSet.getAttribute("on"), "dark");
+          assert.equal(accordion.getAttribute("on"), "dark");
+          assert.equal(accordionHeader.getAttribute("on"), "dark");
+          assert.equal(accordionPanel.getAttribute("on"), "dark");
+
           band.removeAttribute("pfe-color");
+          accordionBand.removeAttribute("pfe-color");
 
           flush(() => {
             assert.equal(contentSet.getAttribute("on"), "light");
             assert.equal(tabs.getAttribute("on"), "light")
             assert.equal(tab.getAttribute("on"), "light");
             assert.equal(panel.getAttribute("on"), "light");
+
+            assert.equal(accordionContentSet.getAttribute("on"), "light");
+            assert.equal(accordion.getAttribute("on"), "light");
+            assert.equal(accordionHeader.getAttribute("on"), "light");
+            assert.equal(accordionPanel.getAttribute("on"), "light");
 
             done();
           });

--- a/elements/pfe-content-set/test/pfe-content-set_test.html
+++ b/elements/pfe-content-set/test/pfe-content-set_test.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <script src="/components/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="/components/web-component-tester/browser.js"></script>
+    <script type="module" src="../../pfe-band/dist/pfe-band.js"></script>
     <script type="module" src="../dist/pfe-content-set.js"></script>
   </head>
   <body>
@@ -74,6 +75,13 @@
       <h2 pfe-content-set--header>Heading 1</h2>
       <p pfe-content-set--panel>Panel 1</p>
     </pfe-content-set>
+
+    <pfe-band id="band" pfe-color="darkest">
+      <pfe-content-set>
+        <h2 pfe-content-set--header>Heading 1</h2>
+        <p pfe-content-set--panel>Panel 1</p>
+      </pfe-content-set>
+    </pfe-band>
 
     <script>
       suite('<pfe-content-set>', () => {
@@ -176,6 +184,30 @@
           const pfeTabAlignValue = pfeTabs.getAttribute("pfe-tab-align");
 
           assert.equal(alignValue, pfeTabAlignValue);
+        });
+
+        test("it should set the correct \"on\" attribute from a parent component that has a pfe-color attribute", done => {
+          const band = document.querySelector("#band");
+          const contentSet = band.querySelector("pfe-content-set");
+          const tabs = band.querySelector("pfe-tabs");
+          const tab = tabs.querySelector("pfe-tab");
+          const panel = tabs.querySelector("pfe-tab-panel");
+
+          assert.equal(contentSet.getAttribute("on"), "dark");
+          assert.equal(tabs.getAttribute("on"), "dark")
+          assert.equal(tab.getAttribute("on"), "dark");
+          assert.equal(panel.getAttribute("on"), "dark");
+
+          band.removeAttribute("pfe-color");
+
+          flush(() => {
+            assert.equal(contentSet.getAttribute("on"), "light");
+            assert.equal(tabs.getAttribute("on"), "light")
+            assert.equal(tab.getAttribute("on"), "light");
+            assert.equal(panel.getAttribute("on"), "light");
+
+            done();
+          });
         });
       });
     </script>


### PR DESCRIPTION
Fixes #720

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. View the "Using pfe-color to control the theme" section of the demo.
2. Verify that the "on" attribute has been added to both the tabs and the accordion.
3. Verify that the newly added tests for pfe-content-set are passing

