### PR TITLE
fix: cascade "on" attribute from pfe-tabs to pfe-tab and pfe-tab-panel

### DIFF
--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -129,7 +129,7 @@
   <section class="faux-container" style="max-width: 800px">
     <h4 class="label">Default pfe-content-set in a 800px container</h4>
 
-    <pfe-content-set>
+    <pfe-content-set on="dark">
       <h4 pfe-content-set--header>Heading 1</h4>
       <div pfe-content-set--panel>
         <p>Content for heading 1. Maecenas faucibus mollis interdum. Maecenas sed diam eget risus varius blandit sit

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -67,7 +67,7 @@
       <h1></h1>
 
       <h2>Style: Horizontal plain</h2>
-      <pfe-tabs>
+      <pfe-tabs on="saturated">
           <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -39,6 +39,12 @@ class PfeTabs extends PFElement {
     return "pfe-tabs.json";
   }
 
+  static get cascadingAttributes() {
+    return {
+      on: "pfe-tab, pfe-tab-panel"
+    };
+  }
+
   static get observedAttributes() {
     return [
       "vertical",
@@ -111,6 +117,8 @@ class PfeTabs extends PFElement {
   }
 
   attributeChangedCallback(attr, oldValue, newValue) {
+    super.attributeChangedCallback(attr, oldValue, newValue);
+
     switch (attr) {
       case "pfe-variant":
         if (this.getAttribute("pfe-variant") === "wind") {
@@ -141,13 +149,6 @@ class PfeTabs extends PFElement {
           this.removeAttribute("aria-orientation");
           this._allPanels().forEach(panel => panel.removeAttribute("vertical"));
           this._allTabs().forEach(tab => tab.removeAttribute("vertical"));
-        }
-        break;
-
-      case "on":
-        if (this.getAttribute("on") === "dark") {
-          this._allTabs().forEach(tab => tab.setAttribute("on", "dark"));
-          this._allPanels().forEach(panel => panel.setAttribute("on", "dark"));
         }
         break;
 

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -112,6 +112,11 @@
       <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
     </pfe-tabs>
 
+    <pfe-tabs id="onAttribute" on="dark">
+      <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
+      <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+    </pfe-tabs>
+
     <pfe-tabs id="history" pfe-tab-history>
       <pfe-tab role="heading" slot="tab" id="historyTab1">Tab 1</pfe-tab>
       <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
@@ -357,6 +362,20 @@
 
           assert.equal(tab.getAttribute("pfe-variant"), "earth");
           assert.equal(panel.getAttribute("pfe-variant"), "earth");
+        });
+
+        test("it should cascade the on attribute to pfe-tab and pfe-tab-panel from pfe-tabs", () => {
+          const tabs = document.querySelector("#onAttribute");
+          const tab = tabs.querySelector("pfe-tab");
+          const panel = tabs.querySelector("pfe-tab-panel");
+
+          assert.equal(tab.getAttribute("on"), tabs.getAttribute("on"));
+          assert.equal(panel.getAttribute("on"), tabs.getAttribute("on"));
+
+          tabs.setAttribute("on", "light");
+
+          assert.equal(tab.getAttribute("on"), tabs.getAttribute("on"));
+          assert.equal(panel.getAttribute("on"), tabs.getAttribute("on"));
         });
       });
 


### PR DESCRIPTION
Fixes #799

**Testing Instructions**
- Add or modify any of the existing `on` attributes on a `pfe-tabs` component on the pfe-tabs demo page
- Changing the `on` attribute should cascade the value down to the child `pfe-tab` and `pfe-tab-panel` components
- Removing the `on` attribute from `pfe-tab` should remove the `on` attribute from the child `pfe-tab` and `pfe-tab-panel` components