### PR TITLE
fix: pfe-health-index color support in IE11

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,8 +1,9 @@
 ## Prerelease 53 ( TBD )
 
-- []() fix: pfe-autocomplete prevent search-event from firing twice on option select
+- [743913e](https://github.com/patternfly/patternfly-elements/commit/743913e0620ee0ca6f0cdf95cc1ed2597b5fe6e3) fix: pfe-autocomplete prevent search-event from firing twice on option select
 - [f20b509](https://github.com/patternfly/patternfly-elements/commit/f20b5094b6eb02ed473b0e3dab2ea5280e56bda7) fix: pfe-autocomplete add composed flag to option-selected event (#988)
 - [0ffd92a](https://github.com/patternfly/patternfly-elements/commit/0ffd92a621d1082b118b84a07063bd39b9c8a904) fix: Move pfe-sass to a dev dependency (#983)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-health-index color support in IE11 (#992)
 
 ## Prerelease 52 ( 2020-07-17 )
 

--- a/elements/pfe-health-index/src/pfe-health-index.scss
+++ b/elements/pfe-health-index/src/pfe-health-index.scss
@@ -39,8 +39,8 @@ $colors: (
   @each $level in (a b c d e f) {
     &.#{$level} {
       @include pfe-print-local((
-        accent: #{map-get($colors, $level)},
-        accent--text: #{pfe-var(text--on-dark)}
+        accent: map-get($colors, $level),
+        accent--text: pfe-var(text--on-dark)
       ));
     }
   }
@@ -57,8 +57,18 @@ $colors: (
 
     &.active {
       background-color: pfe-local(accent);
+
+      @include browser-query(ie11) {
+        @each $level in (a b c d e f) {
+          &.#{$level} {
+            background-color: map-get($colors, $level);
+          }
+        }
+      }
+
     }
   }
+
   :host([size="mini"]) & {
     display: flex;
     width: pfe-var(ui--element--size);
@@ -70,7 +80,18 @@ $colors: (
     // Color applied to the background
     background-color: pfe-local(accent);
     color: pfe-local(accent--text);
+
+    @include browser-query(ie11) {
+      @each $level in (a b c d e f) {
+        &.#{$level} {
+          background-color: map-get($colors, $level);
+          color: pfe-fetch(text--on-dark);
+        }
+      }
+    }
+
   }
+
   :host([size="lg"]) & {
     background-color: pfe-var(surface--lightest);
     color: pfe-var(ui-disabled--text);
@@ -113,6 +134,16 @@ $colors: (
     &.active .grade {
       background-color: pfe-local(accent);
       color: pfe-local(accent--text);
+    }
+
+    @include browser-query(ie11) {
+      @each $level in (a b c d e f) {
+        &.#{$level} > .bottom,
+        &.active.#{$level} .grade {
+          background-color: map-get($colors, $level);
+          color: pfe-fetch(text--on-dark);
+        }
+      }
     }
   }
   &-container {


### PR DESCRIPTION
## pfe-health-index

IE11 support for health index colors:

<img width="1091" alt="Screen Shot 2020-07-21 at 9 16 19 AM" src="https://user-images.githubusercontent.com/1840295/88059850-6961a900-cb33-11ea-86c3-6b1d8b571d32.png">

### Related issue

- (#992) IE11: pfe-health-index colors

### Preview

Link(s) to demo page(s) where this element can be viewed:
- [Link](https://5e6089f7c8e38b0008963801--happy-galileo-ea79c4.netlify.com/examples/) 

### What has changed and why

Added IE11 fallback styles.

### Testing instructions

1. Open the health index demo page in IE11.
2. Ensure color renders appropriately for each state.

#### Browser requirements

Your component should work in all of the following environments:

- [x] Internet Explorer 11 (should be useable, not pixel perfect)

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [x] Changelog updated (not needed for documentation updates).


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
