### PR TITLE
fix: pfe-cta arrow wrap issue #679

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,10 @@
+## Prerelease 39 ( TBD )
+
+Tag: [v1.0.0-prerelease.40](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.40)
+
+- [ ]( ) fix: Prevent default pfe-cta arrow from wrapping to a new line by itself (#679)
+
+
 ## Prerelease 39 ( 2020-02-19 )
 
 Tag: [v1.0.0-prerelease.39](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.39)

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -18,20 +18,33 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
 }
 
 .resize {
+  display: flex;
+  flex-flow: row nowrap;
   resize: horizontal;
   overflow: auto;
   border: 1px solid #ddd;
+  width: 500px;
   padding: 10px;
 }
 
-.card-layout {
-  width: 100%;
-  display: block;
-
+.resize>pfe-cta:first-child {
+  margin-right: 20px;
 }
 
-.card-layout > * {
-  margin-bottom: 20px;
+.card-layout {
+  display: flex;
+  flex-flow: row wrap;
+  display: grid;
+  grid-gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+  margin-top: -10px;
+  margin-left: -20px;
+}
+
+.card-layout>pfe-cta,
+.card-layout .cta-align>pfe-cta {
+  margin-top: 10px;
+  margin-left: 20px;
 }
 
 .custom-dark-band {

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -25,16 +25,13 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
 }
 
 .card-layout {
-  display: flex;
-  flex-flow: row wrap;
-  display: grid;
-  grid-gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, max-content));
+  width: 100%;
+  display: block;
+
 }
 
-.card-layout > pfe-cta,
-.card-layout .cta-align > pfe-cta {
-  margin-top: 10px;
+.card-layout > * {
+  margin-bottom: 20px;
 }
 
 .custom-dark-band {

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -18,12 +18,9 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
 }
 
 .resize {
-  display: flex;
-  flex-flow: row nowrap;
   resize: horizontal;
   overflow: auto;
   border: 1px solid #ddd;
-  width: 500px;
   padding: 10px;
 }
 

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -24,16 +24,12 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
   padding: 10px;
 }
 
-.resize > pfe-cta:first-child {
-  margin-right: 20px;
-}
-
 .card-layout {
   display: flex;
   flex-flow: row wrap;
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+  grid-template-columns: repeat(auto-fit, minmax(280px, max-content));
   margin-top: -10px;
   margin-left: -20px;
 }
@@ -41,7 +37,7 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
 .card-layout > pfe-cta,
 .card-layout .cta-align > pfe-cta {
   margin-top: 10px;
-  margin-left: 20px;
+  display: block;
 }
 
 .custom-dark-band {

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -30,11 +30,6 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
   display: grid;
   grid-gap: 10px;
   grid-template-columns: repeat(auto-fit, minmax(280px, max-content));
-  margin-top: -10px;
-  margin-left: -20px;
-}
-.padding {
-  padding: 16px;
 }
 
 .card-layout > pfe-cta,

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -33,6 +33,9 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
   margin-top: -10px;
   margin-left: -20px;
 }
+.padding {
+  padding: 16px;
+}
 
 .card-layout > pfe-cta,
 .card-layout .cta-align > pfe-cta {

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -254,7 +254,7 @@
     <h2 style="color:white;">Custom saturated band with broadcast vars</h2>
 
     <h3 style="color:white;">Color responsive</h3>
-    <div class="card-layout">
+    <div class="card-layout padding">
       <pfe-cta pfe-theme="saturated"><a href="https://www.redhat.com">Default</a></pfe-cta>
       <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
       <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
@@ -263,7 +263,7 @@
     <br />
 
     <h3 style="color:white;">Color override</h3>
-    <div class="card-layout">
+    <div class="card-layout padding">
       <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
       <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
       </pfe-cta>
@@ -284,7 +284,7 @@
     </h2>
 
     <h3 style="color: white">Color responsive</h3>
-    <div class="card-layout">
+    <div class="card-layout  padding">
       <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
       <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
       <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
@@ -293,7 +293,7 @@
     <br />
 
     <h3 style="color: white">Color override</h3>
-    <div class="card-layout">
+    <div class="card-layout  padding">
       <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
       <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
       </pfe-cta>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -49,10 +49,10 @@
     <pfe-band pfe-color="lightest">
       <h2>CTAs in light containers</h2>
       <div class="card-layout">
-        <pfe-card pfe-color="lightest" pfe-size="small">
+        <pfe-card pfe-color="lightest" pfe-size="small" class="resize">
           <h3 slot="pfe-card--header">No color attribute</h3>
           <div class="cta-align">
-            <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
+            <pfe-cta><a href="https://www.redhat.com">Default call to action a b c</a></pfe-cta>
             <pfe-cta pfe-priority="primary"
               ><a href="https://www.redhat.com">Primary</a></pfe-cta
             >

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -48,7 +48,6 @@
     <div class="card-layout">
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header">No color attribute</h3>
-
           <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
           <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
           <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a>
@@ -58,7 +57,6 @@
           </pfe-cta>
           <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a>
           </pfe-cta>
-
       </pfe-card>
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -34,7 +34,6 @@
       "../../pfe-band/dist/pfe-band.umd.js",
       "../../pfe-card/dist/pfe-card.umd.js"
     ]);
