### PR TITLE
fix: set consistent line-height for pfe-nav triggers

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,8 +2,9 @@
 
 Tag: [v1.0.0-prerelease.41](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.41)
 
-- [](https://github.com/patternfly/patternfly-elements/commit/) feat: Add events to the generator
-- [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-health-index size="mini" version #789
+- [fdfd6fc](https://github.com/patternfly/patternfly-elements/commit/fdfd6fcb25cf01a8a107cb4947864e30da06d087) feat: Add events to the generator
+- [e2ba182](https://github.com/patternfly/patternfly-elements/commit/e2ba18204fb751f8dd434ceb18d6ccdbc05b4081) feat: pfe-health-index size="mini" version #789
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers  #790
 
 ## Prerelease 40 ( 2020-03-10 )
 

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,7 +2,7 @@
 
 Tag: [v1.0.0-prerelease.42](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.42)
 
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers  #790
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers (#773)
 
 
 ## Prerelease 41 ( 2020-03-19 )

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -301,6 +301,7 @@ pfe-navigation-item {
     [slot="trigger"] {
         font-family: #{pfe-var(font-family)};
         margin: .25em 0 0 0!important;
+        line-height: 1.3;
     }
     // Utility links.
     pfe-icon + [slot="trigger"] > a {


### PR DESCRIPTION
* Link to discovery documentation (should contain all the planning and requirements for this work):
   - See the `DISCOVERY.md` template at the root of the project
* Link(s) to demo pages where this element can be viewed:

---

### What has changed and why
As an SEO expert, I would like the ability to remove heading tags from the navigation, without styles changing. Currently rhdotcom relies on the h3 line-height to control the spacing between the icon and the text. 

*

### Testing instructions
When viewing the pfe-navigation in my browser, I should be able to change the tag that contains the `slot=trigger` to a div, p, h2, h1, and not see any difference in the space between the icon and the tag.

#### Browser requirements
Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Galaxy S9 Firefox
- [ ] iPhone X Safari
- [ ] iPad Pro Safari
- [ ] Pixel 3 Chrome


### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one feature request or issue (no stragglers)?
- [ ] Did browser testing pass?
- [ ] Did you update or add any necessary documentation (README.md, WHY.md, etc.)?
- [ ] Was this feature demo'd and the design review approved?
- [x] Did you update the CHANGELOG.md file with a summary of this update?


**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

