### PR TITLE
Us250350 pfe-cta wrapping issues

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -5,6 +5,7 @@ Tag: [v1.0.0-prerelease.41](https://github.com/patternfly/patternfly-elements/re
 - [](https://github.com/patternfly/patternfly-elements/commit/) feat: Add events to the generator
 - [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-tabs keep history on tab click and open tab based on url parameters #786
 - [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-health-index size="mini" version #789
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-cta text wrapping issues
 
 ## Prerelease 40 ( 2020-03-10 )
 

--- a/elements/pfe-cta/demo/demo.css
+++ b/elements/pfe-cta/demo/demo.css
@@ -18,12 +18,10 @@ pfe-band[pfe-color="lightest"] pfe-card[pfe-color="lightest"] {
 }
 
 .resize {
-  display: flex;
-  flex-flow: row nowrap;
   resize: horizontal;
   overflow: auto;
   border: 1px solid #ddd;
-  width: 500px;
+  width: 700px;
   padding: 10px;
 }
 

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -214,7 +214,7 @@
     <h3>Force wrap to test arrow line-wrap</h3>
     <div class="resize">
       <pfe-cta><a href="https://www.redhat.com">Default link cta with longer text</a></pfe-cta>
-      <pfe-cta><button>Default button cta with longer text</button></pfe-cta>
+      <pfe-cta><button>Default button cta: arrow won't wrap correctly</button></pfe-cta>
     </div>
 
     <br />

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -42,7 +42,6 @@ $variables: (
   display: inline-block;
   position: relative;
   z-index: 0;
-  max-width: max-content;
   vertical-align: middle;
   transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
 
@@ -109,6 +108,7 @@ $variables: (
       $fallback: #{pfe-var(line-height)}
     )};
   text-decoration: #{pfe-local(TextDecoration)} !important;
+  text-align: center;
 
   @include browser-query(ie11 edge) {
     padding: 0 !important;
@@ -133,6 +133,7 @@ $variables: (
   &--wrapper {
     display: block; 
     white-space: nowrap;
+    min-width: calc(100%);
 
     :host([pfe-priority]) &,
     :host([aria-disabled="true"]) & {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -108,7 +108,6 @@ $variables: (
       $fallback: #{pfe-var(line-height)}
     )};
   text-decoration: #{pfe-local(TextDecoration)} !important;
-  text-align: center;
 
   @include browser-query(ie11 edge) {
     padding: 0 !important;
@@ -117,6 +116,10 @@ $variables: (
   :host(:hover) & {
     color: #{pfe-local(Color--hover)} !important;
     text-decoration: #{pfe-local(TextDecoration--hover)} !important;
+  }
+
+  :host([pfe-priority]) & {
+    text-align: center;
   }
 }
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -136,7 +136,7 @@ $variables: (
   &--wrapper {
     display: block; 
     white-space: nowrap;
-    min-width: calc(100%);
+    min-width: 100%;
 
     :host([pfe-priority]) &,
     :host([aria-disabled="true"]) & {


### PR DESCRIPTION
1. Resolves issue where default pfe-ctas are wrapping when there is still enough room.  
![image](https://user-images.githubusercontent.com/456863/77004105-ef2ad900-6934-11ea-8252-abb009888a44.png)

2. Resolves issue where priority CTAs wrap to two lines and text is left aligned. It should be centered.

![image](https://user-images.githubusercontent.com/456863/77004982-63b24780-6936-11ea-8cee-9e6289f3282b.png)


Preview page with fixes:
https://deploy-preview-791--happy-galileo-ea79c4.netlify.com/elements/pfe-cta/demo/