-
   </script>
 </head>
 
@@ -48,15 +47,14 @@
     <div class="card-layout">
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header">No color attribute</h3>
+        <div class="cta-align">
           <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
           <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
-          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a>
-          </pfe-cta>
-          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a
-              href="https://www.redhat.com">Secondary + wind</a>
-          </pfe-cta>
-          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a>
-          </pfe-cta>
+          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind
+              variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta>
+        </div>
       </pfe-card>
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
@@ -65,7 +63,7 @@
           <pfe-cta pfe-priority="primary" pfe-color="base"><a href="https://www.redhat.com">Primary</a></pfe-cta>
           <pfe-cta pfe-priority="secondary" pfe-color="base"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
           <pfe-cta pfe-priority="secondary" pfe-color="base" pfe-variant="wind"><a
-              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
           <pfe-cta aria-disabled="true" pfe-color="base"><a href="https://www.redhat.com" disabled>Disabled</a>
           </pfe-cta>
         </div>
@@ -77,7 +75,7 @@
           <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary</a></pfe-cta>
           <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
           <pfe-cta pfe-priority="secondary" pfe-color="accent" pfe-variant="wind"><a
-              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
           <pfe-cta aria-disabled="true" pfe-color="accent"><a href="https://www.redhat.com" disabled>Disabled</a>
           </pfe-cta>
         </div>
@@ -90,7 +88,7 @@
           <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary</a>
           </pfe-cta>
           <pfe-cta pfe-priority="secondary" pfe-color="complement" pfe-variant="wind"><a
-              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
           <pfe-cta aria-disabled="true" pfe-color="complement"><a href="https://www.redhat.com" disabled>Disabled</a>
           </pfe-cta>
         </div>
@@ -214,13 +212,8 @@
     <br />
 
     <h3>Force wrap to test arrow line-wrap</h3>
-    <div class="resize" style="width: 180px">
+    <div class="resize">
       <pfe-cta><a href="https://www.redhat.com">Default link cta with longer text</a></pfe-cta>
-    </div>
-
-    <br />
-    <h3>Incorrect use of a button in a default CTA (triggers console warning)</h3>
-    <div style="width: 180px">
       <pfe-cta><button>Default button cta with longer text</button></pfe-cta>
     </div>
 
@@ -255,7 +248,7 @@
     <h2 style="color:white;">Custom saturated band with broadcast vars</h2>
 
     <h3 style="color:white;">Color responsive</h3>
-    <div class="card-layout padding">
+    <div class="card-layout">
       <pfe-cta pfe-theme="saturated"><a href="https://www.redhat.com">Default</a></pfe-cta>
       <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
       <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
@@ -264,7 +257,7 @@
     <br />
 
     <h3 style="color:white;">Color override</h3>
-    <div class="card-layout padding">
+    <div class="card-layout">
       <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
       <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
       </pfe-cta>
@@ -285,7 +278,7 @@
     </h2>
 
     <h3 style="color: white">Color responsive</h3>
-    <div class="card-layout  padding">
+    <div class="card-layout">
       <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
       <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
       <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
@@ -294,7 +287,7 @@
     <br />
 
     <h3 style="color: white">Color override</h3>
-    <div class="card-layout  padding">
+    <div class="card-layout">
       <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
       <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
       </pfe-cta>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -1,492 +1,312 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes"
-    />
-    <title>PatternFly Elements: pfe-cta demo</title>
 
-    <!-- Stylesheets for testing light DOM styles.
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
+  <title>PatternFly Elements: pfe-cta demo</title>
+
+  <!-- Stylesheets for testing light DOM styles.
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/typebase.css/0.5.0/typebase.css">
     -->
 
-    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
-    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />
-    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-layouts.css" />
+  <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
+  <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />
+  <link rel="stylesheet" href="../../pfe-styles/dist/pfe-layouts.css" />
 
-    <noscript>
-      <link
-        href="../../pfelement/dist/pfelement--noscript.min.css"
-        rel="stylesheet"
-      />
-    </noscript>
+  <noscript>
+    <link href="../../pfelement/dist/pfelement--noscript.min.css" rel="stylesheet" />
+  </noscript>
 
