### PR TITLE
fix: make it so pfe-tabs inside pfe-tabs works

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -3,6 +3,7 @@
 Tag: [v1.0.0-prerelease.42](https://github.com/patternfly/patternfly-elements/releases/tag/v1.0.0-prerelease.42)
 
 - [fbc251b](https://github.com/patternfly/patternfly-elements/commit/fbc251b5180684da26a57c0941235d57f961990e) fix: set consistent line-height for pfe-nav triggers (#773)
+- []() fix: make it so pfe-tabs inside pfe-tabs works
 - [29780ab](https://github.com/patternfly/patternfly-elements/commit/29780abfab1074aa05a021a43d79bee00afed31b) feat: adding event to pfe-cta component
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: set pfe-cta's with the priority attribute relative to theme font-size
 

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -323,6 +323,31 @@
     </section>
 
     <section class="example">
+      <h2>Tabs in Tabs</h2>
+      <pfe-tabs>
+        <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel">
+          <pfe-tabs id="subtabset">
+            <pfe-tab role="heading" slot="tab">Sub Tab 1</pfe-tab>
+            <pfe-tab-panel role="region" slot="panel">
+              <h2>Content for Sub Tab 1</h2>
+            </pfe-tab-panel>
+            <pfe-tab role="heading" slot="tab">Sub Tab 2</pfe-tab>
+            <pfe-tab-panel role="region" slot="panel">
+              <h2>Content for Sub Tab 2</h2>
+              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            </pfe-tab-panel>
+          </pfe-tabs>
+        </pfe-tab-panel>
+        <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel">
+          <h1>Tab 2 Content</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </pfe-tab-panel>
+      </pfe-tabs>
+    </section>
+
+    <section class="example">
 
       <h2>Dynamically Adding a Tab and Tab Panel</h2>
       <pfe-tabs id="dynamic">

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -295,11 +295,11 @@ class PfeTabs extends PFElement {
   }
 
   _allPanels() {
-    return [...this.querySelectorAll("pfe-tab-panel")];
+    return [...this.children].filter(child => child.matches("pfe-tab-panel"));
   }
 
   _allTabs() {
-    return [...this.querySelectorAll("pfe-tab")];
+    return [...this.children].filter(child => child.matches("pfe-tab"));
   }
 
   _panelForTab(tab) {
@@ -386,6 +386,8 @@ class PfeTabs extends PFElement {
   }
 
   _onKeyDown(event) {
+    event.stopPropagation();
+
     if (event.target.getAttribute("role") !== "tab") {
       return;
     }
@@ -426,6 +428,8 @@ class PfeTabs extends PFElement {
   }
 
   _onClick(event) {
+    event.stopPropagation();
+
     if (event.currentTarget.getAttribute("role") !== "tab") {
       return;
     }

--- a/elements/pfe-tabs/src/polyfills--pfe-tabs.js
+++ b/elements/pfe-tabs/src/polyfills--pfe-tabs.js
@@ -93,3 +93,9 @@ if (!Array.prototype.findIndex) {
     writable: true
   });
 }
+
+// @POLYFILL Element.prototype.matches
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector;
+}

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -118,6 +118,28 @@
       <pfe-tab role="heading" slot="tab" id="historyTab2">Tab 1</pfe-tab>
       <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
     </pfe-tabs>
+
+    <pfe-tabs id="tabs-in-tabs">
+      <pfe-tab role="heading" slot="tab" id="tabs-in-tabs-1">Tab 1</pfe-tab>
+      <pfe-tab-panel role="region" slot="panel">
+        <pfe-tabs id="subtabset">
+          <pfe-tab role="heading" slot="tab" id="subtab1">Sub Tab 1</pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content for Sub Tab 1</h2>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab" id="subtab2">Sub Tab 2</pfe-tab>
+          <pfe-tab-panel role="region" slot="panel" id="subtab2panel">
+            <h2>Content for Sub Tab 2</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+        </pfe-tabs>
+      </pfe-tab-panel>
+      <pfe-tab role="heading" slot="tab" id="tabs-in-tabs-2">Tab 2</pfe-tab>
+      <pfe-tab-panel role="region" slot="panel" id="tabs-in-tabs-panel2">
+        <h1>Tab 2 Content</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </pfe-tab-panel>
+    </pfe-tabs>
     <script>
       suite('<pfe-tabs>', () => {
         setup(() => {
@@ -357,6 +379,40 @@
 
           assert.equal(tab.getAttribute("pfe-variant"), "earth");
           assert.equal(panel.getAttribute("pfe-variant"), "earth");
+        });
+
+        test("it should function properly with tabs in tabs", done => {
+          const tabset1 = document.querySelector("#tabs-in-tabs");
+          const tabset1Tab1 = tabset1.querySelector("#tabs-in-tabs-1");
+          const tabset1Tab2 = tabset1.querySelector("#tabs-in-tabs-2");
+          const tabset1Tab2Panel = tabset1.querySelector("#tabs-in-tabs-panel2");
+          const tabset2 = tabset1.querySelector("pfe-tabs");
+          const tabset2SubTab1 = tabset2.querySelector("#subtab1");
+          const tabset2SubTab2 = tabset2.querySelector("#subtab2");
+          const tabset2SubTabPanel = tabset2.querySelector("#subtab2panel");
+
+          tabset2SubTab2.click();
+
+          flush(() => {
+            assert.equal(tabset2SubTab2.getAttribute('aria-selected'), 'true');
+            assert.isTrue(!tabset2SubTabPanel.hasAttribute('hidden'));
+
+            tabset1Tab2.click();
+
+            flush(() => {
+              assert.equal(tabset1Tab2.getAttribute('aria-selected'), 'true');
+              assert.isTrue(!tabset1Tab2Panel.hasAttribute('hidden'));
+
+              tabset1Tab1.click();
+
+              flush(() => {
+                assert.equal(tabset2SubTab2.getAttribute('aria-selected'), 'true');
+                assert.isTrue(!tabset2SubTabPanel.hasAttribute('hidden'));
+                
+                done();
+              });
+            });
+          });
         });
       });
 


### PR DESCRIPTION
Fixes #805

**Testing Instructions**
- On your local machine, go to http://localhost:8000/elements/pfe-tabs/demo/ and scroll down to the "Tabs In Tabs" heading
- Click on Sub Tab 2 and ensure the content shows
- Click on Tab 2 and ensure the Tab 2 content shows
- Click on Tab 1 and ensure that Sub Tab 2 is still active and the Sub Tab 2 content is showing

This has been tested on:
- Chrome
- Firefox
- Safari
- Edge 80
- IE 11