### PR TITLE
Cpfed 3743 main nav styles

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -78,12 +78,20 @@
           color: #fff;
         }
 
-        .pfe-navigation__custom-links a:hover,
-        .pfe-navigation__custom-links button:hover,
+        .pfe-navigation__custom-links a ,
+        .pfe-navigation__custom-links button {
+          border: 1px solid transparent;
+        }
+
         .pfe-navigation__custom-links a:focus,
-        .pfe-navigation__custom-links button:focus {
+        .pfe-navigation__custom-links button:focus
+        .pfe-navigation__custom-links a:hover,
+        .pfe-navigation__custom-links button:hover {
           -webkit-box-shadow: inset 0 4px 0 0 #e00;
           box-shadow: inset 0 4px 0 0 #e00;
+          border: 1px dashed #fff;
+          border-top: 0px dashed #fff;
+          outline: 0;
         }
       }
 

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -53,9 +53,6 @@ $breakpoints: (
   appearance: none;
   cursor: pointer;
   transition: box-shadow 0.25s;
-  // added to counteract jumpiness when dashed border is visible on focus and hover
-  border: 1px solid transparent;
-  border-top: 0px;
 
   @include breakpoint('secondary-links-break') {
     display: flex;
@@ -69,10 +66,25 @@ $breakpoints: (
     color: #fff;
   }
 
+  // added to counteract jumpiness when dashed border is visible on focus and hover
+  border: 1px solid transparent;
+  border-top: 0px;
+
+  // focus styles
   &:focus,
   &:hover {
+    @include focus-styles(#fff, 0px);
+
     @include breakpoint('secondary-links-break') {
       box-shadow: inset 0 4px 0 0 #e00;
+    }
+  }
+
+  &[pfe-navigation-state="main-menu--open"] {
+    // @todo: fix focus-styles on mobile for accordion links and menu toggle button
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 0px);
     }
   }
 
@@ -86,12 +98,6 @@ $breakpoints: (
     @include breakpoint('secondary-links-break') {
       margin: 0 0 4px;
     }
-  }
-
-  // focus styles
-  &:focus,
-  &:hover {
-    @include focus-styles(#fff, 0px);
   }
 
 }

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -29,6 +29,15 @@ $breakpoints: (
   // @todo add support for JS nav-break
 }
 
+/// Focus indicator styles specific to pfe-navigation
+/// @param {string} $border-color Color of dashed border (white or black depending on bg-color)
+/// @param {string} $border-top-size Size of border-top (0px or 1px depending on which navigation main/mega menu
+@mixin focus-styles($border-color, $border-top-size) {
+  border: 1px dashed $border-color;
+  border-top: $border-top-size dashed $border-color;
+  outline: none;
+}
+
 /// Styles for top level buttons
 /// @todo Needs to be included in shadow dom and no-js styles
 @mixin top-level-button {
@@ -44,6 +53,10 @@ $breakpoints: (
   appearance: none;
   cursor: pointer;
   transition: box-shadow 0.25s;
+  // added to counteract jumpiness when dashed border is visible on focus and hover
+  border: 1px solid transparent;
+  border-top: 0px;
+
   @include breakpoint('secondary-links-break') {
     display: flex;
     flex-direction: column;
@@ -56,8 +69,8 @@ $breakpoints: (
     color: #fff;
   }
 
-  &:hover,
-  &:focus {
+  &:focus,
+  &:hover {
     @include breakpoint('secondary-links-break') {
       box-shadow: inset 0 4px 0 0 #e00;
     }
@@ -75,5 +88,10 @@ $breakpoints: (
     }
   }
 
-  // @todo Focus styles?
+  // focus styles
+  &:focus,
+  &:hover {
+    @include focus-styles(#fff, 0px);
+  }
+
 }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -47,6 +47,11 @@
 
   a {
     text-decoration: none;
+    // @todo: move these styles to be more specific with dropdown class so that logo link can be styled without conflicting
+    // &:focus,
+    // &:hover {
+    //   @include focus-styles(#000, 1px);
+    // }
   }
 }
 
@@ -64,6 +69,15 @@
   display: block;
   padding: 6px 8px;
   margin-left: -8px; // Should be flush left with container
+
+  // avoid jumpiness from focus/hover styles
+  border: 1px solid transparent;
+
+  // focus styles
+  &:focus,
+  &:hover {
+    @include focus-styles(#fff, 1px);
+  }
 }
 
 .pfe-navigation__logo-image {
@@ -102,8 +116,8 @@
   padding-right: 8px;
   color: #fff;
 
-  &:hover,
-  &:focus {
+  &:focus,
+  &:hover {
     box-shadow: inset 0 4px 0 0 #e00;
   }
 
@@ -277,18 +291,23 @@
     color: #fff;
   }
 
-  &:hover,
-  &:focus {
+  // @todo: remove the comment below
+  // LoVe Fears HAte
+
+  // added border to focus and hover rules bc focus and hover should be the same for a11y and usibility
+  // need to regroup on this and discuss with designer and make sure they approve
+  &:focus,
+  &:hover {
+    @include focus-styles(#fff, 0px);
+
     @include breakpoint('nav-break') {
       box-shadow: inset 0 4px 0 0 #e00;
     }
   }
 
-  &:focus {
-    border: 1px dashed #fff;
-    border-top: 0;
-    outline: none;
-  }
+  // &:focus {
+  //   @include focus-styles(#fff, 1px);
+  // }
 
   &[aria-haspopup=true] {
     position: relative;
@@ -296,8 +315,8 @@
       box-shadow: none;
     }
 
-    &:hover,
-    &:focus {
+    &:focus,
+    &:hover {
       @include breakpoint('nav-break') {
         box-shadow: inset 0 4px 0 0 #e00;
       }
@@ -329,13 +348,21 @@
       }
     }
     
-    &:hover,
-    &:focus {
+    &:focus,
+    &:hover {
       &:before {
         @include breakpoint('nav-break') {
           border-top-color: #B8BBBE;
         }
       }
+    }
+  }
+
+  // swap focus indicator color to #000 when menu is open so that focus indicator is still visible on white bg-color
+  &[aria-expanded="true"] {
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 0px);
     }
   }
 
@@ -413,10 +440,19 @@
 
   li a {
     color: var(--pfe-broadcasted--link,#06c);
+
+    // avoid jumpiness caused by focus/hover styles
+    border: 1px solid transparent;
+
+    &:focus,
     &:hover {
+      // focus styles
+      @include focus-styles(#000, 1px);
+
       color: var(--pfe-broadcasted--link--hover,#036);
       text-decoration: underline;
     }
+
   }
 }
 
@@ -480,6 +516,11 @@
     color: #151515;
     background: #fff;
     box-shadow: inset 0 4px 0 0 #e00;
+
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 0px);
+    }
   }
 }
 
@@ -514,8 +555,20 @@
   a,
   button {
     color: #151515;
+
+    // focus styles
+    &:focus,
+    &:hover {
+      @include focus-styles(#fff, 0px);
+    }
+
     @include breakpoint('secondary-links-break') {
-      color: #fff;
+      color: red;
+      // focus styles
+      &:focus,
+      &:hover {
+        @include focus-styles(#fff, 0px);
+      }
     }
   }
 }
@@ -533,6 +586,12 @@
     color: #151515;
     background: #fff;
     box-shadow: inset 0 4px 0 0 #e00;
+
+    //focus styles
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 0px);
+    }
   }
 }
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -140,6 +140,10 @@
     color: #151515;
     background: #fff;
     box-shadow: inset 0 4px 0 0 #e00;
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 0px);
+    }
   }
 }
 
