### PR TITLE
fix: pfe-navigation cta overlap bug

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,7 +2,8 @@
 
 Tag: [v1.0.0-prerelease.40](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.40)
 
-- [ ]( ) fix: Prevent default pfe-cta arrow from wrapping to a new line by itself (#679)
+- [7deb9bb](https://github.com/patternfly/patternfly-elements/commit/7deb9bb6227c0560b60a665ecd43b450db0f90e1) fix: Prevent default pfe-cta arrow from wrapping to a new line by itself (#679)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-navigation cta overlap bug in IE11 (#766)
 
 
 ## Prerelease 39 ( 2020-02-19 )

--- a/docs/content/develop/step-2a.md
+++ b/docs/content/develop/step-2a.md
@@ -15,7 +15,7 @@ npm run live-demo
 ```
 
 If you prefer to only watch specific component (this can be quicker), you'll need two terminal processes, start the watch process with:
-``shell
+```shell
 # Replace pfe-cool-element with your component's name
 npm run dev pfe-cool-element
 ```

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -166,6 +166,12 @@ $variables: map-merge($variables, $nav-light-dom-variables);
     pfe-navigation [slot="logo"] {
         max-width: 100%;
     }
+    .pfe-navigation--footer .pfe-navigation--column {
+        @media (min-width: #{pfe-breakpoint(md)}) {
+            display: flex;
+            align-items: center;
+        }
+    }
 }
 
 @include browser-query(edge) {
@@ -269,6 +275,12 @@ $variables: map-merge($variables, $nav-light-dom-variables);
     }
     .pfe-navigation__logo {
         margin-right: 20px; // Account for collapsed padding-right: 20px;
+    }
+    .pfe-navigation--footer .pfe-navigation--column {
+        @media (min-width: #{pfe-breakpoint(md)}) {
+            display: flex;
+            align-items: center;
+        }
     }
 }
 
@@ -446,20 +458,6 @@ pfe-navigation-item {
             display: -ms-grid;
             grid-template-columns: repeat(4, 1fr);
             -ms-grid-columns: 1fr 1fr 1fr 1fr;
-            align-items: center;
-        }
-    }
-    &--column {
-        @media (min-width: #{pfe-breakpoint(md)}) {
-            @include browser-query(ie11) {
-                display: flex;
-                align-items: center;
-            }
-        }
-        @media (min-width: #{pfe-breakpoint(lg)}) {
-            @include browser-query(ie11) {
-                display: block;
-            }
         }
     }
 }

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -380,9 +380,9 @@ pfe-navigation-item {
         }
     }
     &--footer:not(:empty) {
-        margin:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 10px !important;
+        margin:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 0;
         border-top: 1px solid lightgray;
-        padding:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 0;
+        padding:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2.5) 0 calc(#{pfe-var(container-spacer, $fallback: 16px)} * 1.5);
 
         >*:not(:last-child) {
             margin-bottom: 32px;

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -389,13 +389,14 @@ pfe-navigation-item {
         }
 
         >* {
-            flex: 45%;
+            flex: 0 1 45%;
         }
 
         @media (min-width: #{pfe-breakpoint(sm)}) {
             display: flex;
             flex-wrap: wrap;
-            align-items: baseline;
+            align-items: center;
+            justify-content: space-between;
 
             >*:not(:last-child) {
                 margin-bottom: 0;
@@ -406,24 +407,21 @@ pfe-navigation-item {
             }
         }
 
+        @media (min-width: #{pfe-breakpoint(md)}) {
+            justify-content: flex-start;
+        }
+
         @media (min-width: #{pfe-breakpoint(lg)}) {
             // Not setting grid prefix here since IE doesn't support auto-flow
             display: grid;
             grid-gap: 32px;
             grid-auto-flow: column;
+            -ms-grid-columns: 1fr 1fr 1fr;
+            -ms-grid-rows: 1fr 1fr;
 
             >*:nth-child(3) {
                 margin-top: 0;
             }
-        }
-
-        @media (min-width: #{pfe-breakpoint(xl)}) {
-            padding-bottom: 0;
-            display: -ms-grid;
-            grid-template-columns: repeat(4, 1fr);
-            -ms-grid-columns: 1fr 1fr 1fr 1fr;
-            align-items: center;
-
             .pfe-navigation--column:nth-child(1) {
                 -ms-grid-column: 1;
             }
@@ -437,7 +435,24 @@ pfe-navigation-item {
             }
 
             .pfe-navigation--column:nth-child(4) {
-                -ms-grid-column: 4;
+                -ms-grid-column: 1;
+                -ms-grid-row: 2;
+            }
+        }
+
+        @media (min-width: #{pfe-breakpoint(xl)}) {
+            padding-bottom: 0;
+            display: -ms-grid;
+            grid-template-columns: repeat(4, 1fr);
+            -ms-grid-columns: 1fr 1fr 1fr 1fr;
+            align-items: center;
+        }
+    }
+    &--column {
+        @media (min-width: #{pfe-breakpoint(md)}) {
+            @include browser-query(ie11) {
+                display: flex;
+                align-items: center;
             }
         }
     }

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -402,7 +402,8 @@ pfe-navigation-item {
                 margin-bottom: 0;
             }
 
-            >*:nth-child(3) {
+            >*:nth-child(3),
+            >*:nth-child(4) {
                 margin-top: 32px;
             }
         }
@@ -416,12 +417,8 @@ pfe-navigation-item {
             display: grid;
             grid-gap: 32px;
             grid-auto-flow: column;
-            -ms-grid-columns: 1fr 1fr 1fr;
-            -ms-grid-rows: 1fr 1fr;
+            -ms-grid-columns: 1fr 1fr 1fr 1fr;
 
-            >*:nth-child(3) {
-                margin-top: 0;
-            }
             .pfe-navigation--column:nth-child(1) {
                 -ms-grid-column: 1;
             }
@@ -435,8 +432,12 @@ pfe-navigation-item {
             }
 
             .pfe-navigation--column:nth-child(4) {
-                -ms-grid-column: 1;
-                -ms-grid-row: 2;
+                -ms-grid-column: 4;
+            }               
+
+            >*:nth-child(3),
+            >*:nth-child(4) {
+                margin-top: 0;
             }
         }
 
@@ -453,6 +454,11 @@ pfe-navigation-item {
             @include browser-query(ie11) {
                 display: flex;
                 align-items: center;
+            }
+        }
+        @media (min-width: #{pfe-breakpoint(lg)}) {
+            @include browser-query(ie11) {
+                display: block;
             }
         }
     }

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -380,9 +380,9 @@ pfe-navigation-item {
         }
     }
     &--footer:not(:empty) {
-        margin:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2) 0 0;
+        margin:   calc(#{pfe-var(container-padding, $fallback: 16px)} * 2) 0 calc(#{pfe-var(container-padding, $fallback: 16px)} * 1.5);
         border-top: 1px solid lightgray;
-        padding:   calc(#{pfe-var(container-spacer, $fallback: 16px)} * 2.5) 0 calc(#{pfe-var(container-spacer, $fallback: 16px)} * 1.5);
+        padding:   calc(#{pfe-var(container-padding, $fallback: 16px)} * 2.5) 0 0;
 
         >*:not(:last-child) {
             margin-bottom: 32px;


### PR DESCRIPTION
##  Fix: pfe-navigation CTA overlap bug in IE11 and spacing between CTAs 

* Link(s) to demo pages where this element can be viewed: https://web-dev-drupal-anbartle.dev.a1.vary.redhat.com/de

---

### What has changed and why
* Set ms grid rows and grid columns for items in the footer tray. 
* In mobile displays set `space-between: justify-content` so that CTAs with longer text do not butt up against each other.
* Vertically centered CTAs in footer tray.
* Updated space above and below the CTAs in the tray footer to be ~40px.

#### Browser requirements
Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Galaxy S9 Firefox
- [ ] iPhone X Safari
- [ ] iPad Pro Safari
- [ ] Pixel 3 Chrome

Your repository infrastructure updates should work for at least:
- [ ] Node v8.x
- [ ] NPM v7.x

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [x] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

