### PR TITLE
fix: pfe-tabs adding dynamic tab in IE11

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,5 +1,6 @@
 ## Prerelese 45 ( TBD )
 
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-tabs adding dynamic tab in IE11 #838
 - [eb74cb8](https://github.com/patternfly/patternfly-elements/commit/eb74cb8f989048164fbb6ed1508c502659a752ed) feat: add event emission to pfe-select
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: Add a warning about updating the on attribute before upgrade
 

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -16,6 +16,11 @@ const KEYCODE = {
 // https://caniuse.com/#search=urlsearchparams
 const CAN_USE_URLSEARCHPARAMS = window.URLSearchParams ? true : false;
 
+const TABS_MUTATION_CONFIG = {
+  childList: true,
+  subtree: true
+};
+
 function generateId() {
   return Math.random()
     .toString(36)
@@ -88,7 +93,7 @@ class PfeTabs extends PFElement {
         this._init();
       }
 
-      this._observer.observe(this, { childList: true });
+      this._observer.observe(this, TABS_MUTATION_CONFIG);
     });
   }
 
@@ -235,7 +240,7 @@ class PfeTabs extends PFElement {
     if (mutationsList) {
       for (let mutation of mutationsList) {
         if (mutation.type === "childList" && mutation.addedNodes.length) {
-          mutation.addedNodes.forEach(addedNode => {
+          [...mutation.addedNodes].forEach(addedNode => {
             if (
               addedNode.tagName.toLowerCase() === PfeTab.tag ||
               addedNode.tagName.toLowerCase() === PfeTabPanel.tag
@@ -279,7 +284,7 @@ class PfeTabs extends PFElement {
     this._linked = true;
 
     if (window.ShadyCSS) {
-      this._observer.observe(this, { childList: true });
+      this._observer.observe(this, TABS_MUTATION_CONFIG);
     }
   }
 


### PR DESCRIPTION
Fixes #836

**Testing Instructions**
- [Open the demo page for pfe-tabs](https://deploy-preview-838--happy-galileo-ea79c4.netlify.app/elements/pfe-tabs/demo/) in IE11
- Go to the very bottom of the demo page to the "Dynamically Adding a Tab and Tab Panel" section
- Click on the "Add a Tab and Tab Panel" button and validate that a new tab is added to the tab set
- Click on the new tab and ensure that the tab opens