@@ -291,17 +295,18 @@
     color: #fff;
   }
 
-  // @todo: remove the comment below
-  // LoVe Fears HAte
+  // added to avoid jumpiness when focus/hover styles are active
+  border: 1px solid transparent;
 
   // added border to focus and hover rules bc focus and hover should be the same for a11y and usibility
   // need to regroup on this and discuss with designer and make sure they approve
   &:focus,
   &:hover {
-    @include focus-styles(#fff, 0px);
+    @include focus-styles(#000, 1px);
 
     @include breakpoint('nav-break') {
       box-shadow: inset 0 4px 0 0 #e00;
+      @include focus-styles(#fff, 0px);
     }
   }
 
@@ -317,8 +322,11 @@
 
     &:focus,
     &:hover {
+      @include focus-styles(#000, 1px);
+
       @include breakpoint('nav-break') {
         box-shadow: inset 0 4px 0 0 #e00;
+        @include focus-styles(#fff, 0px);
       }
     }
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -435,7 +435,19 @@
   h4 a,
   h5 a,
   h6 a {
-    color: var(--pfe-theme--color--ui-complement,#464646);
+    color: var(--pfe-theme--color--ui-complement,#464646);    
+    
+    // avoid jumpiness caused by focus/hover styles
+    border: 1px solid transparent;
+
+    &:focus,
+    &:hover {
+      // focus styles
+      @include focus-styles(#000, 1px);
+
+      color: var(--pfe-broadcasted--link--hover,#036);
+      text-decoration: underline;
+    }
   }
 
   li a {


### PR DESCRIPTION
---
name: CPFED-3743 Main Nav Styles
labels: ready for review
---

## pfe-navigation

Updated focus styles for main menu and dropdowns, cleaned up main nav styles and double checked colors and focus/hover states with design and redhat.com example.

### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

1. Using a keyboard, tab through the menu to see the new focus states.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