-    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet" />
+  <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet" />
 
-    <link href="../../pfe-cta/dist/pfe-cta--lightdom.css" rel="stylesheet" />
-    <link href="demo.css" rel="stylesheet" />
+  <link href="../../pfe-cta/dist/pfe-cta--lightdom.css" rel="stylesheet" />
+  <link href="demo.css" rel="stylesheet" />
 
-    <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
-    <script>
-      require([
-        "../dist/pfe-cta.umd.js",
-        "../../pfe-band/dist/pfe-band.umd.js",
-        "../../pfe-card/dist/pfe-card.umd.js"
-      ]);
-    </script>
-  </head>
-  <body unresolved>
-    <pfe-band pfe-color="complement" pfe-size="small">
-      <h1 slot="pfe-band--header"><code>&lt;pfe-cta&gt;</code> demo page</h1>
-    </pfe-band>
+  <!-- uncomment the es5-adapter if you're using the umd version -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+  <script>
+    require([
+      "../dist/pfe-cta.umd.js",
+      "../../pfe-band/dist/pfe-band.umd.js",
+      "../../pfe-card/dist/pfe-card.umd.js"
+    ]);
 
-    <pfe-band pfe-color="lightest">
-      <h2>CTAs in light containers</h2>
-      <div class="card-layout">
-        <pfe-card pfe-color="lightest" pfe-size="small" class="resize">
-          <h3 slot="pfe-card--header">No color attribute</h3>
-          <div class="cta-align">
-            <pfe-cta><a href="https://www.redhat.com">Default call to action a b c</a></pfe-cta>
-            <pfe-cta pfe-priority="primary"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="lightest" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="base"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="base"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="base"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="base"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="base"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="lighter" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="accent"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="accent"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="accent"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="lighter" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="complement"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="complement"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="complement"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-      </div>
+  </script>
+</head>
 
-      <br />
-      <hr />
-      <br />
+<body unresolved>
+  <pfe-band pfe-color="complement" pfe-size="small">
+    <h1 slot="pfe-band--header"><code>&lt;pfe-cta&gt;</code> demo page</h1>
+  </pfe-band>
 
-      <h2>CTAs in dark containers</h2>
-      <div class="card-layout">
-        <pfe-card pfe-color="darkest" pfe-size="small">
-          <h3 slot="pfe-card--header">No color attribute</h3>
-          <div class="cta-align">
-            <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
-            <pfe-cta pfe-priority="primary"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="darkest" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="base"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="base"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="base"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="base"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="base"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="darker" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="accent"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="accent"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="accent"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="darker" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="complement"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="complement"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="complement"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-      </div>
-
-      <br />
-      <hr />
-      <br />
-
-      <h3>CTAs in saturated containers</h3>
-      <div class="card-layout">
-        <pfe-card pfe-color="complement" pfe-size="small">
-          <h3 slot="pfe-card--header">No color attribute</h3>
-          <div class="cta-align">
-            <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
-            <pfe-cta pfe-priority="primary"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="complement" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="base"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="base"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="base"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="base"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="base"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="accent" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="accent"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="accent"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="accent"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="accent"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-        <pfe-card pfe-color="accent" pfe-size="small">
-          <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
-          <div class="cta-align">
-            <pfe-cta pfe-color="complement"
-              ><a href="https://www.redhat.com">Default</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="primary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Primary</a></pfe-cta
-            >
-            <pfe-cta pfe-priority="secondary" pfe-color="complement"
-              ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-            >
-            <pfe-cta
-              pfe-priority="secondary"
-              pfe-color="complement"
-              pfe-variant="wind"
-              ><a href="https://www.redhat.com"
-                >Secondary + wind variant</a
-              ></pfe-cta
-            >
-            <pfe-cta aria-disabled="true" pfe-color="complement"
-              ><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta
-            >
-          </div>
-        </pfe-card>
-      </div>
-
-      <br />
-      <hr />
-      <br />
-
-      <h3>Force wrap to test arrow line-wrap</h3>
-      <div class="resize">
-        <pfe-cta
-          ><a href="https://www.redhat.com"
-            >Default link cta with longer text</a
-          ></pfe-cta
-        >
-        <pfe-cta><button>Default button cta with longer text</button></pfe-cta>
-      </div>
-
-      <br />
-      <hr />
-      <br />
-
-      <h3>Link and button styles (displayed inline)</h3>
-      <div>
-        <pfe-cta style="outline: 1px dashed darkgray;"
-          ><a href="https://www.redhat.com">Link</a></pfe-cta
-        >
-        <pfe-cta style="outline: 1px dashed darkgray;"
-          ><button>Button</button></pfe-cta
-        >
-
-        <pfe-cta pfe-priority="primary"
-          ><a href="https://www.redhat.com">Link</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary"><button>Button</button></pfe-cta>
-
-        <pfe-cta pfe-priority="secondary"
-          ><a href="https://www.redhat.com">Link</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary"><button>Button</button></pfe-cta>
-
-        <pfe-cta aria-disabled="true"
-          ><a href="https://www.redhat.com">Link</a></pfe-cta
-        >
-        <pfe-cta aria-disabled="true"><button>Button</button></pfe-cta>
-      </div>
-    </pfe-band>
+  <pfe-band pfe-color="lightest">
+    <h2>CTAs in light containers</h2>
+    <div class="card-layout">
+      <pfe-card pfe-color="lightest" pfe-size="small">
+        <h3 slot="pfe-card--header">No color attribute</h3>
+        <div class="cta-align">
+          <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind</a>
+          </pfe-cta>
+          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="lightest" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="base"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="base"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="base"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="lighter" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="accent"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="accent"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="lighter" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="complement"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="complement"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary</a>
+          </pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="complement"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+    </div>
 
     <br />
     <hr />
     <br />
 
