### PR TITLE
CPFED-3735: updated styles for mega menu footers, updated demo for me…

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -381,6 +381,7 @@
                 </ul>
               </section>
 
+              <!-- documentation note: mega menu footer region can fit at most 4 ctas -->
               <section class="pfe-navigation__footer">
                 <pfe-cta pfe-priority="primary">
                   <a href="#">Learn more about PFElements</a>
@@ -388,6 +389,14 @@
 
                 <pfe-cta>
                   <a href="https://github.com/">GitHub</a>
+                </pfe-cta>
+
+                <pfe-cta>
+                  <a href="https://github.com/">Another CTA Example</a>
+                </pfe-cta>
+
+                <pfe-cta pfe-priority="primary">
+                  <a href="#">Learn more about CTAs and How to Use Them</a>
                 </pfe-cta>
               </section>
             </div> <!-- end .pfe-navigation__dropdown -->
@@ -399,7 +408,7 @@
             </a>
 
             <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
-              <!-- note: single-col dropdowns CANNOT have pfe-nav footer regions -->
+              <!-- documentation note: single-col dropdowns CANNOT have pfe-nav footer regions -->
               <section>
                 <h3>
                   <a href="#">Platforms</a>

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -371,11 +371,14 @@
     padding: 32px 64px;
     // Fits as many columns as it can given the constraints
     // @todo evaluate layout needs and if this is a sane default
-    grid-template-columns: 
-      repeat(
-        auto-fill,
-        minmax(#{200 / 16 * 1em}, #{350 / 16 * 1em})
-      );
+    // grid-template-columns: 
+    //   repeat(
+    //     auto-fill,
+    //     minmax(#{200 / 16 * 1em}, #{350 / 16 * 1em})
+    //   );
+    // @todo: still need to test and see if this is a good setting for the flexibility needs of pfe-nav mega menu tray
+    // I tested this setting with 12 sections in the mega menu tray (on Firefox and Chrome) and it worked well. (KS)
+    grid-template-columns: repeat(4, 1fr); // changed to this to fix issues on 1200px brkpt, seems to look better and fit better
     grid-gap: 2em;
     background: #fff;
     // temp style
@@ -451,9 +454,15 @@
 .pfe-navigation__footer {
   grid-column: 1 / -1; // col spans to the end of col grid line always
 
-  display: grid;
-  grid-gap: 32px;
-  grid-auto-flow: column;
+  // display: grid;
+  grid-gap: 32px; // @todo: change to 2em for consitency, check design and see if 2em spacing matches well enough
+  // grid-auto-flow: row;
+
+  // change to display: flex bc it makes content fit better with 4 ctas
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
 
   border-top: 1px solid #d3d3d3;
 
@@ -462,8 +471,17 @@
   padding: 26px 8px 16px 8px;
 
   @include breakpoint('nav-break') {
+    // grid-auto-flow: column;
+    flex-direction: row;
+    align-items: center;
+    
     margin: calc(var(--pfe-theme--container-padding,16px) * 2) 0 calc(var(--pfe-theme--container-padding,16px) * 1.5);
     padding: calc(var(--pfe-theme--container-padding,16px) * 2.5) 0 0; 
+  }
+
+  // fix display block issue for pfe-cta links
+  pfe-cta a {
+    display: inline-block;
   }
 
 }


### PR DESCRIPTION
---
name: Cpfed 3735 megamenu tray footers
labels: ready for review
---

## pfe-navigation

Updated mega menu tray footers and grid column settings of mega menu dropdown based on design specs and redhat.com example.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
