### PR TITLE
fix: pfe-tabs - Issue 845 text added to tab or panel error

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,7 @@
+## Prerelese 46 ( TBD )
+
+- []() fix: pfe-tabs check for tagName on addedNode mutation before continuing
+
 ## Prerelese 45 ( 2020-04-27 )
 
 - [8dbea7b](https://github.com/patternfly/patternfly-elements/commit/8dbea7b5fbd94614d89828c27afafdcc287f016f) fix: typo in pfe-icon README (#840)

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -406,6 +406,29 @@
 
     </section>
 
+    <section class="example">
+      <h2 id="add-text-to-tab-and-panel">Dynamically Adding Text to Tab and Panel</h2>
+      <pfe-tabs id="dynamic-text">
+        <pfe-tab role="heading" slot="tab" id="dynamicTextTab">Tab 1</pfe-tab>
+        <pfe-tab-panel role="region" slot="panel" id="dynamicTextPanel">
+          <h4>Tab 1</h4>
+        </pfe-tab-panel>
+      </pfe-tabs>
+
+      <div>
+        <label>
+          Additional Tab Text
+          <input type="text" placeholder="Additional Tab Text" id="additional-tab-text">
+        </label>
+      </div>
+      <div>
+        <label>
+          Additional Panel Text
+          <input type="text" placeholder="Additional Panel Text" id="additional-panel-text">
+        </label>
+      </div>
+    </section>
+
     <script>
       var jumpLinksMenu = document.querySelector("#jump-links");
       var headings = document.querySelectorAll("section > h2[id]");
@@ -441,6 +464,19 @@
         fragment.appendChild(tab);
         fragment.appendChild(panel);
         pfeTabs.appendChild(fragment);
+      });
+
+      var dynamicTextTab = document.querySelector("#dynamicTextTab");
+      var dynamicTextPanel = document.querySelector("#dynamicTextPanel")
+      var additionalTabTextInput = document.querySelector("#additional-tab-text");
+      var additionalPanelTextInput = document.querySelector("#additional-panel-text");
+
+      additionalTabTextInput.addEventListener("change", function (event) {
+        dynamicTextTab.innerHTML += event.target.value;
+      });
+
+      additionalPanelTextInput.addEventListener("change", function (event) {
+        dynamicTextPanel.innerHTML += event.target.value;
       });
     </script>
   </body>

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -241,6 +241,10 @@ class PfeTabs extends PFElement {
       for (let mutation of mutationsList) {
         if (mutation.type === "childList" && mutation.addedNodes.length) {
           [...mutation.addedNodes].forEach(addedNode => {
+            if (!addedNode.tagName) {
+              return;
+            }
+
             if (
               addedNode.tagName.toLowerCase() === PfeTab.tag ||
               addedNode.tagName.toLowerCase() === PfeTabPanel.tag

--- a/elements/pfe-tabs/test/pfe-tabs_test.html
+++ b/elements/pfe-tabs/test/pfe-tabs_test.html
@@ -99,7 +99,7 @@
 
     <pfe-tabs id="dynamic">
       <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
-      <pfe-tab-panel role="region" slot="panel">Tab 1 Content</pfe-tab-panel>
+      <pfe-tab-panel role="region" slot="panel" id="dynamicTab1">Tab 1 Content</pfe-tab-panel>
     </pfe-tabs>
 
     <pfe-tabs id="initialVariant" pfe-variant="earth">
@@ -347,6 +347,9 @@
           documentFragment.appendChild(newTab);
           documentFragment.appendChild(newPanel);
           pfeAccordion.appendChild(documentFragment);
+
+          const dynamicTab1 = document.querySelector("#dynamicTab1");
+          dynamicTab1.innerHTML += "More text";
 
           flush(() => {
             const newTabElement = document.querySelector("#newTab");


### PR DESCRIPTION
**Testing Instructions**
- Visit the [demo page](https://deploy-preview-846--happy-galileo-ea79c4.netlify.app/elements/pfe-tabs/demo/#add-text-to-tab-and-panel)
- Add text into the "Additional Tab Text" input field and hit the tab key
- Add text into the "Additional Panel Text" input field and hit the tab key
- Validate that there are no errors in the console relating to `Cannot read property 'toLowerCase' of undefined`