-    <h1>Old school testing (custom backgrounds)</h1>
+    <h2>CTAs in dark containers</h2>
+    <div class="card-layout">
+      <pfe-card pfe-color="darkest" pfe-size="small">
+        <h3 slot="pfe-card--header">No color attribute</h3>
+        <div class="cta-align">
+          <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind
+              variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="darkest" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="base"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="base"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="base"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="darker" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="accent"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="accent"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="darker" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="complement"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="complement"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary</a>
+          </pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="complement"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+    </div>
+
+    <br />
+    <hr />
     <br />
 
-    <div class="custom-saturated-band">
-      <h2 style="color:white;">Custom saturated band with broadcast vars</h2>
-
-      <h3 style="color:white;">Color responsive</h3>
-      <div class="card-layout">
-        <pfe-cta pfe-theme="saturated"
-          ><a href="https://www.redhat.com">Default</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary"
-          ><a href="https://www.redhat.com">Primary</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary"
-          ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-        >
-      </div>
-
-      <br />
-
-      <h3 style="color:white;">Color override</h3>
-      <div class="card-layout">
-        <pfe-cta pfe-priority="primary" pfe-color="accent"
-          ><a href="https://www.redhat.com">Primary accent</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-color="accent"
-          ><a href="https://www.redhat.com">Secondary accent</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary" pfe-color="complement"
-          ><a href="https://www.redhat.com">Primary complement</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-color="complement"
-          ><a href="https://www.redhat.com">Secondary complement</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary" pfe-color="lightest"
-          ><a href="https://www.redhat.com">Primary lightest</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="https://www.redhat.com"
-            >Secondary + wind variant</a
-          ></pfe-cta
-        >
-      </div>
+    <h3>CTAs in saturated containers</h3>
+    <div class="card-layout">
+      <pfe-card pfe-color="complement" pfe-size="small">
+        <h3 slot="pfe-card--header">No color attribute</h3>
+        <div class="cta-align">
+          <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind
+              variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="complement" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="base"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="base"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="base" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="base"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="accent" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="accent"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="accent"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="accent" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="accent"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
+      <pfe-card pfe-color="accent" pfe-size="small">
+        <h3 slot="pfe-card--header"><code>pfe-color="complement"</code></h3>
+        <div class="cta-align">
+          <pfe-cta pfe-color="complement"><a href="https://www.redhat.com">Default</a></pfe-cta>
+          <pfe-cta pfe-priority="primary" pfe-color="complement"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary</a>
+          </pfe-cta>
+          <pfe-cta pfe-priority="secondary" pfe-color="complement" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind variant</a></pfe-cta>
+          <pfe-cta aria-disabled="true" pfe-color="complement"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+        </div>
+      </pfe-card>
     </div>
 
-    <div class="custom-dark-band">
-      <h2 style="color:white;">
-        Custom dark band with custom broadcast variables
-      </h2>
+    <br />
+    <hr />
+    <br />
 
-      <h3 style="color: white">Color responsive</h3>
-      <div class="card-layout">
-        <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
-        <pfe-cta pfe-priority="primary"
-          ><a href="https://www.redhat.com">Primary</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary"
-          ><a href="https://www.redhat.com">Secondary</a></pfe-cta
-        >
-      </div>
-
-      <br />
-
-      <h3 style="color: white">Color override</h3>
-      <div class="card-layout">
-        <pfe-cta pfe-priority="primary" pfe-color="accent"
-          ><a href="https://www.redhat.com">Primary accent</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-color="accent"
-          ><a href="https://www.redhat.com">Secondary accent</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary" pfe-color="complement"
-          ><a href="https://www.redhat.com">Primary complement</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-color="complement"
-          ><a href="https://www.redhat.com">Secondary complement</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="primary" pfe-color="lightest"
-          ><a href="https://www.redhat.com">Primary lightest</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="https://www.redhat.com"
-            >Secondary + wind variant</a
-          ></pfe-cta
-        >
-      </div>
+    <h3>Force wrap to test arrow line-wrap</h3>
+    <div class="resize" style="width: 180px">
+      <pfe-cta><a href="https://www.redhat.com">Default link cta with longer text</a></pfe-cta>
     </div>
