### PR TITLE
feat: pfe-tabs keep history on tab click and open tab based on url parameters

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,13 +3,14 @@
 Tag: [v1.0.0-prerelease.41](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.41)
 
 - [](https://github.com/patternfly/patternfly-elements/commit/) feat: Add events to the generator
+- [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-tabs keep history on tab click and open tab based on url parameters #786
 
 ## Prerelease 40 ( 2020-03-10 )
 
 Tag: [v1.0.0-prerelease.40](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.40)
 
 - [d0c2a45](https://github.com/patternfly/patternfly-elements/commit/d0c2a4526ec3fc15339bd4ec393364486a260c84) fix: pfe-navigation cta overlap bug in IE11 (#766)
-- [eb4a9f6](https://github.com/patternfly/patternfly-elements/commit/eb4a9f63514ad9635d1b195e89d596c3feaf2201) chore: Prettier updates (#770) 
+- [eb4a9f6](https://github.com/patternfly/patternfly-elements/commit/eb4a9f63514ad9635d1b195e89d596c3feaf2201) chore: Prettier updates (#770)
 - [7deb9bb](https://github.com/patternfly/patternfly-elements/commit/7deb9bb6227c0560b60a665ecd43b450db0f90e1) fix: Prevent default pfe-cta arrow from wrapping to a new line by itself #679 (#765)
 - [ba9d8b2](https://github.com/patternfly/patternfly-elements/commit/ba9d8b2cfed50580671041778d3d00cb5d5741d1) chore: Fixed invalid Markdown, was missing a back tic (#762)
 

--- a/elements/pfe-tabs/README.md
+++ b/elements/pfe-tabs/README.md
@@ -68,6 +68,62 @@ Changes the context of the call-to-action to one of 3 possible themes:
 
 This will override any context being passed from a parent component and will add a style attribute setting the `--theme` variable.
 
+**`pfe-tab-history`** (observed)
+
+Updates window.history and the URL to create sharable links. With the
+`pfe-tab-history` attribute, the tabs and each tab *must* have an `id`.
+
+The URL pattern will be `?{id-of-tabs}={id-of-selected-tab}`. In the example
+below, selecting "Tab 2" will update the URL as follows: `?my-tabs=tab2`.
+
+```html
+<pfe-tabs pfe-tab-history id="my-tabs">
+  <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
+  <pfe-tab-panel role="region" slot="panel">
+    <h2>Content 1</h2>
+    <p>Tab 1 panel content.</p>
+  </pfe-tab-panel>
+  <pfe-tab role="heading" slot="tab" id="tab2">Tab 2</pfe-tab>
+  <pfe-tab-panel role="region" slot="panel">
+    <h2>Content 2</h2>
+    <p>Tab 2 panel content.</p>
+  </pfe-tab-panel>
+</pfe-tabs>
+```
+
+*Note:* This feature is not supported in IE11.
+
+## Using the URL to open a specific tab
+
+By default, `pfe-tabs` will read the URL and look for a query string parameter
+that matches the id of a `pfe-tabs` component and a value of a specific
+`pfe-tab`.
+
+For example, `?my-tabs=tab2` would open the second tab in the code sample below.
+"my-tabs" is equal to the id of the `pfe-tabs` component and "tab2" is equal to
+the id of the second tab in the tab set.
+
+```html
+<pfe-tabs id="my-tabs">
+  <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
+  <pfe-tab-panel role="region" slot="panel">
+    <h2>Content 1</h2>
+    <p>Tab 1 panel content.</p>
+  </pfe-tab-panel>
+  <pfe-tab role="heading" slot="tab" id="tab2">Tab 2</pfe-tab>
+  <pfe-tab-panel role="region" slot="panel">
+    <h2>Content 2</h2>
+    <p>Tab 2 panel content.</p>
+  </pfe-tab-panel>
+</pfe-tabs>
+```
+
+In the event that a tab with the supplied id in the URL does not exist,
+`pfe-tabs` will fall back to the `selected-index` attribute if one is supplied
+in the markup, or the first tab if `selected-index` is not provided.
+
+*Note:* This feature is not supported in IE11.
+
 ## Events
 
 ### pfe-tabs:shown-tab

--- a/elements/pfe-tabs/README.md
+++ b/elements/pfe-tabs/README.md
@@ -73,8 +73,8 @@ This will override any context being passed from a parent component and will add
 Updates window.history and the URL to create sharable links. With the
 `pfe-tab-history` attribute, the tabs and each tab *must* have an `id`.
 
-The URL pattern will be `?{id-of-tabs}={id-of-selected-tab}`. In the example
-below, selecting "Tab 2" will update the URL as follows: `?my-tabs=tab2`.
+The URL pattern will be `?pfe-{id-of-tabs}={id-of-selected-tab}`. In the example
+below, selecting "Tab 2" will update the URL as follows: `?pfe-my-tabs=tab2`.
 
 ```html
 <pfe-tabs pfe-tab-history id="my-tabs">
@@ -99,7 +99,7 @@ By default, `pfe-tabs` will read the URL and look for a query string parameter
 that matches the id of a `pfe-tabs` component and a value of a specific
 `pfe-tab`.
 
-For example, `?my-tabs=tab2` would open the second tab in the code sample below.
+For example, `?pfe-my-tabs=tab2` would open the second tab in the code sample below.
 "my-tabs" is equal to the id of the `pfe-tabs` component and "tab2" is equal to
 the id of the second tab in the tab set.
 

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -296,7 +296,7 @@
 
     <section class="example">
 
-      <h2>Tab History</h2>
+      <h2 id="tab-history">Tab History</h2>
       <pfe-tabs id="my-tabs" pfe-tab-history>
         <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
         <pfe-tab-panel role="region" slot="panel">

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -67,7 +67,7 @@
       <h1></h1>
 
       <h2>Style: Horizontal plain</h2>
-      <pfe-tabs id="tabsetOne">
+      <pfe-tabs>
           <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
@@ -88,9 +88,8 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
       </pfe-tabs>
-    </section>
 
-      <!-- <h2>Style: Horizontal wind with center alignment</h2>
+      <h2>Style: Horizontal wind with center alignment</h2>
       <pfe-tabs pfe-tab-align="center" pfe-variant="wind">
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
@@ -275,7 +274,7 @@
         <pfe-tab-panel role="region" slot="panel">
           <h2>Content 1</h2>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-          <a href="https://kristyandkyle.com">https://kristyandkyle.com</a>
+          <a href="https://redhat.com">https://redhat.com</a>
         </pfe-tab-panel>
         <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
         <pfe-tab-panel role="region" slot="panel">
@@ -284,6 +283,34 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
         <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel">
+          <h2>Content 3</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </pfe-tab-panel>
+      </pfe-tabs>
+
+    </section>
+
+    <section class="example">
+
+      <h2>Tab History</h2>
+      <pfe-tabs id="my-tabs" pfe-tab-history>
+        <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel">
+          <h2>Content 1</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <a href="https://redhat.com">https://redhat.com</a>
+        </pfe-tab-panel>
+        <pfe-tab role="heading" slot="tab" id="tab2">Tab 2</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel">
+          <h2>Content 2</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </pfe-tab-panel>
+        <pfe-tab role="heading" slot="tab" id="tab3">Tab 3</pfe-tab>
         <pfe-tab-panel role="region" slot="panel">
           <h2>Content 3</h2>
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -312,9 +339,9 @@
       </pfe-tabs>
       <button id="addTabAndPanelBtn">Add a Tab and Tab Panel</button>
 
-    </section> -->
+    </section>
 
-    <!-- <script>
+    <script>
       var btn = document.querySelector("#addTabAndPanelBtn");
       var pfeTabs = document.querySelector("#dynamic");
 
@@ -335,6 +362,6 @@
         fragment.appendChild(panel);
         pfeTabs.appendChild(fragment);
       });
-    </script> -->
+    </script>
   </body>
 </html>

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/typebase.css/0.5.0/typebase.css">
     -->
-    
+
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />
     <link rel="stylesheet" href="../../pfe-styles/dist/pfe-layouts.css" />
@@ -61,23 +61,25 @@
   </head>
   <body unresolved>
     <h1>&lt;pfe-tabs&gt;</h1>
-    
+
     <section class="example">
-      
+
+      <h1></h1>
+
       <h2>Style: Horizontal plain</h2>
-      <pfe-tabs>
-          <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
+      <pfe-tabs id="tabsetOne">
+          <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab" id="tab2">Tab 2</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
+          <pfe-tab role="heading" slot="tab" id="tab3">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -86,8 +88,9 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
       </pfe-tabs>
+    </section>
 
-      <h2>Style: Horizontal wind with center alignment</h2>
+      <!-- <h2>Style: Horizontal wind with center alignment</h2>
       <pfe-tabs pfe-tab-align="center" pfe-variant="wind">
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
@@ -109,11 +112,11 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
       </pfe-tabs>
-      
+
     </section>
-    
+
     <section class="example">
-      
+
       <h2>Style: Horizontal earth</h2>
       <pfe-tabs pfe-variant="earth">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -136,11 +139,11 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
       </pfe-tabs>
-      
+
     </section>
-    
+
     <section class="example">
-      
+
       <h2>Style: Vertical wind</h2>
       <pfe-tabs vertical pfe-variant="wind">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -163,11 +166,11 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
       </pfe-tabs>
-      
+
     </section>
-    
+
     <section class="example">
-      
+
       <h2>Style: Vertical earth </h2>
       <pfe-tabs vertical pfe-variant="earth" pfe-tab-align="center" >
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -191,9 +194,9 @@
         </pfe-tab-panel>
       </pfe-tabs>
     </section>
-    
+
     <section class="example" style="background-color: #000;">
-      
+
       <h2 style="color: #fff;">Style: Horizontal plain (on dark background)</h2>
       <pfe-tabs  on="dark">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -216,7 +219,7 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
       </pfe-tabs>
-      
+
       <h2 style="color: #fff;">Style: Horizontal earth (on dark background)</h2>
       <pfe-tabs pfe-variant="earth" on="dark">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -239,7 +242,7 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
       </pfe-tabs>
-      
+
       <h2 style="color: #fff;">Style: Horizontal wind (on dark background)</h2>
       <pfe-tabs pfe-variant="wind" on="dark">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -263,9 +266,9 @@
         </pfe-tab-panel>
       </pfe-tabs>
     </section>
-    
+
     <section class="example">
-      
+
       <h2>Selected Index</h2>
       <pfe-tabs pfe-variant="earth" selected-index="1">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -289,11 +292,11 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </pfe-tab-panel>
       </pfe-tabs>
-      
+
     </section>
-    
+
     <section class="example">
-      
+
       <h2>Dynamically Adding a Tab and Tab Panel</h2>
       <pfe-tabs id="dynamic">
         <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
@@ -308,10 +311,10 @@
         </pfe-tab-panel>
       </pfe-tabs>
       <button id="addTabAndPanelBtn">Add a Tab and Tab Panel</button>
-      
-    </section>
 
-    <script>
+    </section> -->
+
+    <!-- <script>
       var btn = document.querySelector("#addTabAndPanelBtn");
       var pfeTabs = document.querySelector("#dynamic");
 
@@ -332,6 +335,6 @@
         fragment.appendChild(panel);
         pfeTabs.appendChild(fragment);
       });
-    </script>
+    </script> -->
   </body>
 </html>

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -62,6 +62,24 @@ class PfeTabs extends PFElement {
     this._onClick = this._onClick.bind(this);
     this._linkPanels = this._linkPanels.bind(this);
     this._observer = new MutationObserver(this._init);
+
+    // window.addEventListener("popstate", e => {
+    //   let urlParams;
+    //
+    //   if (window.URLSearchParams) {
+    //     urlParams = new URLSearchParams(window.location.search);
+    //   }
+    //
+    //   if (urlParams && urlParams.has(this.id)) {
+    //     const tabIndex = this._allTabs().findIndex(
+    //       tab => tab.id === urlParams.get(this.id)
+    //     );
+    //
+    //     this.selectedIndex = tabIndex !== -1 ? tabIndex : 0;
+    //   } else if (!this.hasAttribute("selected-index")) {
+    //     this.selectedIndex = 0;
+    //   }
+    // });
   }
 
   connectedCallback() {
@@ -169,6 +187,14 @@ class PfeTabs extends PFElement {
       return;
     }
 
+    console.log("update the url");
+    // rebuild the url
+    const pathname = window.location.pathname;
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.set("tabsetOne", tab.id);
+    const hash = window.location.hash;
+    history.pushState({}, "", `${pathname}?${urlParams.toString()}${hash}`);
+
     this._selectTab(tab);
   }
 
@@ -177,7 +203,21 @@ class PfeTabs extends PFElement {
       this.setAttribute("role", "tablist");
     }
 
-    if (!this.hasAttribute("selected-index")) {
+    let urlParams;
+
+    // @IE11 doesn't support URLSearchParams
+    // https://caniuse.com/#search=urlsearchparams
+    if (window.URLSearchParams) {
+      urlParams = new URLSearchParams(window.location.search);
+    }
+
+    if (urlParams && urlParams.has(this.id)) {
+      const tabIndex = this._allTabs().findIndex(
+        tab => tab.id === urlParams.get(this.id)
+      );
+
+      this.selectedIndex = tabIndex !== -1 ? tabIndex : 0;
+    } else if (!this.hasAttribute("selected-index")) {
       this.selectedIndex = 0;
     }
 

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -12,6 +12,10 @@ const KEYCODE = {
   END: 35
 };
 
+// @IE11 doesn't support URLSearchParams
+// https://caniuse.com/#search=urlsearchparams
+const CAN_USE_URLSEARCHPARAMS = window.URLSearchParams ? true : false;
+
 function generateId() {
   return Math.random()
     .toString(36)
@@ -74,9 +78,6 @@ class PfeTabs extends PFElement {
     this._popstateEventHandler = this._popstateEventHandler.bind(this);
     this._observer = new MutationObserver(this._init);
     this._updateHistory = true;
-    // @IE11 doesn't support URLSearchParams
-    // https://caniuse.com/#search=urlsearchparams
-    this._canUseURLSearchParams = window.URLSearchParams ? true : false;
   }
 
   connectedCallback() {
@@ -203,14 +204,14 @@ class PfeTabs extends PFElement {
       this.selected &&
       this.tabHistory &&
       this._updateHistory &&
-      this._canUseURLSearchParams
+      CAN_USE_URLSEARCHPARAMS
     ) {
       // rebuild the url
       const pathname = window.location.pathname;
       const urlParams = new URLSearchParams(window.location.search);
       const hash = window.location.hash;
 
-      urlParams.set(this.id, tab.id);
+      urlParams.set(`pfe-${this.id}`, tab.id);
       history.pushState({}, "", `${pathname}?${urlParams.toString()}${hash}`);
     }
 
@@ -226,7 +227,7 @@ class PfeTabs extends PFElement {
 
     // @IE11 doesn't support URLSearchParams
     // https://caniuse.com/#search=urlsearchparams
-    if (this._canUseURLSearchParams) {
+    if (CAN_USE_URLSEARCHPARAMS) {
       urlParams = new URLSearchParams(window.location.search);
     }
 
@@ -438,13 +439,13 @@ class PfeTabs extends PFElement {
 
     // @IE11 doesn't support URLSearchParams
     // https://caniuse.com/#search=urlsearchparams
-    if (window.URLSearchParams) {
+    if (CAN_USE_URLSEARCHPARAMS) {
       urlParams = new URLSearchParams(window.location.search);
     }
 
-    if (urlParams && urlParams.has(this.id)) {
+    if (urlParams && urlParams.has(`pfe-${this.id}`)) {
       tabIndex = this._allTabs().findIndex(
-        tab => tab.id === urlParams.get(this.id)
+        tab => tab.id === urlParams.get(`pfe-${this.id}`)
       );
     }
 

--- a/elements/pfe-tabs/src/pfe-tabs.json
+++ b/elements/pfe-tabs/src/pfe-tabs.json
@@ -61,6 +61,12 @@
           "enum": ["light", "dark"],
           "default": "light",
           "prefixed": false
+        },
+        "tab-history": {
+          "title": "Tab history",
+          "type": "boolean",
+          "default": false,
+          "prefixed": true
         }
       }
     }

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -365,7 +365,7 @@
           // the parameter should be equal to the id of the tabset
           // the value should be equal to the id of the tab you want opened
           const searchParams = new URLSearchParams(window.location.search)
-          searchParams.set("fromQueryString", "fromQueryStringTab2");
+          searchParams.set("pfe-fromQueryString", "fromQueryStringTab2");
           var newPath = window.location.pathname + '?' + searchParams.toString();
           history.pushState(null, '', newPath);
 
@@ -393,7 +393,7 @@
 
         test("it should open the first tab if the querystring in the URL doesn't match the id of any of the tabs", done => {
           const searchParams = new URLSearchParams(window.location.search)
-          searchParams.set("fromQueryString", "iDontExist");
+          searchParams.set("pfe-fromQueryString", "iDontExist");
           var newPath = window.location.pathname + '?' + searchParams.toString();
           history.pushState(null, '', newPath);
 
@@ -427,7 +427,7 @@
 
           flush(() => {
             const urlSearchParams = new URLSearchParams(window.location.search);
-            assert.equal(urlSearchParams.get("history"), "historyTab2");
+            assert.equal(urlSearchParams.get("pfe-history"), "historyTab2");
             assert.equal(tabs.selectedIndex, 1);
             assert.isTrue(tab2.hasAttribute("aria-selected"));
             done();
@@ -444,7 +444,7 @@
 
           flush(() => {
             const urlSearchParams = new URLSearchParams(window.location.search);
-            assert.equal(urlSearchParams.get("history"), "historyTab2");
+            assert.equal(urlSearchParams.get("pfe-history"), "historyTab2");
             assert.equal(tabs.selectedIndex, 0);
             assert.isTrue(tab1.hasAttribute("aria-selected"));
             done();

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -111,6 +111,13 @@
       <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
       <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
     </pfe-tabs>
+
+    <pfe-tabs id="history" pfe-tab-history>
+      <pfe-tab role="heading" slot="tab" id="historyTab1">Tab 1</pfe-tab>
+      <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+      <pfe-tab role="heading" slot="tab" id="historyTab2">Tab 1</pfe-tab>
+      <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+    </pfe-tabs>
     <script>
       suite('<pfe-tabs>', () => {
         setup(() => {
@@ -350,6 +357,98 @@
 
           assert.equal(tab.getAttribute("pfe-variant"), "earth");
           assert.equal(panel.getAttribute("pfe-variant"), "earth");
+        });
+      });
+
+      suite('<pfe-tabs> Tab History', () => {
+        test("it should show the correct tab if there is a querystring parameter in the URL", done => {
+          // the parameter should be equal to the id of the tabset
+          // the value should be equal to the id of the tab you want opened
+          const searchParams = new URLSearchParams(window.location.search)
+          searchParams.set("fromQueryString", "fromQueryStringTab2");
+          var newPath = window.location.pathname + '?' + searchParams.toString();
+          history.pushState(null, '', newPath);
+
+          const fragment = document.createRange().createContextualFragment(`
+            <pfe-tabs id="fromQueryString">
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab1">Tab 1</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab2">Tab 2</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+            </pfe-tabs>
+          `);
+
+          document.body.appendChild(fragment);
+
+          flush(() => {
+            const tabs = document.querySelector("#fromQueryString");
+            const tab2 = tabs.querySelector("#fromQueryStringTab2");
+            assert.equal(tabs.selectedIndex, 1);
+            assert.isTrue(tab2.hasAttribute("aria-selected"));
+
+            document.body.removeChild(tabs);
+            done();
+          });
+        });
+
+        test("it should open the first tab if the querystring in the URL doesn't match the id of any of the tabs", done => {
+          const searchParams = new URLSearchParams(window.location.search)
+          searchParams.set("fromQueryString", "iDontExist");
+          var newPath = window.location.pathname + '?' + searchParams.toString();
+          history.pushState(null, '', newPath);
+
+          const fragment = document.createRange().createContextualFragment(`
+            <pfe-tabs id="fromQueryString">
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab1">Tab 1</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab2">Tab 2</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+            </pfe-tabs>
+          `);
+
+          document.body.appendChild(fragment);
+
+          flush(() => {
+            const tabs = document.querySelector("#fromQueryString");
+            const tab1 = tabs.querySelector("#fromQueryStringTab1");
+            assert.equal(tabs.selectedIndex, 0);
+            assert.isTrue(tab1.hasAttribute("aria-selected"));
+
+            document.body.removeChild(tabs);
+            done();
+          });
+        });
+
+        test("it should update the URL on tab selection if the pfe-tab-history attribute is present", done => {
+          const tabs = document.querySelector("#history");
+          const tab2 = tabs.querySelector("#historyTab2");
+
+          tab2.click();
+
+          flush(() => {
+            const urlSearchParams = new URLSearchParams(window.location.search);
+            assert.equal(urlSearchParams.get("history"), "historyTab2");
+            assert.equal(tabs.selectedIndex, 1);
+            assert.isTrue(tab2.hasAttribute("aria-selected"));
+            done();
+          });
+        });
+
+        test("it should stop updating the URL if the pfe-tab-history attribute is removed", done => {
+          // this test builds on the previous test
+          const tabs = document.querySelector("#history");
+          const tab1 = tabs.querySelector("#historyTab1");
+
+          tabs.removeAttribute("pfe-tab-history");
+          tab1.click();
+
+          flush(() => {
+            const urlSearchParams = new URLSearchParams(window.location.search);
+            assert.equal(urlSearchParams.get("history"), "historyTab2");
+            assert.equal(tabs.selectedIndex, 0);
+            assert.isTrue(tab1.hasAttribute("aria-selected"));
+            done();
+          });
         });
       });
     </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,197 +1,106 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes"
-    />
-    <title>PatternFly Elements</title>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+        <title>PatternFly Elements</title>
+        
+        <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-base.css" />
+        <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-layouts.css" />
 
-    <link rel="stylesheet" href="../../elements/pfe-styles/dist/pfe-base.css" />
-    <link
-      rel="stylesheet"
-      href="../../elements/pfe-styles/dist/pfe-layouts.css"
-    />
+        <noscript>
+            <link href="../../elements/pfelement/dist/pfelement--noscript.min.css" rel="stylesheet">
+        </noscript>
 
-    <noscript>
-      <link
-        href="../../elements/pfelement/dist/pfelement--noscript.min.css"
-        rel="stylesheet"
-      />
-    </noscript>
+        <link href="../../elements/pfelement/dist/pfelement.min.css" rel="stylesheet">
 
-    <link
-      href="../../elements/pfelement/dist/pfelement.min.css"
-      rel="stylesheet"
-    />
+        <!-- uncomment the es5-adapter if you're using the umd version -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
 
-    <!-- uncomment the es5-adapter if you're using the umd version -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+        <script>require([
+            '../../elements/pfe-band/dist/pfe-band.umd.min.js',
+            '../../elements/pfe-cta/dist/pfe-cta.umd.min.js',
+            '../../elements/pfe-markdown/dist/pfe-markdown.umd.min.js'
+        ])</script>
+        <style>
+            #demos pfe-cta {
+                max-width: 100%;
+                text-align: center;
+            }
+            #demos pfe-cta a {
+                width: 100%;
+            }
+            table tr th, table tr td {
+                padding: 3px 10px;
+                border: 1px solid gray;
+            }
+            table + h3 {
+                margin-top: 50px;
+            }
+        </style>
+    </head>
+    <body>
+        <pfe-band pfe-color="lightest">
+            <h1>Demo pages</h1>
 
-    <script>
-      require([
-        "../../elements/pfe-band/dist/pfe-band.umd.min.js",
-        "../../elements/pfe-cta/dist/pfe-cta.umd.min.js",
-        "../../elements/pfe-markdown/dist/pfe-markdown.umd.min.js"
-      ]);
-    </script>
-    <style>
-      #demos pfe-cta {
-        max-width: 100%;
-        text-align: center;
-      }
-      #demos pfe-cta a {
-        width: 100%;
-      }
-      table tr th,
-      table tr td {
-        padding: 3px 10px;
-        border: 1px solid gray;
-      }
-      table + h3 {
-        margin-top: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <pfe-band pfe-color="lightest">
-      <h1>Demo pages</h1>
+            <div id="demos" class="pfe-l-grid pfe-l-grid-fill-height pfe-m-gutters pfe-m-all-2-col">
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-accordion/demo">pfe-accordion</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-autocomplete/demo">pfe-autocomplete</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-avatar/demo">pfe-avatar</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-badge/demo">pfe-badge</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-band/demo">pfe-band</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-card/demo">pfe-card</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-collapse/demo">pfe-collapse</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-content-set/demo">pfe-content-set</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-health-index/demo">pfe-health-index</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-markdown/demo">pfe-markdown</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-modal/demo">pfe-modal</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-navigation/demo">pfe-navigation</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-number/demo">pfe-number</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-page-status/demo">pfe-page-status</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-progress-indicator/demo">pfe-progress-indicator</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-select/demo">pfe-select</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-styles/demo">pfe-styles</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-tabs/demo">pfe-tabs</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-toast/demo">pfe-toast</a></pfe-cta>
+			</div>
+        </pfe-band>
 
-      <div
-        id="demos"
-        class="pfe-l-grid pfe-l-grid-fill-height pfe-m-gutters pfe-m-all-2-col"
-      >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-accordion/demo">pfe-accordion</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-autocomplete/demo"
-            >pfe-autocomplete</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-avatar/demo">pfe-avatar</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-badge/demo">pfe-badge</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-band/demo">pfe-band</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-card/demo">pfe-card</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-collapse/demo">pfe-collapse</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-content-set/demo"
-            >pfe-content-set</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-health-index/demo"
-            >pfe-health-index</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-markdown/demo">pfe-markdown</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-modal/demo">pfe-modal</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-navigation/demo">pfe-navigation</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-number/demo">pfe-number</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-page-status/demo"
-            >pfe-page-status</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-progress-indicator/demo"
-            >pfe-progress-indicator</a
-          ></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-select/demo">pfe-select</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-styles/demo">pfe-styles</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-tabs/demo">pfe-tabs</a></pfe-cta
-        >
-        <pfe-cta pfe-priority="secondary" pfe-variant="wind"
-          ><a href="../elements/pfe-toast/demo">pfe-toast</a></pfe-cta
-        >
-      </div>
-    </pfe-band>
+        <pfe-band>
+            <pfe-markdown>
+                <div pfe-markdown-container>### POLYFILLs
+| Filename | line # | POLYFILL
+|:------|:------:|:------
+| [pfe-accordion](../elements/pfe-accordion/src/polyfills--pfe-accordion.js#L1) | 1 | Array.prototype.findIndex
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L1) | 1 | Element.matches
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L9) | 9 | Element.closest
+| [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L22) | 22 | Array.includes
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L1) | 1 | Element.matches
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L9) | 9 | Element.closest
+| [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L22) | 22 | Array.includes
+| [pfe-modal](../elements/pfe-modal/src/polyfills--pfe-modal.js#L1) | 1 | String.prototype.startsWith
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L1) | 1 | Array.prototype.filter
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L43) | 43 | Element.prototype.matches
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L51) | 51 | Element.prototype.closest
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L65) | 65 | Array.prototype.includes
+| [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L123) | 123 | Event.prototype.path
+| [pfe-number](../elements/pfe-number/src/polyfills--pfe-number.js#L1) | 1 | isNaN, non-mutating polyfill for IE11
+| [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L1) | 1 | Array.prototype.find
+| [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L49) | 49 | Array.prototype.findIndex
 
-    <pfe-band>
-      <pfe-markdown>
-        <div pfe-markdown-container>
-          ### POLYFILLs | Filename | line # | POLYFILL |:------|:------:|:------
-          |
-          [pfe-accordion](../elements/pfe-accordion/src/polyfills--pfe-accordion.js#L1)
-          | 1 | Array.prototype.findIndex |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L1) | 1 |
-          Element.matches |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L9) | 9 |
-          Element.closest |
-          [pfe-band](../elements/pfe-band/src/polyfills--pfe-band.js#L22) | 22 |
-          Array.includes |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L1) | 1 |
-          Element.matches |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L9) | 9 |
-          Element.closest |
-          [pfe-card](../elements/pfe-card/src/polyfills--pfe-card.js#L22) | 22 |
-          Array.includes |
-          [pfe-modal](../elements/pfe-modal/src/polyfills--pfe-modal.js#L1) | 1
-          | String.prototype.startsWith |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L1)
-          | 1 | Array.prototype.filter |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L43)
-          | 43 | Element.prototype.matches |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L51)
-          | 51 | Element.prototype.closest |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L65)
-          | 65 | Array.prototype.includes |
-          [pfe-navigation](../elements/pfe-navigation/src/polyfills--pfe-navigation.js#L123)
-          | 123 | Event.prototype.path |
-          [pfe-number](../elements/pfe-number/src/polyfills--pfe-number.js#L1) |
-          1 | isNaN, non-mutating polyfill for IE11 |
-          [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L1) | 1 |
-          Array.prototype.find |
-          [pfe-tabs](../elements/pfe-tabs/src/polyfills--pfe-tabs.js#L49) | 49 |
-          Array.prototype.findIndex ### TODOs | Filename | line # | TODO
-          |:------|:------:|:------ |
-          [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49
-          | when we stop supporting IE11, the need to disconnect and |
-          [pfelement](../elements/pfelement/src/pfelement.js#L161) | 161 | maybe
-          we should use just the attribute instead of the class? |
-          [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This
-          is a duplicate function to cssVariable above, combine them
-        </div>
-      </pfe-markdown>
-    </pfe-band>
-  </body>
+### TODOs
+| Filename | line # | TODO
+|:------|:------:|:------
+| [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
+| [pfelement](../elements/pfelement/src/pfelement.js#L161) | 161 | maybe we should use just the attribute instead of the class?
+| [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>
+            </pfe-markdown>
+        </pfe-band>
+    </body>
 </html>


### PR DESCRIPTION
Test by opening this demo page: http://localhost:8000/elements/pfe-tabs/demo/#tab-history

Click on each of the tabs and you should see the URL update with the id of the selected tab.

To test the feature where the correct tab opens on page load based on a query string parameter, open this page: http://localhost:8000/elements/pfe-tabs/demo/?my-tabs=tab3#tab-history. The third tab should be open on page load.

Fixes #562 