### PR TITLE
Reduce CTA arrow spacing, bring closer to text

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,7 +1,7 @@
 ## Prerelese 46 ( TBD )
 
 - [27fee5f](https://github.com/patternfly/patternfly-elements/commit/27fee5f5c5eb021ac126f3767dd0299f5cda8231) fix: pfe-tabs check for tagName on addedNode mutation before continuing
-- [2c950b](https://github.com/patternfly/patternfly-elements/commit/2c950b08f7638787df50aa5ee6738f1205ea3a9d) fix: Add clearfix within tab and accordion panels
+- [2c950b0](https://github.com/patternfly/patternfly-elements/commit/2c950b08f7638787df50aa5ee6738f1205ea3a9d) fix: Add clearfix within tab and accordion panels
 - []() fix: adjust arrow spacing & alignment on pfe-cta
 
 ## Prerelese 45 ( 2020-04-27 )

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,6 +2,7 @@
 
 - [27fee5f](https://github.com/patternfly/patternfly-elements/commit/27fee5f5c5eb021ac126f3767dd0299f5cda8231) fix: pfe-tabs check for tagName on addedNode mutation before continuing
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: Add clearfix within tab and accordion panels
+- []() Fix spacing around pfe-cta arrow
 
 ## Prerelese 45 ( 2020-04-27 )
 

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,8 +1,8 @@
 ## Prerelese 46 ( TBD )
 
 - [27fee5f](https://github.com/patternfly/patternfly-elements/commit/27fee5f5c5eb021ac126f3767dd0299f5cda8231) fix: pfe-tabs check for tagName on addedNode mutation before continuing
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Add clearfix within tab and accordion panels
-- []() Fix spacing around pfe-cta arrow
+- [2c950b](https://github.com/patternfly/patternfly-elements/commit/2c950b08f7638787df50aa5ee6738f1205ea3a9d) fix: Add clearfix within tab and accordion panels
+- []() fix: adjust arrow spacing & alignment on pfe-cta
 
 ## Prerelese 45 ( 2020-04-27 )
 
@@ -12,7 +12,6 @@
 - [f9c2813](https://github.com/patternfly/patternfly-elements/commit/f9c2813892eace5e600d168d876ecc4ffd46b472) fix: Add a warning about updating the on attribute before upgrade (#809)
 - [a55449b](https://github.com/patternfly/patternfly-elements/commit/a55449bc1da11abdaf98f959961f25bfa20edc67) docs: Content set and tabs update (#824)
 - [eb74cb8](https://github.com/patternfly/patternfly-elements/commit/eb74cb8f989048164fbb6ed1508c502659a752ed) feat: Update pfe-select to use new event emission format (#758) (#760)
-- []() fix: adjust arrow spacing & alignment on pfe-cta
 
 ## Prerelease 44 ( 2020-04-02 )
 

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -11,6 +11,7 @@
 - [f9c2813](https://github.com/patternfly/patternfly-elements/commit/f9c2813892eace5e600d168d876ecc4ffd46b472) fix: Add a warning about updating the on attribute before upgrade (#809)
 - [a55449b](https://github.com/patternfly/patternfly-elements/commit/a55449bc1da11abdaf98f959961f25bfa20edc67) docs: Content set and tabs update (#824)
 - [eb74cb8](https://github.com/patternfly/patternfly-elements/commit/eb74cb8f989048164fbb6ed1508c502659a752ed) feat: Update pfe-select to use new event emission format (#758) (#760)
+- []() fix: adjust arrow spacing & alignment on pfe-cta
 
 ## Prerelease 44 ( 2020-04-02 )
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -7,9 +7,9 @@ $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
 
 // Arrow animation
-$h-spacing: 3px;
-$arrow-basic: 0 $h-spacing;
-$arrow-hover: 0 0 0 #{$h-spacing * 2};
+$horizontal-spacing: 3px;
+$arrow-basic: 0 $horizontal-spacing;
+$arrow-hover: 0 0 0 #{$horizontal-spacing * 2};
 
 
 $variables: (
@@ -46,13 +46,10 @@ $variables: (
 :host {
   @include pfe-print-variables($variables);
 
-  // properties
   display: inline-block;
   position: relative;
   z-index: 0;
   vertical-align: middle;
-  //transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
-
   background-color: #{pfe-local(BackgroundColor)};
   border-color: #{pfe-local(BorderColor)};
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -26,7 +26,7 @@ $variables: (
   FontSize--priority: calc(#{pfe-local($cssvar: FontSize) / 1.125}),
   arrow: (
     Display: inline,
-    Padding: 0 0.125rem 0 0.375rem,
+    Padding: 0 0.05rem,
     size: 13px,
     MarginLeft: calc(#{pfe-var(content-spacer)} * 0.25)
   ),
@@ -194,7 +194,8 @@ $variables: (
     width: #{pfe-local($cssvar: size, $region: arrow)};
     height: #{pfe-local($cssvar: size, $region: arrow)};
     transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
-
+    margin-bottom: -1px;
+   
     :host(.focus-within) & {
       fill: #{pfe-local(Color--focus)};
     }

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -202,7 +202,6 @@ $variables: (
     height: #{pfe-local($cssvar: size, $region: arrow)};
     transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
     margin-bottom: -1px;
-   
     :host(.focus-within) & {
       fill: #{pfe-local(Color--focus)};
     }

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -51,7 +51,7 @@ $variables: (
   position: relative;
   z-index: 0;
   vertical-align: middle;
-  transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
+  //transition: padding #{pfe-var(animation-speed)} #{pfe-var(animation-timing)};
 
   background-color: #{pfe-local(BackgroundColor)};
   border-color: #{pfe-local(BorderColor)};

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -6,6 +6,13 @@ $LOCAL: cta;
 $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
 
+// Arrow animation
+$left: 0.2rem;
+$right: 0.2rem;
+$arrow-basic: 0 $right 0 $left;
+$arrow-hover: 0 0 0 #{$right + $left};
+
+
 $variables: (
   Padding: 0.6rem 0,
   BorderRadius: 0,
@@ -26,7 +33,7 @@ $variables: (
   FontSize--priority: calc(#{pfe-local($cssvar: FontSize) / 1.125}),
   arrow: (
     Display: inline,
-    Padding: 0 0.05rem,
+    Padding: #{$arrow-basic},
     size: 13px,
     MarginLeft: calc(#{pfe-var(content-spacer)} * 0.25)
   ),
@@ -76,7 +83,7 @@ $variables: (
 :host(:hover),
 :host(:hover) ::slotted(*),
 ::slotted(:hover) {
-  --pfe-cta__arrow--Padding: 0 0 0 0.5rem;
+  --pfe-cta__arrow--Padding: #{$arrow-hover};
 }
 
 :host(:hover) {

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -7,10 +7,9 @@ $pfe-cta--BackgroundColor--focus: rgba(40, 151, 240, 0.2);
 $pfe-cta--Color--fallback: #003366;
 
 // Arrow animation
-$left: 0.2rem;
-$right: 0.2rem;
-$arrow-basic: 0 $right 0 $left;
-$arrow-hover: 0 0 0 #{$right + $left};
+$h-spacing: 3px;
+$arrow-basic: 0 $h-spacing;
+$arrow-hover: 0 0 0 #{$h-spacing * 2};
 
 
 $variables: (

--- a/elements/pfe-icon/demo/svgtest.html
+++ b/elements/pfe-icon/demo/svgtest.html
@@ -31,7 +31,6 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.innerHTML = "";
           this.template.innerHTML = `
-
     <div style="filter: url(#fg); height: 40px; width: 40px; background-image: url(rh-icon-api.svg);"></div>
 `;
           this.shadowRoot.appendChild(this.template.content.cloneNode(true));
@@ -87,6 +86,7 @@
     <h1>&lt;use&gt; the embedded svg</h1>
     <svg xmlns="http://www.w3.org/2000/svg">
       <use href="#icon"></use>
+      <!-- <use href="http://localhost:8000/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg#icon"></use> -->
       <!-- <use href="https://raw.githubusercontent.com/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg#icon"></use> -->
     </svg>
 
@@ -96,7 +96,7 @@
     </svg>
 
     <h1>img tag pointing at an svg with content-type "text/plain"</h1>
-    <img src="https://static.redhat.com/libs/redhat/rh-iconfont/latest/svg/rh-icon-beer-glasses.svg">
+    <img src="http://localhost:8000/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg">
 
     <h1>img tag pointing at an svg with content-type "image/svg+xml"</h1>
     <img style="width: 40px" src="rh-icon-api.svg">

--- a/elements/pfe-icon/demo/svgtest.html
+++ b/elements/pfe-icon/demo/svgtest.html
@@ -87,7 +87,6 @@
     <h1>&lt;use&gt; the embedded svg</h1>
     <svg xmlns="http://www.w3.org/2000/svg">
       <use href="#icon"></use>
-      <!-- <use href="http://localhost:8000/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg#icon"></use> -->
       <!-- <use href="https://raw.githubusercontent.com/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg#icon"></use> -->
     </svg>
 

--- a/elements/pfe-icon/demo/svgtest.html
+++ b/elements/pfe-icon/demo/svgtest.html
@@ -96,7 +96,7 @@
     </svg>
 
     <h1>img tag pointing at an svg with content-type "text/plain"</h1>
-    <img src="http://localhost:8000/RedHatOfficial/rh-iconfont/master/src/iconfont/vectors/rh_icon/rh-icon-api.svg">
+    <img src="https://static.redhat.com/libs/redhat/rh-iconfont/latest/svg/rh-icon-beer-glasses.svg">
 
     <h1>img tag pointing at an svg with content-type "image/svg+xml"</h1>
     <img style="width: 40px" src="rh-icon-api.svg">

--- a/elements/pfe-icon/demo/svgtest.html
+++ b/elements/pfe-icon/demo/svgtest.html
@@ -31,6 +31,7 @@
           this.attachShadow({ mode: "open" });
           this.shadowRoot.innerHTML = "";
           this.template.innerHTML = `
+
     <div style="filter: url(#fg); height: 40px; width: 40px; background-image: url(rh-icon-api.svg);"></div>
 `;
           this.shadowRoot.appendChild(this.template.content.cloneNode(true));


### PR DESCRIPTION
Without theme: 
![image](https://user-images.githubusercontent.com/456863/80610250-1e8a3680-8a07-11ea-862d-cc38e3a5b3cb.png)

With RH theme:
![image](https://user-images.githubusercontent.com/456863/80610319-3497f700-8a07-11ea-9bea-b8fc375eb634.png)


[Design spec](https://xd.adobe.com/spec/3e62e93c-8338-4f31-5040-3b81f0ed5c71-4853/screen/f1027edf-aec8-476c-a763-576c508ba029/CTA-light-theme)



### Testing instructions

1. View the [CTA demo page](https://deploy-preview-844--happy-galileo-ea79c4.netlify.app//elements/pfe-cta/demo/) & compare the default CTA to the [mockups](https://xd.adobe.com/spec/3e62e93c-8338-4f31-5040-3b81f0ed5c71-4853/screen/f1027edf-aec8-476c-a763-576c508ba029/CTA-light-theme)
    - observe the spacing around the arrow, it should be closer to the text, as shown in the mockup
    - Test the hover and focus states
 
### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Browser testing passed.
- [x] Approved by designer.