### PR TITLE
feat: Add a default template for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,72 @@
+---
+name: Default template
+about: Generic template
+labels: feature
+---
+
+## Component name
+
+<!-- tldr; goes here -->
+
+
+### Related issue
+
+- (#100) Description
+
+
+### Preview
+
+<!-- Suggest linking to Netlify or a public sandbox; not a resource behind a log-in or VPN -->
+Link(s) to demo page(s) where this element can be viewed:
+- [Link](https://5e6089f7c8e38b0008963801--happy-galileo-ea79c4.netlify.com/examples/) 
+
+
+### What has changed and why
+
+<!-- See the `DISCOVERY.md` template at the root of the project; this can be copied and stored in your component folder for reference. -->
+
+Link to discovery documentation (should contain all the planning and requirements for this work):
+   - 
+
+
+### Testing instructions
+
+<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->
+
+1. 
+
+
+#### Browser requirements
+
+Your component should work in all of the following environments:
+
+- [ ] Latest 2 versions of Edge
+- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
+- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
+- [ ] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
+- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
+- [ ] Latest 2 versions of Safari
+- [ ] Android mobile device (such as the Galaxy S9)
+- [ ] Apple mobile device (such as the iPhone X)
+- [ ] Apple tablet device (such as the iPhone Pro)
+
+
+### Ready-for-merge Checklist
+
+Check off items as they are completed.  Feel free to delete items if they are not applicable.
+
+- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
+- [ ] Tests have been updated to cover these changes.
+- [ ] Browser testing passed.
+- [ ] Repository compiles and tests pass.
+- [ ] Changelog updated.
+- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
+- [ ] Link to the demo recording: []()
+- [ ] Approved by designer.
+
+
+### Merging
+
+Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
+
+**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 name: Default template
 about: Generic template
-labels: feature, Needs: AT updates, Needs: changelog, Ready: branch testing, sev-1
+labels: "feature, needs: AT updates, needs: changelog, needs: branch testing, priority: low"
 ---
 
 ## Component name

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,7 +59,7 @@ Check off items as they are completed.  Feel free to delete items if they are no
 - [ ] Tests have been updated to cover these changes.
 - [ ] Browser testing passed.
 - [ ] Repository compiles and tests pass.
-- [ ] Changelog updated.
+- [ ] Changelog updated (not needed for documentation updates).
 - [ ] Documentation (README.md, WHY.md, etc.) updated or added.
 - [ ] Link to the demo recording: []()
 - [ ] Approved by designer.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 name: Default template
 about: Generic template
-labels: feature
+labels: feature, Needs: AT updates, Needs: changelog, Ready: branch testing, sev-1
 ---
 
 ## Component name


### PR DESCRIPTION
## Add a default template for pull requests

### What has changed and why

Summarize files edited as part of this MR along with a brief description of what was changed/why.

- Add a generic pull request template in the .github folder that will load when any new PR is created

### Testing instructions

Cannot be tested until this is merged.  When a new PR is opened, this template should auto-populate.

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

