### PR TITLE
Add support for font family to select options

### DIFF
--- a/elements/pfe-select/src/pfe-select.scss
+++ b/elements/pfe-select/src/pfe-select.scss
@@ -17,8 +17,8 @@ $variables: (
   BorderLeft:                 #{pfe-local(BorderWidth) pfe-var(ui--border-style) pfe-local(BorderColor)},
   BorderRight:                #{pfe-local(BorderWidth) pfe-var(ui--border-style) pfe-local(BorderColor)},
   BorderBottom:               #{pfe-local(BorderBottomWidth) pfe-var(ui--border-style) pfe-local(BorderBottomColor)},
-  BorderBottom--hover:        #{pfe-local(BorderBottomWidth) pfe-var(ui--border-style) pfe-local(BorderBottomColor--hover)}
-
+  BorderBottom--hover:        #{pfe-local(BorderBottomWidth) pfe-var(ui--border-style) pfe-local(BorderBottomColor--hover)},
+  FontFamily:                 #{pfe-var(font-family)}
 );
 
 :host {
@@ -82,6 +82,7 @@ $variables: (
 
     font-size:    #{pfe-var(font-size)};
     font-weight:  #{pfe-var(font-weight--normal)};
+    font-family: #{pfe-local(FontFamily)};
 
     appearance: none;
     box-shadow: none;


### PR DESCRIPTION
Currently the pfe-select options use the system font:
![image](https://user-images.githubusercontent.com/456863/77109107-c02a6b00-69f9-11ea-9f53-80c7e98818c8.png)

![image](https://user-images.githubusercontent.com/456863/77109126-c4ef1f00-69f9-11ea-93e2-a47a5c2c0111.png)


This update adds the font-family variable to the `::slotted(select) {` selector. 

To test, go to the [demo page](https://deploy-preview-794--happy-galileo-ea79c4.netlify.com/elements/pfe-select/demo/) and add the links to the redhat font & theme to the demo file head via web inspector:
http://pastebin.test.redhat.com/846613

Or add this to the body tag ;)
```
--pfe-theme--font-family: "Comic Sans MS";
```