-  </body>
+
+    <br />
+    <h3>Incorrect use of a button in a default CTA (triggers console warning)</h3>
+    <div style="width: 180px">
+      <pfe-cta><button>Default button cta with longer text</button></pfe-cta>
+    </div>
+
+    <br />
+    <hr />
+    <br />
+
+    <h3>Link and button styles (displayed inline)</h3>
+    <div>
+      <pfe-cta style="outline: 1px dashed darkgray;"><a href="https://www.redhat.com">Link</a></pfe-cta>
+      <pfe-cta style="outline: 1px dashed darkgray;"><button>Button</button></pfe-cta>
+
+      <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Link</a></pfe-cta>
+      <pfe-cta pfe-priority="primary"><button>Button</button></pfe-cta>
+
+      <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Link</a></pfe-cta>
+      <pfe-cta pfe-priority="secondary"><button>Button</button></pfe-cta>
+
+      <pfe-cta aria-disabled="true"><a href="https://www.redhat.com">Link</a></pfe-cta>
+      <pfe-cta aria-disabled="true"><button>Button</button></pfe-cta>
+    </div>
+  </pfe-band>
+
+  <br />
+  <hr />
+  <br />
+
+  <h1>Old school testing (custom backgrounds)</h1>
+  <br />
+
+  <div class="custom-saturated-band">
+    <h2 style="color:white;">Custom saturated band with broadcast vars</h2>
+
+    <h3 style="color:white;">Color responsive</h3>
+    <div class="card-layout">
+      <pfe-cta pfe-theme="saturated"><a href="https://www.redhat.com">Default</a></pfe-cta>
+      <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+      <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+    </div>
+
+    <br />
+
+    <h3 style="color:white;">Color override</h3>
+    <div class="card-layout">
+      <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="primary" pfe-color="complement"><a href="https://www.redhat.com">Primary complement</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary complement</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="primary" pfe-color="lightest"><a href="https://www.redhat.com">Primary lightest</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind variant</a>
+      </pfe-cta>
+    </div>
+  </div>
+
+  <div class="custom-dark-band">
+    <h2 style="color:white;">
+      Custom dark band with custom broadcast variables
+    </h2>
+
+    <h3 style="color: white">Color responsive</h3>
+    <div class="card-layout">
+      <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
+      <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+      <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
+    </div>
+
+    <br />
+
+    <h3 style="color: white">Color override</h3>
+    <div class="card-layout">
+      <pfe-cta pfe-priority="primary" pfe-color="accent"><a href="https://www.redhat.com">Primary accent</a></pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-color="accent"><a href="https://www.redhat.com">Secondary accent</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="primary" pfe-color="complement"><a href="https://www.redhat.com">Primary complement</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-color="complement"><a href="https://www.redhat.com">Secondary complement</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="primary" pfe-color="lightest"><a href="https://www.redhat.com">Primary lightest</a>
+      </pfe-cta>
+      <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind variant</a>
+      </pfe-cta>
+    </div>
+  </div>
+</body>
+
 </html>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -48,14 +48,17 @@
     <div class="card-layout">
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header">No color attribute</h3>
-        <div class="cta-align">
+
           <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
-          <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
-          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a></pfe-cta>
-          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="https://www.redhat.com">Secondary + wind</a>
+          <pfe-cta name="pfe-card--footer" pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta name="pfe-card--footer" pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a>
           </pfe-cta>
-          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a></pfe-cta>
-        </div>
+          <pfe-cta name="pfe-card--footer" pfe-priority="secondary" pfe-variant="wind"><a
+              href="https://www.redhat.com">Secondary + wind</a>
+          </pfe-cta>
+          <pfe-cta name="pfe-card--footer" aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a>
+          </pfe-cta>
+
       </pfe-card>
       <pfe-card pfe-color="lightest" pfe-size="small">
         <h3 slot="pfe-card--header"><code>pfe-color="base"</code></h3>

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -50,13 +50,13 @@
         <h3 slot="pfe-card--header">No color attribute</h3>
 
           <pfe-cta><a href="https://www.redhat.com">Default</a></pfe-cta>
