### PR TITLE
Add clearfix to tabs & accordions, in case of floating content

### DIFF
--- a/elements/pfe-accordion/src/pfe-accordion-panel.html
+++ b/elements/pfe-accordion/src/pfe-accordion-panel.html
@@ -1,5 +1,5 @@
 <div tabindex="-1" role="tabpanel">
-  <div class="container">
+  <div class="container clearfix">
     <slot></slot>
   </div>
 </div>

--- a/elements/pfe-accordion/src/pfe-accordion-panel.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-panel.scss
@@ -23,6 +23,10 @@ $LOCAL: accordion;
   --pfe-accordion--panel-container--Padding: 0 calc(#{pfe-local(base--Padding)} * 3) #{pfe-local(base--Padding)} calc(#{pfe-local(base--Padding)} * 1.5);
 }
 
+.clearfix {
+  @include pfe-clearfix;
+}
+
 :host(:last-of-type[expanded]) {
   margin-bottom: 0;
 }

--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -367,6 +367,26 @@
     </pfe-content-set>
   </section>
 
+    <section class="example">
+      <h2>Content set with floating content</h2>
+      <pfe-content-set pfe-variant="earth" pfe-breakpoint="2000">
+        <h4 pfe-content-set--header role="heading" >Tab 1</h4>
+        <div pfe-content-set--panel role="region" >
+          <div style="float: left;width:48%;margin-right:2%;border: #eee solid 1px; padding: 20px;">
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </div>
+          <div style="float: left;width:48%;margin-right:2%;border: #eee solid 1px; padding: 20px;">
+            <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </div>
+        </div>
+        <h4 pfe-content-set--header role="heading" >Tab 2</h4>
+        <div pfe-content-set--panel role="region" >
+          <h1>Tab 2 Content</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </div>
+      </pfe-content-set>
+    </section>
+
   <section>
     <h3>The pfe-content-set comes with a mutation observer so that you may dynamically add headers and panels.</h3>
   </section>

--- a/elements/pfe-tabs/src/pfe-tab-panel.html
+++ b/elements/pfe-tabs/src/pfe-tab-panel.html
@@ -1,5 +1,5 @@
 <div tabindex="-1" role="tabpanel">
-  <div class="container">
+  <div class="container clearfix">
     <slot></slot>
   </div>
 </div>

--- a/elements/pfe-tabs/src/pfe-tab-panel.scss
+++ b/elements/pfe-tabs/src/pfe-tab-panel.scss
@@ -90,3 +90,7 @@ $variables: (
 :host([hidden]) {
   display: none;
 }
+
+.clearfix {
+  @include pfe-clearfix;
+}


### PR DESCRIPTION
Currently, if there is content that floats inside the accordions, the padding on the container is not clearing the floats, so the content ends up too close to the bottom border:

![image](https://user-images.githubusercontent.com/456863/79800969-41dc2400-832b-11ea-8ef5-2c9eb21fce97.png)

This PR adds clearfixes on the container, so that the padding is always visible around the content

![image](https://user-images.githubusercontent.com/456863/79801012-55878a80-832b-11ea-8d3e-1258902d0a99.png)
