### PR TITLE
fix: run prettier only on js and json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,13 @@
+# Ignore these files and file-types, regardless of where they are in the
+# directory tree.
+
 test
 package.json
 package-lock.json
+*.scss
+*.css
+*.html
+*.md
 
 generators/element/templates/*
 


### PR DESCRIPTION
This extends the list of files ignored by prettier to include `scss`, `css`, `html`, and `md`.  Those filetypes were untintentionally being prettier-ified by an error in #726.