-          <pfe-cta name="pfe-card--footer" pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
-          <pfe-cta name="pfe-card--footer" pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a>
+          <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com">Primary</a></pfe-cta>
+          <pfe-cta pfe-priority="secondary"><a href="https://www.redhat.com">Secondary</a>
           </pfe-cta>
-          <pfe-cta name="pfe-card--footer" pfe-priority="secondary" pfe-variant="wind"><a
+          <pfe-cta pfe-priority="secondary" pfe-variant="wind"><a
               href="https://www.redhat.com">Secondary + wind</a>
           </pfe-cta>
-          <pfe-cta name="pfe-card--footer" aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a>
+          <pfe-cta aria-disabled="true"><a href="https://www.redhat.com" disabled>Disabled</a>
           </pfe-cta>
 
       </pfe-card>

--- a/elements/pfe-cta/src/pfe-cta.html
+++ b/elements/pfe-cta/src/pfe-cta.html
@@ -1,5 +1,5 @@
 <span class="pfe-cta--wrapper">
-  <slot></slot>${this.defaultStyle ? `<svg
+  <slot></slot>${this.defaultStyle ? `&#160;<svg
     class="pfe-cta--arrow"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 31.56 31.56"

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -142,7 +142,7 @@ $variables: (
       height: 100%;
     }
     // Default CTA arrow wrap fix for Firefox
-    :host( :not([pfe-priority]):not([aria-disabled="true"])) & {
+    :host(:not([pfe-priority]):not([aria-disabled="true"])) & {
       @include browser-query(firefox) {
         max-width: calc(100% - 8px - #{pfe-local($cssvar: size, $region: arrow)});
       }

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -144,7 +144,7 @@ $variables: (
     // Default CTA arrow wrap fix for Firefox
     :host(:not([pfe-priority]):not([aria-disabled="true"])) & {
       @include browser-query(firefox) {
-        max-width: calc(100% - 8px - #{pfe-local($cssvar: size, $region: arrow)});
+        max-width: calc(100% - 1ch - #{pfe-local($cssvar: size, $region: arrow)});
       }
     }
     @include browser-query(edge) {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -129,15 +129,6 @@ $variables: (
   cursor: default !important;
 }
 
-// Default CTA fix for Firefox + arrow
-:host( :not([pfe-priority]):not([aria-disabled="true"]) ) {
-  .pfe-cta--wrapper {
-    @include browser-query(firefox) {
-      max-width: calc(100% - 8px - #{pfe-local($cssvar: size, $region: arrow)});
-    }
-  }
-}
-
 .pfe-cta {
   &--wrapper {
     display: block; 
@@ -150,7 +141,12 @@ $variables: (
       align-items: center;
       height: 100%;
     }
-
+    // Default CTA arrow wrap fix for Firefox
+    :host( :not([pfe-priority]):not([aria-disabled="true"])) & {
+      @include browser-query(firefox) {
+        max-width: calc(100% - 8px - #{pfe-local($cssvar: size, $region: arrow)});
+      }
+    }
     @include browser-query(edge) {
       button,
       input {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -2,7 +2,7 @@
 
 $LOCAL: cta;
 
-$pfe-cta__arrow-size: 0.313em;
+ 
 $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
 
@@ -94,9 +94,8 @@ $variables: (
 }
 
 ::slotted(*) {
-  white-space: normal;
-  display: inline;
-
+  white-space: normal; 
+  display: inline; 
   padding: #{pfe-local($cssvar: Padding)} !important;
   color: #{pfe-local(Color, $pfe-cta--Color--fallback)} !important;
   font-family: #{pfe-local(
@@ -130,8 +129,18 @@ $variables: (
   cursor: default !important;
 }
 
+// Default CTA fix for Firefox + arrow
+:host( :not([pfe-priority]):not([aria-disabled="true"]) ) {
+  .pfe-cta--wrapper {
+    @include browser-query(firefox) {
+      max-width: calc(100% - 8px - #{pfe-local($cssvar: size, $region: arrow)});
+    }
+  }
+}
+
 .pfe-cta {
   &--wrapper {
+    display: block; 
     white-space: nowrap;
 
     :host([pfe-priority]) &,

--- a/elements/pfe-sass/mixins/_mixins.scss
+++ b/elements/pfe-sass/mixins/_mixins.scss
@@ -1,20 +1,22 @@
 @mixin browser-query($browser-list) {
   @each $browser in $browser-list {
-
     @if $browser == ie11 {
       @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) { /* IE10+ */
         @content;
       }
     }
-
     @if $browser == edge12 {
       @supports (-ms-accelerator: true) { /* Microsoft Edge Browser 12+ */
         @content;
+      }
     }
-  }
-
     @if $browser == edge {
       @supports (-ms-ime-align: auto) { /* Microsoft Edge Browser 16+ (All) */
+        @content;
+      }
+    }
+    @if $browser==firefox {
+      @media all and (min--moz-device-pixel-ratio:0) { /* Mozilla Firefox (All) */
         @content;
       }
     }

--- a/elements/pfe-sass/mixins/_mixins.scss
+++ b/elements/pfe-sass/mixins/_mixins.scss
@@ -15,7 +15,7 @@
         @content;
       }
     }
-    @if $browser==firefox {
+    @if $browser == firefox {
       @media all and (min--moz-device-pixel-ratio:0) { /* Mozilla Firefox (All) */
         @content;
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,197 +1,106 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes"
-    />
-    <title>PatternFly Elements</title>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+        <title>PatternFly Elements</title>
+        
+        <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-base.css" />
+        <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-layouts.css" />
 
-    <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-base.css" />
-    <link
-      rel="stylesheet"
-      href="../../elements/pfe-styles/dist/pfe-layouts.css"
-    />
+        <noscript>
+            <link href="../../elements/pfelement/dist/pfelement--noscript.min.css" rel="stylesheet">
+        </noscript>
 
-    <noscript>
-      <link
-        href="../../elements/pfelement/dist/pfelement--noscript.min.css"
-        rel="stylesheet"
-      />
-    </noscript>
+        <link href="../../elements/pfelement/dist/pfelement.min.css" rel="stylesheet">
 
-    <link
-      href="../../elements/pfelement/dist/pfelement.min.css"
-      rel="stylesheet"
-    />
+        <!-- uncomment the es5-adapter if you're using the umd version -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 
-    <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script>require([
+            '../../elements/pfe-band/dist/pfe-band.umd.min.js',
+            '../../elements/pfe-cta/dist/pfe-cta.umd.min.js',
+            '../../elements/pfe-markdown/dist/pfe-markdown.umd.min.js'
+        ])</script>
+        <style>
+            #demos pfe-cta {
+                max-width: 100%;
+                text-align: center;
+            }
+            #demos pfe-cta a {
+                width: 100%;
+            }
+            table tr th, table tr td {
+                padding: 3px 10px;
+                border: 1px solid gray;
+            }
+            table + h3 {
+                margin-top: 50px;
+            }
+        </style>
+    </head>
+    <body>
+        <pfe-band pfe-color="lightest">
+            <h1>Demo pages</h1>
 
-    <script>
-      require([
-        "../../elements/pfe-band/dist/pfe-band.umd.min.js",
-        "../../elements/pfe-cta/dist/pfe-cta.umd.min.js",
-        "../../elements/pfe-markdown/dist/pfe-markdown.umd.min.js"
-      ]);
-    </script>
-    <style>
-      #demos pfe-cta {
-        max-width: 100%;
-        text-align: center;
-      }
-      #demos pfe-cta a {
-        width: 100%;
-      }
-      table tr th,
-      table tr td {
-        padding: 3px 10px;
-        border: 1px solid gray;
-      }
-      table + h3 {
-        margin-top: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <pfe-band pfe-color="lightest">
-      <h1>Demo pages</h1>
+            <div id="demos" class="pfe-l-grid pfe-l-grid-fill-height pfe-m-gutters pfe-m-all-2-col">
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-accordion/demo">pfe-accordion</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-autocomplete/demo">pfe-autocomplete</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-avatar/demo">pfe-avatar</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-badge/demo">pfe-badge</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-band/demo">pfe-band</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-card/demo">pfe-card</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-collapse/demo">pfe-collapse</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-content-set/demo">pfe-content-set</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-health-index/demo">pfe-health-index</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-markdown/demo">pfe-markdown</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-modal/demo">pfe-modal</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-navigation/demo">pfe-navigation</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-number/demo">pfe-number</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-page-status/demo">pfe-page-status</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-progress-indicator/demo">pfe-progress-indicator</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-select/demo">pfe-select</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-styles/demo">pfe-styles</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-tabs/demo">pfe-tabs</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-toast/demo">pfe-toast</a></pfe-cta>
+			</div>
+        </pfe-band>
 
-      <div
-        id="demos"
-        class="pfe-l-grid pfe-l-grid-fill-height pfe-m-gutters pfe-m-all-2-col"
-      >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-accordion/demo">pfe-accordion</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-autocomplete/demo"
-            >pfe-autocomplete</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-avatar/demo">pfe-avatar</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-badge/demo">pfe-badge</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-band/demo">pfe-band</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-card/demo">pfe-card</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-collapse/demo">pfe-collapse</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-content-set/demo"
-            >pfe-content-set</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-health-index/demo"
-            >pfe-health-index</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-markdown/demo">pfe-markdown</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-modal/demo">pfe-modal</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-navigation/demo">pfe-navigation</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-number/demo">pfe-number</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-page-status/demo"
-            >pfe-page-status</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-progress-indicator/demo"
-            >pfe-progress-indicator</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-select/demo">pfe-select</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-styles/demo">pfe-styles</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-tabs/demo">pfe-tabs</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-toast/demo">pfe-toast</a></pfe-cta
-        >
-      </div>
-    </pfe-band>
+        <pfe-band>
+            <pfe-markdown>
+                <div pfe-markdown-container>### POLYFILLs
+| Filename | line # | POLYFILL
+|:------|:------:|:------
+| [pfe-accordion](../elements/pfe-accordion/src/polyfills--pfe-accordion.js#L1) | 1 | Array.prototype.findIndex
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L1) | 1 | Element.matches
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L9) | 9 | Element.closest
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L22) | 22 | Array.includes
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L1) | 1 | Element.matches
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L9) | 9 | Element.closest
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L22) | 22 | Array.includes
+| [pfe-modal](../elements/pfe-modal/src/polyfills--pfe-modal.js#L1) | 1 | String.prototype.startsWith
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L1) | 1 | Array.prototype.filter
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L43) | 43 | Element.prototype.matches
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L51) | 51 | Element.prototype.closest
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L65) | 65 | Array.prototype.includes
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L123) | 123 | Event.prototype.path
+| [pfe-number](../elements/pfe-number/src/polyfills--pfe-number.js#L1) | 1 | isNaN, non-mutating polyfill for IE11
+| [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L1) | 1 | Array.prototype.find
+| [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L49) | 49 | Array.prototype.findIndex
 
-    <pfe-band>
-      <pfe-markdown>
-        <div pfe-markdown-container>
-          ### POLYFILLs | Filename | line # | POLYFILL |:------|:------:|:------
-          |
-          [pfe-accordion](../elements/pfe-accordion/src/polyfills--pfe-accordion.js#L1)
-          | 1 | Array.prototype.findIndex |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L1) | 1 |
-          Element.matches |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L9) | 9 |
-          Element.closest |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L22) | 22 |
-          Array.includes |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L1) | 1 |
-          Element.matches |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L9) | 9 |
-          Element.closest |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L22) | 22 |
-          Array.includes |
-          [pfe-modal](../elements/pfe-modal/src/polyfills--pfe-modal.js#L1) | 1
-          | String.prototype.startsWith |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L1)
-          | 1 | Array.prototype.filter |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L43)
-          | 43 | Element.prototype.matches |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L51)
-          | 51 | Element.prototype.closest |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L65)
-          | 65 | Array.prototype.includes |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L123)
-          | 123 | Event.prototype.path |
-          [pfe-number](../elements/pfe-number/src/polyfills--pfe-number.js#L1) |
-          1 | isNaN, non-mutating polyfill for IE11 |
-          [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L1) | 1 |
-          Array.prototype.find |
-          [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L49) | 49 |
-          Array.prototype.findIndex ### TODOs | Filename | line # | TODO
-          |:------|:------:|:------ |
-          [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49
-          | when we stop supporting IE11, the need to disconnect and |
-          [pfelement](../elements/pfelement/src/pfelement.js#L161) | 161 | maybe
-          we should use just the attribute instead of the class? |
-          [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This
-          is a duplicate function to cssVariable above, combine them
-        </div>
-      </pfe-markdown>
-    </pfe-band>
-  </body>
+### TODOs
+| Filename | line # | TODO
+|:------|:------:|:------
+| [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
+| [pfelement](../elements/pfelement/src/pfelement.js#L161) | 161 | maybe we should use just the attribute instead of the class?
+| [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>
+            </pfe-markdown>
+        </pfe-band>
+    </body>
 </html>


### PR DESCRIPTION
[Resolves Issue #679](https://github.com/patternfly/patternfly-elements/issues/679)

* Link(s) to demo pages where this element can be viewed:
https://deploy-preview-765--happy-galileo-ea79c4.netlify.com//elements/pfe-cta/demo/

---

### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* Used nobreak space in the template + white-space:nowrap to force the arrow to stick to the last word in the CTA. Then reset the white-space on the link inside the CTA. Firefox understands the box model differently, so there is a browser specific style to limit the width of the CTA so the arrow does not get cut off.

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

Use the resize box on the pfe-cta demo page (halfway down) to test in various browsers. 
    - The arrow should always be on the same line as the last word in the cta
    - The arrow should stay next to the last word, and not float to the edge of the CTA area

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [x] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Galaxy S9 Firefox
- [x] iPhone X Safari
- [x] iPad Pro Safari
- [x] Pixel 3 Chrome


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [x] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?
 
