### PR TITLE
fix: set pfe-cta with the priority attribute relative to default pfe-cta font-size

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,6 +3,7 @@
 Tag: [v1.0.0-prerelease.42](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.42)
 
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers (#773)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta default font-size to 18px
 
 
 ## Prerelease 41 ( 2020-03-19 )

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,7 +3,7 @@
 Tag: [v1.0.0-prerelease.42](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.42)
 
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers (#773)
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta's with the priority attribute to font-size: 16px
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta's with the priority attribute relative to theme font-size
 
 
 ## Prerelease 41 ( 2020-03-19 )

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,7 +3,7 @@
 Tag: [v1.0.0-prerelease.42](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.42)
 
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: set consistent line-height for pfe-nav triggers (#773)
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta default font-size to 18px
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta's with the priority attribute to font-size: 16px
 
 
 ## Prerelease 41 ( 2020-03-19 )

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -124,15 +124,16 @@ $variables: (
     text-align: center;
     font-size: #{pfe-local($cssvar: FontSize--priority, $fallback: #{pfe-var(font-size)})};
   }
+
+  :host([aria-disabled="true"]) & {
+    cursor: default !important;
+    font-size: #{pfe-local($cssvar: FontSize--priority, $fallback: #{pfe-var(font-size)})};
+  }
 }
 
 :host(:not([aria-disabled="true"])) ::slotted(*:not(:disabled)),
 :host ::slotted(*:not(:disabled)) {
   cursor: pointer;
-}
-
-:host([aria-disabled="true"]) ::slotted(*) {
-  cursor: default !important;
 }
 
 .pfe-cta {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -22,6 +22,8 @@ $variables: (
   TextDecoration--hover: none,
   TextDecoration--focus: none,
   FontWeight: #{pfe-var(font-weight--bold)},
+  FontSize:  #{pfe-var(font-size)},
+  FontSize--priority: calc(#{pfe-local($cssvar: FontSize) / 1.125}),
   arrow: (
     Display: inline,
     Padding: 0 0.125rem 0 0.375rem,

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -5,6 +5,7 @@ $LOCAL: cta;
  
 $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
+$pfe-cta--FontSize--default: calc(#{pfe-local($cssvar: FontSize)} * 1.125);
 
 $variables: (
   Padding: 0.6rem 0,
@@ -101,7 +102,7 @@ $variables: (
       $cssvar: FontFamily,
       $fallback: #{pfe-var(font-family--heading)}
     )};
-  font-size: #{pfe-local($cssvar: FontSize, $fallback: #{pfe-var(font-size)})};
+  font-size: #{pfe-local($cssvar: FontSize--default, $fallback: #{pfe-var(font-size)})};
   font-weight: #{pfe-local(FontWeight)};
   line-height: #{pfe-local(
       $cssvar: LineHeight,
@@ -120,6 +121,7 @@ $variables: (
 
   :host([pfe-priority]) & {
     text-align: center;
+    font-size: #{pfe-local($cssvar: FontSize, $fallback: #{pfe-var(font-size)})};
   }
 }
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -101,7 +101,7 @@ $variables: (
       $cssvar: FontFamily,
       $fallback: #{pfe-var(font-family--heading)}
     )};
-  font-size: #{pfe-local($cssvar: FontSize--default, $fallback: #{pfe-var(font-size)})};
+  font-size: #{pfe-local($cssvar: FontSize, $fallback: #{pfe-var(font-size)})};
   font-weight: #{pfe-local(FontWeight)};
   line-height: #{pfe-local(
       $cssvar: LineHeight,
@@ -120,7 +120,7 @@ $variables: (
 
   :host([pfe-priority]) & {
     text-align: center;
-    font-size: #{pfe-local($cssvar: FontSize, $fallback: #{pfe-var(font-size)})};
+    font-size: #{pfe-local($cssvar: FontSize--priority, $fallback: #{pfe-var(font-size)})};
   }
 }
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -5,7 +5,6 @@ $LOCAL: cta;
  
 $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
-$pfe-cta--FontSize--default: calc(#{pfe-local($cssvar: FontSize)} * 1.125);
 
 $variables: (
   Padding: 0.6rem 0,


### PR DESCRIPTION
**What has changed and why**
Set the default pfe-cta font-size to be larger (18px) than the font-size for pfe-priority ctas (16px).