### PR TITLE
fix: pfe-accordion disclosure

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,7 @@
+## Prerelease 54 ( TBD )
+
+- []() fix: pfe-accordion border styles (#1002)
+
 ## Prerelease 53 ( 2020-07-21 )
 
 - [743913e](https://github.com/patternfly/patternfly-elements/commit/743913e0620ee0ca6f0cdf95cc1ed2597b5fe6e3) fix: pfe-autocomplete prevent search-event from firing twice on option select (#989)

--- a/elements/pfe-accordion/src/pfe-accordion-header.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-header.scss
@@ -81,18 +81,19 @@
       border-left-width: pfe-fetch(surface--border-width);
     }
 
-    &:hover {
-      padding-left: calc(#{pfe-local(Padding, $region: base)} * 3 - #{pfe-var(surface--border-width--heavy)} + #{pfe-var(surface--border-width)});
-      &::before {
-        margin-left: calc((#{pfe-var(surface--border-width--heavy)} - #{pfe-var(surface--border-width)}) * -1);
-      }
-    }
-
     &::before {
       @include pfe-chevron($state: open, $position: before);
     }
     &[aria-expanded="true"]::before {
       transform: rotate(45deg) translateY(4px);
+    }
+  }
+}
+:host([pfe-disclosure="true"]) {
+  button:not([aria-expanded="true"]):hover {
+    padding-left: calc(#{pfe-local(Padding, $region: base)} * 3 - #{pfe-var(surface--border-width--heavy)} + #{pfe-var(surface--border-width)});
+    &::before {
+      margin-left: calc((#{pfe-var(surface--border-width--heavy)} - #{pfe-var(surface--border-width)}) * -1);
     }
   }
 }

--- a/elements/pfe-accordion/src/pfe-accordion-header.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-header.scss
@@ -82,11 +82,11 @@
     }
 
     &::before {
-      @include pfe-chevron($state: open, $position: before);
+      @include pfe-chevron($state: closed, $position: before, $offset: .55em);
     }
     
     &[aria-expanded="true"]::before {
-      transform: rotate(45deg) translateY(4px);
+      transform: rotate(45deg);
     }
 
     &:not([aria-expanded="true"]):hover {

--- a/elements/pfe-accordion/src/pfe-accordion-header.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-header.scss
@@ -84,16 +84,16 @@
     &::before {
       @include pfe-chevron($state: open, $position: before);
     }
+    
     &[aria-expanded="true"]::before {
       transform: rotate(45deg) translateY(4px);
     }
-  }
-}
-:host([pfe-disclosure="true"]) {
-  button:not([aria-expanded="true"]):hover {
-    padding-left: calc(#{pfe-local(Padding, $region: base)} * 3 - #{pfe-var(surface--border-width--heavy)} + #{pfe-var(surface--border-width)});
-    &::before {
-      margin-left: calc((#{pfe-var(surface--border-width--heavy)} - #{pfe-var(surface--border-width)}) * -1);
+
+    &:not([aria-expanded="true"]):hover {
+      padding-left: calc(#{pfe-local(Padding, $region: base)} * 3 - #{pfe-var(surface--border-width--heavy)} + #{pfe-var(surface--border-width)});
+      &::before {
+        margin-left: calc((#{pfe-var(surface--border-width--heavy)} - #{pfe-var(surface--border-width)}) * -1);
+      }
     }
   }
 }

--- a/elements/pfe-sass/mixins/_components.scss
+++ b/elements/pfe-sass/mixins/_components.scss
@@ -87,7 +87,7 @@
 @mixin pfe-accordion-props($variant: default) {
   margin: 0;
   width: pfe-local(Width, 100%);
-  max-width: calc(100% - #{pfe-local(BorderLeftWidth)});
+  max-width: calc(100% - #{pfe-var(surface--border-width--heavy)});
   height: auto;
   position: relative;
 


### PR DESCRIPTION
## pfe-accordion

- On hovering over the disclosure, the padding would shift visibly when the component was expanded.
- The chevron should be pointing toward the content when the disclosure is closed and toward the panel when the disclosure is opened.
- The container should retain it's size when the disclosure is opened and closed.

### Related issue

- (#1002) pfe-accordion has issues with padding


### Preview

Link(s) to demo page(s) where this element can be viewed:
- [pfe-accordion](https://deploy-preview-1003--happy-galileo-ea79c4.netlify.app/elements/pfe-accordion/demo/) 

### What has changed and why

Added context to the padding shift so that it was properly scoped.

### Testing instructions

#### Padding test
1. Open the [demo page](https://deploy-preview-1003--happy-galileo-ea79c4.netlify.app/elements/pfe-accordion/demo/)
2. Scroll down to the disclosure.
3. Open the disclosure.
4. Hover over the header.

You should not see any change in the header positioning.

#### Chevron test

1. Open the [demo page](https://deploy-preview-1003--happy-galileo-ea79c4.netlify.app/elements/pfe-accordion/demo/)
2. Scroll down to the disclosure.
    - The chevron should be point toward the headline in the closed state.
      <img width="1160" alt="Screen Shot 2020-07-28 at 12 11 58 PM" src="https://user-images.githubusercontent.com/1840295/88692460-1310df00-d0cc-11ea-8788-d6225b63ed7d.png">
3. Click on the header.
    - The chevron should point toward the panel in the open state.
      <img width="1161" alt="Screen Shot 2020-07-28 at 12 11 53 PM" src="https://user-images.githubusercontent.com/1840295/88692443-0d1afe00-d0cc-11ea-8eaa-e8a8924b5603.png">

#### Width test

1. Open the [demo page](https://deploy-preview-1003--happy-galileo-ea79c4.netlify.app/elements/pfe-accordion/demo/)
2. Scroll down to the disclosure.
3. Open the disclosure.

You should not see any flicker in the padding on the right side of the container when the component is opened and closed.

#### Browser requirements

Your component should work in all of the following environments:

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [x] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Android mobile device (such as the Galaxy S9)
- [x] Apple mobile device (such as the iPhone X)
- [x] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Browser testing passed.
- [x] Repository compiles and tests pass.
- [x] Changelog updated (not needed for documentation updates).
- [x] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

Rally: https://rally1.rallydev.com/#/detail/defect/407229332616