### PR TITLE
fix: move max-width: 100px from menu triggers to icon triggers

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,6 +2,7 @@
 
 - [27fee5f](https://github.com/patternfly/patternfly-elements/commit/27fee5f5c5eb021ac126f3767dd0299f5cda8231) fix: pfe-tabs check for tagName on addedNode mutation before continuing
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: Add clearfix within tab and accordion panels
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Move max-width:100px to icon triggers
 
 ## Prerelese 45 ( 2020-04-27 )
 

--- a/elements/pfe-navigation/src/_shared-assets.scss
+++ b/elements/pfe-navigation/src/_shared-assets.scss
@@ -64,18 +64,11 @@ $variables: (
     margin: 0 !important;
     max-width: 100%; // added
     text-align: center;
-    // max-width: #{pfe-local($cssvar: MaxWidth, $region: trigger, $fallback: 100%)};
 
     @media screen and (min-width: pfe-breakpoint(xs) ) {
-        // --pfe-navigation__trigger--MaxWidth: 100%; // added
         max-width: 100%;
     }
-    @media screen and (min-width: pfe-breakpoint(sm-desktop, $map: false) ) {
-        // --pfe-navigation__trigger--MaxWidth: 100px; // added
-        max-width: 100px;
-    }
     @media screen and (min-width: pfe-breakpoint(xl) ) {
-        // --pfe-navigation__trigger--MaxWidth: 190px; // added
         max-width: 190px;
     }
 }

--- a/elements/pfe-navigation/src/pfe-navigation-item.scss
+++ b/elements/pfe-navigation/src/pfe-navigation-item.scss
@@ -262,13 +262,9 @@ $variables: map-merge($variables, $nav-item-variables);
 }
 
 // Typography styles need specificity over bootstrap
-
 ::slotted([slot="trigger"]) {
   @extend %trigger;
-}
-
-:host([pfe-icon]) {
-  ::slotted([slot="trigger"]) {
+  :host([pfe-icon]) & {
     margin: 0.25em 0 0 0 !important;
     max-width: 100px;
   }

--- a/elements/pfe-navigation/src/pfe-navigation-item.scss
+++ b/elements/pfe-navigation/src/pfe-navigation-item.scss
@@ -270,6 +270,7 @@ $variables: map-merge($variables, $nav-item-variables);
 :host([pfe-icon]) {
   ::slotted([slot="trigger"]) {
     margin: 0.25em 0 0 0 !important;
+    max-width: 100px;
   }
 }
 


### PR DESCRIPTION
### What has changed and why

Removed max-width: 100px that was causing the accordion trigger text to wrap between 1024px and 1030px. This max-width property was causing triggers inside the menu tray accordions to wrap between ~1000px and ~1024px.

#### Browser requirements

Your component should work in all of the following environments:

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 60.7.2 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Galaxy S9 Firefox
- [x] iPhone X Safari
- [x] iPad Pro Safari
- [x] Pixel 3 Chrome

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- <s>Tests have been updated to cover these changes.</s>
- [x] Browser testing passed.
- <s>Documentation (README.md, WHY.md, etc.) updated or added.</s>
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.

