### PR TITLE
fix: Add clearing to the tabs using the clear-spacing mixin

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,9 @@
+## Prerelease 40 ( TBD )
+
+Tag: [v1.0.0-prerelease.40](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.40)
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Add margin clearing to tab headings in slots
+
 ## Prerelease 39 ( 2020-02-19 )
 
 Tag: [v1.0.0-prerelease.39](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.39)

--- a/elements/pfe-sass/mixins/_copy-mixins.scss
+++ b/elements/pfe-sass/mixins/_copy-mixins.scss
@@ -13,3 +13,31 @@
     text-decoration: underline;
     text-decoration-skip: ink;
 }
+
+/// ===========================================================================
+/// Print clear styles for slotted tags
+///
+/// Returns slotted tags with clear properties to counteract standard browser, bootstrap, or normalize styles
+///
+/// @param {List} $properties [(margin, padding)] - 
+/// @param {List} $tags [(p, h1, h2, h3, h4, h5, h6)]- 
+/// @param {Boolean} $important [false] - 
+/// @param {String} $selector [null] - 
+/// @use -
+///     ```
+///     :host {
+///         @include pfe-clear-spacing($properties: margin-bottom, $important: true);
+///     }
+///     ```
+/// ===========================================================================
+@mixin pfe-clear-spacing($properties: (margin, padding), $tags: (p, h1, h2, h3, h4, h5, h6), $important: false, $selector: null) {
+    // Iterate over provided html tags, attach selector if provided
+    @each $tag in $tags {
+        ::slotted(#{$tag}#{if($selector, unquote(":#{$selector}"), null)}) {
+            // Iterate over provided properties, default is margin and padding
+            @each $prop in $properties {
+                #{$prop}: 0#{if($important, unquote(" !important"), null)};
+            }
+        }
+    }
+}

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -47,6 +47,8 @@ $variables: (
   cursor: pointer;
   text-align: #{pfe-local($cssvar: TextAlign, $region: tab, $fallback: center)};
   
+  @include pfe-clear-spacing($properties: margin-bottom, $important: true);
+  
   ::slotted(*) {
     color: #{pfe-local(Color)} !important;
   }


### PR DESCRIPTION
### What has changed and why
Summarize files edited as part of this MR along with a brief description of what was changed/why.

* Added the clear-spacing mixin to the `copy-mixins`
* Apply clear-spacing mixin to `pfe-tab` to clear slotted content

### Testing instructions
Be sure to include detailed instructions on how your update can be tested by another developer.

1. Open the demo page
2. Add the following to the stylesheet:
  ```
  h2 { margin-bottom: 20px; }
  ```
3. Ensure that the heading level inside the component is zero-ing out this margin on the tabset.

#### Browser requirements
Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Galaxy S9 Firefox
- [ ] iPhone X Safari
- [ ] iPad Pro Safari
- [ ] Pixel 3 Chrome

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Did browser testing pass?
- [x] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

