### PR TITLE
feat: Remove the "pfe-" prefix from the history feature in pfe-tabs

### DIFF
--- a/elements/pfe-tabs/README.md
+++ b/elements/pfe-tabs/README.md
@@ -73,8 +73,8 @@ This will override any context being passed from a parent component and will add
 Updates window.history and the URL to create sharable links. With the
 `pfe-tab-history` attribute, the tabs and each tab *must* have an `id`.
 
-The URL pattern will be `?pfe-{id-of-tabs}={id-of-selected-tab}`. In the example
-below, selecting "Tab 2" will update the URL as follows: `?pfe-my-tabs=tab2`.
+The URL pattern will be `?{id-of-tabs}={id-of-selected-tab}`. In the example
+below, selecting "Tab 2" will update the URL as follows: `?my-tabs=tab2`.
 
 ```html
 <pfe-tabs pfe-tab-history id="my-tabs">
@@ -99,7 +99,7 @@ By default, `pfe-tabs` will read the URL and look for a query string parameter
 that matches the id of a `pfe-tabs` component and a value of a specific
 `pfe-tab`.
 
-For example, `?pfe-my-tabs=tab2` would open the second tab in the code sample below.
+For example, `?my-tabs=tab2` would open the second tab in the code sample below.
 "my-tabs" is equal to the id of the `pfe-tabs` component and "tab2" is equal to
 the id of the second tab in the tab set.
 

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -211,7 +211,7 @@ class PfeTabs extends PFElement {
       const urlParams = new URLSearchParams(window.location.search);
       const hash = window.location.hash;
 
-      urlParams.set(`pfe-${this.id}`, tab.id);
+      urlParams.set(`${this.id}`, tab.id);
       history.pushState({}, "", `${pathname}?${urlParams.toString()}${hash}`);
     }
 
@@ -443,10 +443,17 @@ class PfeTabs extends PFElement {
       urlParams = new URLSearchParams(window.location.search);
     }
 
-    if (urlParams && urlParams.has(`pfe-${this.id}`)) {
-      tabIndex = this._allTabs().findIndex(
-        tab => tab.id === urlParams.get(`pfe-${this.id}`)
-      );
+    // @DEPRECATED
+    // the "pfe-" prefix has been deprecated but we'll continue to support it
+    // we'll give priority to the urlParams.has(`${this.id}`) attribute first
+    // and fallback to urlParams.has(`pfe-${this.id}`) if it exists. We should
+    // be able to remove the || part of the if statement in the future
+    if (
+      urlParams &&
+      (urlParams.has(`${this.id}`) || urlParams.has(`pfe-${this.id}`))
+    ) {
+      const id = urlParams.get(`${this.id}`) || urlParams.get(`pfe-${this.id}`);
+      tabIndex = this._allTabs().findIndex(tab => tab.id === id);
     }
 
     return tabIndex;

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -364,7 +364,38 @@
         test("it should show the correct tab if there is a querystring parameter in the URL", done => {
           // the parameter should be equal to the id of the tabset
           // the value should be equal to the id of the tab you want opened
-          const searchParams = new URLSearchParams(window.location.search)
+          const searchParams = new URLSearchParams();
+          searchParams.set("fromQueryString", "fromQueryStringTab2");
+          var newPath = window.location.pathname + '?' + searchParams.toString();
+          history.pushState(null, '', newPath);
+
+          const fragment = document.createRange().createContextualFragment(`
+            <pfe-tabs id="fromQueryString">
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab1">Tab 1</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+              <pfe-tab role="heading" slot="tab" id="fromQueryStringTab2">Tab 2</pfe-tab>
+              <pfe-tab-panel role="region" slot="panel">Content</pfe-tab-panel>
+            </pfe-tabs>
+          `);
+
+          document.body.appendChild(fragment);
+
+          flush(() => {
+            const tabs = document.querySelector("#fromQueryString");
+            const tab2 = tabs.querySelector("#fromQueryStringTab2");
+            assert.equal(tabs.selectedIndex, 1);
+            assert.isTrue(tab2.hasAttribute("aria-selected"));
+
+            document.body.removeChild(tabs);
+            done();
+          });
+        });
+
+        test("it should continue to support the \"pfe-\" prefix in the URL and show the correct tab if there is a querystring parameter in the URL", done => {
+          // this supports any tabs that are currently using the "pfe-" prefix
+          // in the URL to open to a specific tab. the "pfe-" prefix has been
+          // deprecated and should no longer be used
+          const searchParams = new URLSearchParams();
           searchParams.set("pfe-fromQueryString", "fromQueryStringTab2");
           var newPath = window.location.pathname + '?' + searchParams.toString();
           history.pushState(null, '', newPath);
@@ -427,7 +458,7 @@
 
           flush(() => {
             const urlSearchParams = new URLSearchParams(window.location.search);
-            assert.equal(urlSearchParams.get("pfe-history"), "historyTab2");
+            assert.equal(urlSearchParams.get("history"), "historyTab2");
             assert.equal(tabs.selectedIndex, 1);
             assert.isTrue(tab2.hasAttribute("aria-selected"));
             done();
@@ -444,7 +475,7 @@
 
           flush(() => {
             const urlSearchParams = new URLSearchParams(window.location.search);
-            assert.equal(urlSearchParams.get("pfe-history"), "historyTab2");
+            assert.equal(urlSearchParams.get("history"), "historyTab2");
             assert.equal(tabs.selectedIndex, 0);
             assert.isTrue(tab1.hasAttribute("aria-selected"));
             done();


### PR DESCRIPTION
Fixes #802

**Testing Instructions**
- Navigate to https://deploy-preview-808--happy-galileo-ea79c4.netlify.com/elements/pfe-tabs/demo/?my-tabs=tab2 and verify that "Tab 2" is open in the "Tab History" section of the page
- Next,  navigate to https://deploy-preview-808--happy-galileo-ea79c4.netlify.com/elements/pfe-tabs/demo/?pfe-my-tabs=tab3 and verify that "Tab 3" is open in the "Tab History" section of the page
  - Note the "pfe-" prefix in the URL. This has been deprecated but we're going to support it.

It _is_ expected that clicking on a different tab in the tab set will add another query string parameter to the URL. 

This has been tested on:
- Chrome
- Firefox
- Safari
- Edge 80
- IE 11 (this feature isn't supported on IE11 but it does not break tabs)