### PR TITLE
pfe-tabs fork: Debugging tools, var name updates + backwards compatibility

### DIFF
--- a/elements/pfe-sass/maps/_colors.scss
+++ b/elements/pfe-sass/maps/_colors.scss
@@ -88,8 +88,6 @@ $pfe-colors: (
   ui-disabled--text:                  $pfe-color--gray-600,
   ui-disabled--text--hover:           $pfelements--gray,
   ui-disabled--text--focus:           $pfelements--gray,
-
-  ui--border:                         $pfelements--gray-light,
   
   // ========================================================================
   // Base Surface Colors for Container elements
@@ -127,7 +125,7 @@ $pfe-colors: (
   surface--border--lightest:          $pfe-color--gray-100,
   surface--border--lighter:           $pfe-color--gray-100,
   surface--border:                    $pfelements--gray-light,
-  surface--border--darker:            $pfe-color--gray-300,
+  surface--border--darker:            $pfe-color--gray-600,
   surface--border--darkest:           $pfe-color--gray-800,
 
 

--- a/elements/pfe-sass/maps/_colors.scss
+++ b/elements/pfe-sass/maps/_colors.scss
@@ -89,6 +89,8 @@ $pfe-colors: (
   ui-disabled--text--hover:           $pfelements--gray,
   ui-disabled--text--focus:           $pfelements--gray,
 
+  ui--border:                         $pfelements--gray-light,
+  
   // ========================================================================
   // Base Surface Colors for Container elements
   // ========================================================================

--- a/elements/pfe-sass/maps/_general.scss
+++ b/elements/pfe-sass/maps/_general.scss
@@ -34,6 +34,7 @@ $pfe-vars: (
   ui--element--size:             20px,
 
   ui--border-width:              1px,
+  ui--border-width--active:      3px,
   ui--border-style:              solid,
   ui--border-radius:             2px,
 

--- a/elements/pfe-sass/mixins/_mixins.scss
+++ b/elements/pfe-sass/mixins/_mixins.scss
@@ -109,3 +109,27 @@
   height: #{$size};
   @content;
 }
+
+
+@mixin pfe-local-debug($map: $LOCAL-VARIABLES) {
+  :root {
+      @each $property, $value in $map {
+        $name: "--#{$property}";
+        $styles: $value;
+
+        @if type-of($value) == "map" {
+            @each $prop, $v in $value {
+                $name: "__#{$property}--#{$prop}";
+                $styles: $v;
+
+                // Print the variable definition
+                --#{$repo}-#{$LOCAL}#{$name}: #{$styles};
+            }
+        }
+        @else {
+            // Print the variable definition
+            --#{$repo}-#{$LOCAL}#{$name}: #{$styles};
+        }
+    }
+  }
+}

--- a/elements/pfe-sass/mixins/_mixins.scss
+++ b/elements/pfe-sass/mixins/_mixins.scss
@@ -110,7 +110,7 @@
   @content;
 }
 
-
+// This will print the $LOCAL-VARIABLES map for debugging within components
 @mixin pfe-local-debug($map: $LOCAL-VARIABLES) {
   :root {
       @each $property, $value in $map {

--- a/elements/pfe-sass/mixins/_mixins.scss
+++ b/elements/pfe-sass/mixins/_mixins.scss
@@ -113,23 +113,6 @@
 // This will print the $LOCAL-VARIABLES map for debugging within components
 @mixin pfe-local-debug($map: $LOCAL-VARIABLES) {
   :root {
-      @each $property, $value in $map {
-        $name: "--#{$property}";
-        $styles: $value;
-
-        @if type-of($value) == "map" {
-            @each $prop, $v in $value {
-                $name: "__#{$property}--#{$prop}";
-                $styles: $v;
-
-                // Print the variable definition
-                --#{$repo}-#{$LOCAL}#{$name}: #{$styles};
-            }
-        }
-        @else {
-            // Print the variable definition
-            --#{$repo}-#{$LOCAL}#{$name}: #{$styles};
-        }
-    }
+      @include pfe-print-local($map);
   }
 }

--- a/elements/pfe-tabs/demo/demo.css
+++ b/elements/pfe-tabs/demo/demo.css
@@ -57,6 +57,9 @@ section.pfe-l-grid {
 .example>h2 {
     text-align: right;
 }
+section>h2 {
+    margin-top: 2em;
+}
 
 .subheading {
   margin: 0;
@@ -64,11 +67,24 @@ section.pfe-l-grid {
   font-weight: bold;
   font-family: "Arial";
 }
-
+.inner {
+   margin: auto;
+   max-width:1140px;
+   padding: 50px 0;
+}
+.light-background {
+    background-color: rgb(252, 250, 244);
+    --theme: light;
+}
 .dark-background {
-    background-color: #151515;
+    background-color: #524848;
     --theme: dark;
 }
+.saturated-background {
+    background-color: teal;
+    --theme: saturated;
+}
+
 
 .floating-card {
     float: left;
@@ -123,8 +139,4 @@ button.form-ui {
     height: 2em;
     font-size: 1em;
     padding: 2px 5px;
-}
-.saturated-background {
-    background-color: teal;
-    --theme: saturated;
 }

--- a/elements/pfe-tabs/demo/demo.css
+++ b/elements/pfe-tabs/demo/demo.css
@@ -77,7 +77,7 @@ section>h2 {
     --theme: light;
 }
 .dark-background {
-    background-color: #524848;
+    background-color: #383333;
     --theme: dark;
 }
 .saturated-background {

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -41,18 +41,19 @@
     <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
   </head>
 
-  <body unresolved>
+  <body unresolved  >
+  <div class="light-background"><div class="inner">
     <h1 id="top" class="example-heading"><code>&lt;pfe-tabs&gt;</code></h1>
 
-    <pfe-card class="toc" pfe-color="lightest">
-      <h3 id="toc">Table of contents</h3>
+    <pfe-card style="margin-bottom: 2em;" class="" pfe-color="lightest">
+      <h3 id=" ">Table of contents</h3>
       <ul id="jump-links"></ul>
       <a href="#top">Scroll to top</a>
     </pfe-card>
 
     <a class="scroll-up" title="Scroll to top" href="#top"><pfe-icon size="md" icon="web-caret-thin-up"></pfe-icon></a>
 
-    <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col pfe-m-all-6-col-on-xl">
+    <section class=" ">
       <div>
         <h2 id="style-horizontal-plain">Style: Horizontal plain</h2>
         <pfe-tabs>
@@ -61,7 +62,7 @@
             </pfe-tab>
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 1</h2>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </pfe-tab-panel>
             <pfe-tab role="heading" slot="tab" id="tab2">
               <h3>Tab</h3>
@@ -69,8 +70,8 @@
             </pfe-tab>
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 2</h2>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </pfe-tab-panel>
             <pfe-tab role="heading" slot="tab" id="tab3">
               <pfe-icon icon="rh-atom"></pfe-icon>
@@ -79,7 +80,7 @@
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 3</h2>
               <div class="floating-card">
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
               </div>
               <div class="floating-card">
                 <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -96,21 +97,21 @@
             <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 1</h2>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </pfe-tab-panel>
-            <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+            <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 2</h2>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </pfe-tab-panel>
             <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
             <pfe-tab-panel role="region" slot="panel">
               <h2>Content 3</h2>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </pfe-tab-panel>
         </pfe-tabs>
       </div>
@@ -121,21 +122,21 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
       </div>
@@ -146,21 +147,21 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
@@ -170,7 +171,7 @@
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
             <div class="floating-card">
-              <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+              <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
                 dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
                 ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
                 nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
@@ -192,21 +193,21 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
@@ -215,22 +216,22 @@
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
               id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
               commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
               nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
@@ -247,54 +248,55 @@
           </pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">
             <h3 class="subheading">Tab 2 with a few more words</h3>
           </pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">
             <h3 class="subheading">Tab 3</h3>
           </pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
       </div>
     </section>
-
+</div>
+</div>
 <!--  Dark -->
 
-    <div class="dark-background">
-      <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col">
+    <div class="dark-background"><div class="inner">
+      <section class="">
         <h2 id="style-horizontal-plain-on-dark-background" style="color: #fff;">Style: Horizontal plain (on dark background)</h2>
         <pfe-tabs>
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
 
@@ -303,21 +305,21 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
 
@@ -326,54 +328,144 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
+
+
+        <h2 id="style-vertical-default-on-dark-background" style="color: #fff;">Style: Vertical default (on dark background)</h2>
+        <pfe-tabs vertical  pfe-tab-align="center" >
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 1 with more text so it wraps to two lines</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 1</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 2 with a few more words</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 2</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 3</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 3</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+        </pfe-tabs>
+
+        <h2 id="style-vertical-wind-on-dark-background" style="color: #fff;">Style: Vertical wind (on dark background)</h2>
+        <pfe-tabs vertical pfe-variant="wind" pfe-tab-align="center" >
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 1 with more text so it wraps to two lines</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 1</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 2 with a few more words</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 2</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 3</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 3</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+        </pfe-tabs>
+
+
+        <h2 id="style-vertical-earth-on-dark-background" style="color: #fff;">Style: Vertical earth (on dark background)</h2>
+        <pfe-tabs vertical pfe-variant="earth" pfe-tab-align="center" >
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 1 with more text so it wraps to two lines</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 1</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 2 with a few more words</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 2</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">
+            <h3 class="subheading">Tab 3</h3>
+          </pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 3</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
+        </pfe-tabs>
+ 
       </section>
-    </div>
+    </div></div>
 
 <!-- End Dark -->
 
 <!-- Saturated -->
 
 
-    <div class="saturated-background">
-      <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col">
+    <div class="saturated-background"><div class="inner">
+      <section class="">
 
         <h2 id="style-horizontal-earth-on-saturated-background" style="color: #fff;">Style: Horizontal earth (on saturated background)</h2>
         <pfe-tabs pfe-variant="earth">
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
 
@@ -382,67 +474,66 @@
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
       </section>
-    </div>
+    </div></div>
 
 <!-- End Saturated -->
-
-    <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col">
-      <div>
+     <section  >
+      <div class="inner">
         <h2 id="selected-index">Selected Index</h2>
         <pfe-tabs pfe-variant="earth" selected-index="1">
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <a href="https://redhat.com">https://redhat.com</a>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
           <pfe-tab role="heading" slot="tab">Tab 3</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 3</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
         </pfe-tabs>
       </div>
     </section>
 
-    <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col pfe-m-all-6-col-on-xl">
-      <div>
+    <section >
+      <div class="inner">
         <h2 id="tab-history">Tab history</h2>
         <pfe-tabs id="my-tabs" pfe-tab-history>
           <pfe-tab role="heading" slot="tab" id="tab1">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <a href="https://www.redhat.com">https://www.redhat.com</a>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab" id="tab2">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab" id="tab2">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
             <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -455,16 +546,16 @@
         </pfe-tabs>
       </div>
 
-      <div>
+      <div class="inner">
         <h2 id="testing-tab-history-with-hash-anchors">Testing tab history with hash anchors</h2>
         <pfe-tabs id="tabs-and-has-test" pfe-tab-history>
           <pfe-tab role="heading" slot="tab" id="tabHash1">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 1</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <a href="https://www.redhat.com">https://www.redhat.com</a>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab" id="tabHash2">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab" id="tabHash2">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h2>Content 2</h2>
             <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -478,23 +569,23 @@
       </div>
     </section>
 
-    <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col">
-      <div>
+    <section  >
+      <div class="inner">
         <h2 id="tabs-in-tabs">Tabs in tabs</h2>
         <pfe-tabs pfe-variant="earth" >
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <div class="pfe-l-grid pfe-m-gutters pfe-m-all-6-col-on-xl pfe-m-all-12-col-on-xs">
               <pfe-card class="pfe-m-3-col-on-xl pfe-l-grid-fill-height">
-                <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
+                <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consetetur sadipscing elitr, sed diam nonumy eirmod tempor.</p>
               </pfe-card>
               <pfe-tabs pfe-variant="wind" id="subtabset" class="pfe-m-8-col-on-xl pfe-m-startat-5-col-on-xl">
                 <pfe-tab role="heading" slot="tab">Sub Tab 1</pfe-tab>
                 <pfe-tab-panel role="region" slot="panel">
                   <h2>Content for Sub Tab 1</h2>
-                  <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+                  <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
                 </pfe-tab-panel>
-                <pfe-tab role="heading" slot="tab">Sub Tab 2</pfe-tab>
+                <pfe-tab role="heading" slot="tab">Sub Tab 2 has a few more words</pfe-tab>
                 <pfe-tab-panel role="region" slot="panel">
                   <h2>Content for Sub Tab 2</h2>
                   <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -502,7 +593,7 @@
               </pfe-tabs>
             </div>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h1>Tab 2 Content</h1>
             <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -511,17 +602,17 @@
       </div>
     </section>
 
-    <section class="pfe-l-grid pfe-m-gutters pfe-m-all-12-col pfe-m-all-6-col-on-xl">
-      <div>
+    <section  >
+      <div class="inner">
         <h2 id="dynamically-adding-a-tab-and-tab-panel">Dynamic tabset injection</h2>
         <pfe-tabs pfe-variant="earth" id="dynamic">
           <pfe-tab role="heading" slot="tab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h4>Tab 1</h4>
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel">
             <h4>Tab 2</h4>
             <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -531,15 +622,15 @@
         <button id="addTabAndPanelBtn">Add a Tab and Tab Panel</button>
       </div>
 
-      <div>
+      <div class="inner">
         <h2 id="add-text-to-tab-and-panel">Dynamic text added to tab and panel</h2>
         <pfe-tabs pfe-variant="earth" id="dynamic-text">
           <pfe-tab role="heading" slot="tab" id="dynamicTextTab">Tab 1</pfe-tab>
           <pfe-tab-panel role="region" slot="panel" id="dynamicTextPanel">
             <h4>Tab 1</h4>
-            <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
           </pfe-tab-panel>
-          <pfe-tab role="heading" slot="tab">Tab 2</pfe-tab>
+          <pfe-tab role="heading" slot="tab">Tab 2 has a few more words</pfe-tab>
           <pfe-tab-panel role="region" slot="panel" id="dynamicTextPanel">
             <h4>Tab 2</h4>
             <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -561,6 +652,7 @@
         </pfe-card>
       </div>
     </section>
+  
 
     <script>
       var jumpLinksMenu = document.querySelector("#jump-links");
@@ -618,6 +710,7 @@
       });
 
     </script>
+
   </body>
 
 </html>

--- a/elements/pfe-tabs/demo/index.html
+++ b/elements/pfe-tabs/demo/index.html
@@ -138,6 +138,11 @@
             <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
           </pfe-tab-panel>
+          <pfe-tab role="heading" slot="tab">Tab 4</pfe-tab>
+          <pfe-tab-panel role="region" slot="panel">
+            <h2>Content 4</h2>
+            <p>Lorem ipsum dolor sit amet, <a href="#">link</a> consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu strud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </pfe-tab-panel>
         </pfe-tabs>
       </div>
 

--- a/elements/pfe-tabs/src/pfe-tab-panel.scss
+++ b/elements/pfe-tabs/src/pfe-tab-panel.scss
@@ -17,13 +17,14 @@ $LOCAL-VARIABLES: (
 
 :host {
   display: block;
+  color: pfe-broadcasted(text);
 
   @at-root #{&}(:focus) {
     outline: none;
   }
 
   ::slotted(*) {
-    color: pfe-broadcasted(text);
+    
   }
   [tabindex] {
     display: flex;

--- a/elements/pfe-tabs/src/pfe-tab-panel.scss
+++ b/elements/pfe-tabs/src/pfe-tab-panel.scss
@@ -30,15 +30,6 @@ $LOCAL-VARIABLES: (
     height: 100%;
   }
 
- //updated saturated styles
-  @at-root #{&}([pfe-variant="earth"][on="saturated"]) .container {
-    //background-color: pfe-var(surface--lightest);
-    //color: pfe-var(text);
-  }
-  @at-root #{&}([pfe-variant="earth"][on="saturated"]) ::slotted(*) {
-    //color: pfe-var(text);
-}
-
   .container {
     margin: 0;
     width: 100%;

--- a/elements/pfe-tabs/src/pfe-tab-panel.scss
+++ b/elements/pfe-tabs/src/pfe-tab-panel.scss
@@ -3,11 +3,19 @@
 $LOCAL: tabs;
 
 $LOCAL-VARIABLES: (
-  focus:  pfe-var(link)
+
+  focus:  pfe-var(link),
+  panel: ( // to avoid collisions with tab header
+      BackgroundColor: transparent,
+      Padding:         pfe-var(container-spacer),
+  )
 );
+// DEBUGGING
+//@include pfe-local-debug; // preview local variables in pfe-tab-panel.css
+
+////////////////////////////////
 
 :host {
-
   display: block;
 
   @at-root #{&}(:focus) {
@@ -24,22 +32,32 @@ $LOCAL-VARIABLES: (
 
  //updated saturated styles
   @at-root #{&}([pfe-variant="earth"][on="saturated"]) .container {
-    background-color: pfe-var(surface--lightest);
-    color: pfe-var(text);
+    //background-color: pfe-var(surface--lightest);
+    //color: pfe-var(text);
   }
   @at-root #{&}([pfe-variant="earth"][on="saturated"]) ::slotted(*) {
-    color: pfe-var(text);
+    //color: pfe-var(text);
 }
 
   .container {
     margin: 0;
     width: 100%;
-    padding: pfe-local(Padding, $region: panel, $fallback: pfe-var(container-spacer) 0);
-
+    background-color: pfe-local(BackgroundColor, $region: panel);
     border-top:    pfe-local(BorderTop, 0, $region: panel);
     border-right:  pfe-local(BorderRight, 0, $region: panel);
     border-bottom: pfe-local(BorderBottom, 0, $region: panel);
     border-left:   pfe-local(BorderLeft, 0, $region: panel);
+
+    padding: pfe-local(Padding, $region: panel); //16px
+    @media screen and (min-width: pfe-breakpoint(md) ) {
+      padding: calc(#{pfe-local(Padding, $region: panel)} * 2);
+    }
+    @media screen and (min-width: pfe-breakpoint(lg) ) {
+      padding: calc(#{pfe-local(Padding, $region: panel)} * 3);
+    }
+    @media screen and (min-width: pfe-breakpoint(xl) ) {
+      padding: calc(#{pfe-local(Padding, $region: panel)} * 4);
+    }
 
     @include pfe-clearfix;
     @include browser-query(ie11) {
@@ -54,26 +72,21 @@ $LOCAL-VARIABLES: (
 /// HORIZONTAL
 /// ===========================================================================
 :host([pfe-variant="earth"]) {
-  --pfe-tabs__panel--Padding: calc(#{pfe-var(container-spacer)} * 2);
 
   @include browser-query(ie11) {
     .container {
+      background-color: pfe-fetch(surface--lightest);
       padding: 1em;
       border-right: 1px solid pfe-fetch(surface--border);
       border-bottom: 1px solid pfe-fetch(surface--border);
       border-left: 1px solid pfe-fetch(surface--border);
     }
   }
+
 }
 :host([vertical][pfe-variant="earth"]) {
-  @include pfe-print-local((
-    panel: (
-      BorderTop:    0,
-      BorderRight:  0,
-      BorderBottom: 0,
-      BorderLeft:   pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border)
-    )
-  ));
+    border-top: 0px;
+    border-left:   pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
 }
 
 /// ===========================================================================
@@ -82,7 +95,9 @@ $LOCAL-VARIABLES: (
 
 @media screen and (min-width: #{pfe-breakpoint(md)}) {
   :host([pfe-variant="wind"][vertical]) {
-    --pfe-tabs__panel--Padding: #{pfe-var(container-spacer)} 0 #{pfe-var(container-spacer)} calc(#{pfe-var(container-spacer)} * 2);
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-right: 0;
 
     @include browser-query(ie11) {
       .container {
@@ -106,3 +121,34 @@ $LOCAL-VARIABLES: (
 :host([hidden]) {
   display: none;
 }
+
+/// ===========================================================================
+/// CONTEXTS: DARK & SATURATED
+/// ===========================================================================
+/// In dark & saturated contexts, we override the local color vars
+
+
+:host {
+  @at-root #{&}([pfe-variant="earth"][on="dark"]) {
+    --pfe-tabs__panel--BackgroundColor: #{pfe-var(surface--darkest)};
+  }
+}
+
+:host {
+  @at-root #{&}([pfe-variant="earth"][on="saturated"]) {
+    --pfe-tabs__panel--BackgroundColor: #{pfe-var(surface--lightest)};
+
+      ::slotted(*) {
+        color: pfe-var(text);
+      }
+  }
+ 
+}
+
+//VERTICAL
+:host {
+  @at-root #{&}([pfe-variant="earth"][vertical]) {
+    --pfe-tabs__panel--BorderTop: 0;
+  }
+}
+

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -4,22 +4,35 @@ $LOCAL: tabs;
 
 $LOCAL-VARIABLES: (
   BackgroundColor:       transparent,
-  Color:                 pfe-var(text--muted),
-  link:                  pfe-var(link),
-  text--hover:           #151515,
-  focus:                 pfe-var(link--focus),
-  highlight:             pfe-var(ui-accent),
-  BorderWidth--hover:    pfe-var(surface--border-width--active),
-  BorderColor--hover:    pfe-var(surface--base),
   BackgroundColor--dark: #3c3f42,
+  Color:                 pfe-var(text--muted),
+  Color--focus:          #151515,
+  BorderColor:           pfe-var(ui-accent),
+  BorderColor--hover:    pfe-var(surface--base),
+  BorderWidth:           pfe-var(surface--border-width--active),
+  FontSize:              pfe-var(font-size),
+  PaddingTop:            pfe-var(container-padding),
+  PaddingRight:          calc(#{pfe-var(container-padding)} * 2),
+  PaddingBottom:         pfe-var(container-padding),
+  PaddingLeft:           calc(#{pfe-var(container-padding)} * 2),
+);
+
+// TODO: These will be deprecated at 1.0  
+$backwards-compatibility: (
+  focus:                 pfe-local(Color--focus), 
+  highlight:             pfe-local(BorderColor),
   tab: (
-    FontSize:            pfe-var(font-size),
-    PaddingTop:          pfe-var(container-padding),
-    PaddingRight:        calc(#{pfe-var(container-padding)} * 2),
-    PaddingBottom:       pfe-var(container-padding),
-    PaddingLeft:         calc(#{pfe-var(container-padding)} * 2),
+    FontSize:            pfe-local(FontSize),
+    PaddingTop:          pfe-local(PaddingTop),
+    PaddingRight:        pfe-local(PaddingRight),
+    PaddingBottom:       pfe-local(PaddingBottom),
+    PaddingLeft:         pfe-local(PaddingLeft),
   )
 );
+$LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
+
+// Uncomment to preview local variables in pfe-tab.css:
+//@include pfe-local-debug;
 
 /// ===========================================================================
 /// HORIZONTAL TAB ORIENTATION
@@ -42,8 +55,7 @@ $LOCAL-VARIABLES: (
 
   // Inner style
   background-color: pfe-local(BackgroundColor);
-  color: pfe-local(Color);  // @todo replace with pfe(text-muted) in Kendall's color story
-
+  color: pfe-local(Color);
   cursor: pointer;
   text-align: pfe-local(TextAlign, center, $region: tab);
 
@@ -61,9 +73,9 @@ $LOCAL-VARIABLES: (
   }
 
   @at-root #{&}(:hover) {
-    --pfe-tabs--Color:  #{pfe-local(text--hover)};
+    --pfe-tabs--Color:  #{pfe-local(focus)};
     @include browser-query(ie11) {
-      color: pfe-fetch(text--hover);
+      color: pfe-fetch(focus);
     }
   }
 
@@ -74,18 +86,18 @@ $LOCAL-VARIABLES: (
   }
 
   @at-root #{&}([on="dark"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
     @include browser-query(ie11) {
       color: pfe-var(text--muted);
     }
   }
 
   @at-root #{&}([aria-selected="true"]) {
-    --pfe-tabs--Color: #{pfe-local(text--hover)};
+    --pfe-tabs--Color: #{pfe-local(focus)};
     --pfe-tabs__tab--BorderColor: transparent;
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
     @include browser-query(ie11) {
-      border-bottom: pfe-fetch(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-fetch(ui-accent);
+      border-bottom: pfe-fetch(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(ui-accent);
     }
   }
 }
@@ -114,7 +126,7 @@ $LOCAL-VARIABLES: (
 
   :host([vertical][aria-selected="true"]) {
     --pfe-tabs__tab--BorderTopColor: transparent;
-    --pfe-tabs__tab--BorderRight:    #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    --pfe-tabs__tab--BorderRight:    #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
     --pfe-tabs__tab--BorderBottom:   0;
 
     @include browser-query(ie11) {
@@ -169,19 +181,19 @@ $LOCAL-VARIABLES: (
 :host{
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:first-of-type) {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth--hover) pfe-var(surface--border-style) pfe-local(highlight);
+      border-bottom: pfe-local(BorderWidth) pfe-var(surface--border-style) pfe-local(highlight);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]) {
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:hover) {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth--hover) pfe-var(surface--border-style) pfe-local(highlight);
+      border-bottom: pfe-local(BorderWidth) pfe-var(surface--border-style) pfe-local(highlight);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:first-of-type):hover {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-bottom: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type) {
@@ -191,7 +203,7 @@ $LOCAL-VARIABLES: (
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type):hover {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-bottom: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
     }
   }
 }
@@ -205,35 +217,35 @@ $LOCAL-VARIABLES: (
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
     @include browser-query(ie11) {
-      border-bottom:  pfe-fetch(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-fetch(BorderColor--hover);
+      border-bottom:  pfe-fetch(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(BorderColor--hover);
     }
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} transparent;
-    --pfe-tabs__tab--BorderLeft:  #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
+    --pfe-tabs__tab--BorderLeft:  #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
     padding-left:                 calc(#{pfe-var(container-padding)} - 2px);
     @include browser-query(ie11) {
       border-right:  0;
-      border-left:   pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-local(highlight);
+      border-left:   pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(highlight);
       padding-left:  10px;
       border-bottom: 0 !important;
     }
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} transparent;
+    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} transparent;
+    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
     --pfe-tabs__tab--BorderBottom: 0;
-    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
     padding-left: calc(#{pfe-var(container-padding)} - 2px);
     @include browser-query(ie11) {
       border-right:  0;
       border-bottom: 0;
       padding-left:  10px;
-      border-left:   pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-left:   pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
     }
   }
 }
@@ -250,10 +262,10 @@ $LOCAL-VARIABLES: (
     }
   }
   @at-root #{&}([on="saturated"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
     --pfe-tabs__tab--BorderBottom: 0 !important;
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--lightest)} !important;
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--lightest)} !important;
   }
   @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]) {
     color: pfe-var(text--on-saturated) !important;
@@ -275,10 +287,10 @@ $LOCAL-VARIABLES: (
   --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
 }
 :host([pfe-variant="earth"][on="saturated"]:hover) {
-  --pfe-tabs--Color: #{pfe-local(text--hover)};
+  --pfe-tabs--Color: #{pfe-local(focus)};
 }
 :host([pfe-variant="earth"][on="saturated"][aria-selected="true"]) {
-  --pfe-tabs--Color: #{pfe-local(text--hover)};
+  --pfe-tabs--Color: #{pfe-local(focus)};
 }
 
 /// ===========================================================================
@@ -291,7 +303,7 @@ $LOCAL-VARIABLES: (
     tab: (
       BorderLeft:    pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border),
       BorderBottom:  pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border),
-      BorderTop:     pfe-local(BorderWidth--hover) pfe-var(ui--border-style) transparent,
+      BorderTop:     pfe-local(BorderWidth) pfe-var(ui--border-style) transparent,
     )
   );
   @include pfe-print-local($variantEarth);
@@ -303,17 +315,17 @@ $LOCAL-VARIABLES: (
 }
 
 :host([pfe-variant="earth"][aria-selected="false"]:hover){
-  --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
+  --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
   @include browser-query(ie11) {
-    border-top: pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover) !important;
-    color: pfe-fetch(text--hover);
+    border-top: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover) !important;
+    color: pfe-fetch(focus);
   }
 }
 
 :host([pfe-variant="earth"][aria-selected="true"]) {
   --pfe-tabs--BackgroundColor:   #{pfe-var(surface--lightest)};
-  //--pfe-tabs--Color:             pfe-local(text--hover); // @todo replace with pfe(text-muted) in Kendall's color story
-  --pfe-tabs__tab--BorderTop:    #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+  //--pfe-tabs--Color:             pfe-local(focus); // @todo replace with pfe(text-muted) in Kendall's color story
+  --pfe-tabs__tab--BorderTop:    #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
   --pfe-tabs__tab--BorderBottom: 0;
   --pfe-tabs__tab--BorderLeft:   #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
 
@@ -321,7 +333,7 @@ $LOCAL-VARIABLES: (
     color:            pfe-fetch(ui-disabled--text); // @todo replace with pfe(text-muted) in Kendall's color story
     background-color: #fff;
     border-left:      pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) #d2d2d2;
-    border-top:       pfe-local(BorderWidth--hover) pfe-fetch(ui--border-style) pfe-local(highlight);
+    border-top:       pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
     border-bottom:    0;
   }
 }
@@ -358,7 +370,7 @@ $LOCAL-VARIABLES: (
   }
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type) {
     border-top:  pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
-    border-left: pfe-local(BorderWidth--hover) pfe-var(ui--border-style) transparent !important;
+    border-left: pfe-local(BorderWidth) pfe-var(ui--border-style) transparent !important;
     @include browser-query(ie11) {
       border-top: 1px pfe-fetch(ui--border-style) transparent !important;
     }
@@ -366,7 +378,7 @@ $LOCAL-VARIABLES: (
   :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
     --pfe-tabs__tab--BorderTop:    #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
     --pfe-tabs__tab--BorderRight:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--lightest)};
-    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
     margin-right: -1px;
 
     @include browser-query(ie11) {
@@ -379,7 +391,7 @@ $LOCAL-VARIABLES: (
   :host([vertical][pfe-variant="earth"][aria-selected="false"]) {
     --pfe-tabs__tab--BorderRight:  0;
     --pfe-tabs__tab--BorderBottom: 0;
-    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth--hover)} #{pfe-var(ui--border-style)} transparent;
+    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
 
     @include browser-query(ie11) {
       border-right:  1px solid pfe-fetch(surface--border);
@@ -389,20 +401,20 @@ $LOCAL-VARIABLES: (
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
+    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
     --pfe-tabs__tab--BorderTop:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
     @include browser-query(ie11) {
-      border-left: pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
       border-top:  pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border) !important;
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type:hover) {
     --pfe-tabs__tab--BorderTop:  #{pfe-var(ui--border-style)} #{pfe-var(ui--border-style)} transparent;
-    border-left: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important;
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important;
     @include browser-query(ie11) {
       border-top:  1px pfe-fetch(ui--border-style) transparent !important;
-      border-left: pfe-local(BorderWidth--hover) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
     }
   }
   :host([vertical][pfe-variant="earth"][aria-selected="true"]:last-of-type) {
@@ -431,7 +443,7 @@ $LOCAL-VARIABLES: (
   }
   @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="dark"]) {
     --pfe-tabs--Color: #{pfe-var(surface--lightest)};
-    --pfe-tabs--BackgroundColor: #{pfe-local(Color--hover)};
+    --pfe-tabs--BackgroundColor: #{pfe-local(focus)};
     border-bottom: pfe-var(ui--border-width) pfe-var(surface--border-style) pfe-var(surface--darkest);
     @include browser-query(ie11) {
         color: pfe-fetch(surface--lightest) !important;
@@ -441,7 +453,7 @@ $LOCAL-VARIABLES: (
     border-bottom: 0;
   }
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-    --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
+    --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
     --pfe-tabs--Color: #{pfe-var(text--on-dark)};
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
@@ -485,7 +497,7 @@ $LOCAL-VARIABLES: (
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
     color: pfe-var(surface--lightest);
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth--hover)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -244,6 +244,12 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// ===========================================================================
 /// EARTH TAB VARIANTS
 /// ===========================================================================
+:host(:not([vertical])[pfe-variant="earth"]:first-of-type) {
+    border-left-color: transparent;
+}
+:host(:not([vertical])[pfe-variant="earth"]:last-of-type) {
+    border-right-color: transparent;
+}
 :host {
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"]) {
     background-color: pfe-local(BackgroundColor--inactive); //@todo update to use opacity
@@ -269,15 +275,15 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
-  @at-root #{&}([pfe-variant="earth"][aria-selected="true"]) {
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"]:nth-of-type(n)) {
     background-color: pfe-var(surface--lightest);
     border-bottom: 0;
-    border-left: solid 1px #{pfe-var(surface--border)};
-    border-right: solid 1px #{pfe-var(surface--border)};
+    border-left-color: pfe-var(surface--border);
+    border-right-color: pfe-var(surface--border);
     border-top: solid pfe-local(highlight) pfe-local(BorderWidth);
 
     @include browser-query(ie11) {
-      color: pfe-fetch(text--muted); // @todo replace with pfe(text-muted) in Kendall's color story
+      color: pfe-fetch(text--muted); 
       background-color: pfe-fetch(surface--lightest);
       border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
       border-top: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
@@ -293,12 +299,6 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 }
-:host(:not([vertical])[pfe-variant="earth"]:first-of-type) {
-    border-left: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent;
-  }
-:host(:not([vertical])[pfe-variant="earth"]:last-of-type) {
-    border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent;
-  }
 
 
 /// ===========================================================================

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -3,36 +3,34 @@
 $LOCAL: tabs;
 
 $LOCAL-VARIABLES: (
-  BackgroundColor:       transparent,
-  BackgroundColor--dark: #3c3f42,
-  Color:                 pfe-var(text--muted),
-  Color--focus:          #151515,
-  BorderColor:           pfe-var(ui-accent),      // active is bright
-  BorderColor--hover:    pfe-var(surface--base),  // hover is gray
-  BorderWidth:           pfe-var(ui--border-width--active),
-  FontSize:              pfe-var(font-size),
-  PaddingTop:            pfe-var(container-padding),
-  PaddingRight:          calc(#{pfe-var(container-padding)} * 2),
-  PaddingBottom:         pfe-var(container-padding),
-  PaddingLeft:           calc(#{pfe-var(container-padding)} * 2),
+  BackgroundColor:           transparent,
+  BackgroundColor--inactive: pfe-var(surface--lighter),
+  Color:                     pfe-var(text--muted),
+  Color--focus:              #151515,
+  BorderColor:               pfe-var(ui-accent),      // active is bright
+  BorderColor--hover:        pfe-var(surface--base),  // hover is gray
+  BorderWidth:               pfe-var(ui--border-width--active),
+  tab: ( // to avoid collisions with panel
+    FontSize:                pfe-var(font-size),
+    PaddingTop:              pfe-var(container-padding),
+    PaddingRight:            calc(#{pfe-var(container-padding)} * 2),
+    PaddingBottom:           pfe-var(container-padding),
+    PaddingLeft:             calc(#{pfe-var(container-padding)} * 2),
+  )
 );
 
 // TODO: These will be deprecated at 1.0  
 $backwards-compatibility: (
   focus:                 pfe-local(Color--focus), 
   highlight:             pfe-local(BorderColor),
-  tab: (
-    FontSize:            pfe-local(FontSize),
-    PaddingTop:          pfe-local(PaddingTop),
-    PaddingRight:        pfe-local(PaddingRight),
-    PaddingBottom:       pfe-local(PaddingBottom),
-    PaddingLeft:         pfe-local(PaddingLeft),
-  )
 );
 $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 
-// Uncomment to preview local variables in pfe-tab.css:
-//@include pfe-local-debug;
+// DEBUGGING
+//@include pfe-local-debug; // preview local variables in pfe-tab.css
+//:host {
+//  outline: none;
+//}
 
 /// ===========================================================================
 /// HORIZONTAL TAB ORIENTATION
@@ -43,10 +41,11 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   display: block;
   margin: pfe-local(Margin, $region: tab, $fallback: 0 0 -1px);
   // Padding
-  padding: pfe-local(PaddingTop, $region: tab) 
-           pfe-local(PaddingRight, $region: tab) 
-           pfe-local(PaddingBottom, $region: tab) 
-           pfe-local(PaddingLeft, $region: tab);
+  padding: 
+      pfe-local(PaddingTop, $region: tab) 
+      pfe-local(PaddingRight, $region: tab) 
+      pfe-local(PaddingBottom, $region: tab) 
+      pfe-local(PaddingLeft, $region: tab);
   // Borders         
   border-style: pfe-var(ui--border-style);
   border-width: pfe-var(ui--border-width);
@@ -60,9 +59,10 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 
   // Exposing this for customization
   text-transform: pfe-local(TextTransform, $region: tab, $fallback: none);
-  font-family:  pfe-var(font-family);
-  font-weight:  pfe-var(font-weight--normal);
-  font-size:    pfe-local(FontSize, $region: tab);
+  font-family: pfe-var(font-family);
+  font-weight: pfe-var(font-weight--normal);
+  font-size: pfe-local(FontSize, $region: tab);
+
 
   .pfe-tab * {
     font-size: inherit;
@@ -72,8 +72,9 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   }
 
   @at-root #{&}(:hover) {
-    --pfe-tabs--Color:  #{pfe-local(focus)};
+    color: pfe-local(focus);
     border-bottom-color: pfe-var(surface--base);
+
     @include browser-query(ie11) {
       color: pfe-fetch(focus);
     }
@@ -83,11 +84,11 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   // TODO: ShadyCSS falls flat on this pseudo element in IE11 `:host(:focus-visible)`, add back when we drop ShadyCSS
   @at-root #{&}(:focus) {
     color: pfe-var(text);
-    outline: 0;
   }
 
   @at-root #{&}([on="dark"][aria-selected="false"][pfe-variant="wind"]:hover) {
     border-bottom-color: pfe-var(surface--base);
+
     @include browser-query(ie11) {
       color: pfe-var(text--muted);
     }
@@ -96,6 +97,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   @at-root #{&}([aria-selected="true"]) {
     color: pfe-local(focus);
     border-bottom-color: pfe-local(highlight);
+
     @include browser-query(ie11) {
       border-bottom: pfe-fetch(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(ui-accent);
     }
@@ -110,19 +112,19 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   :host([vertical]) {
     border-bottom-color: transparent;
     border-bottom-width: 0;
-    border-left-color: pfe-var(ui--border);
+    border-left-color: pfe-var(surface--border);
     border-left-width: pfe-var(ui--border-width);
-    
+
     --pfe-tabs--Margin: 0 -1px 0 0;
     padding: pfe-var(container-padding);
 
-      @include browser-query(ie11) {
-        border: 1px solid transparent;
-        border-bottom: 0;
-        border-right: 0;
-        margin: 0 -1px 0 0;
-        padding-left: 12px;
-      }
+    @include browser-query(ie11) {
+      border: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent;
+      border-bottom: 0;
+      border-right: 0;
+      margin: 0 #{pfe-fetch(ui--border-width) * -1} 0 0;
+      padding-left: pfe-fetch(container-padding);
+    }
   }
 
   :host([vertical][aria-selected="true"]) {
@@ -130,10 +132,10 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     border-left-width: 3px;
 
     @include browser-query(ie11) {
-      color:            $pfe-color--black;
+      color: $pfe-color--black;
       border-top-color: transparent;
-      border-right:     pfe-fetch(ui--border-width--active) pfe-var(ui--border-style) pfe-var(ui-accent);
-      border-bottom:    0;
+      border-right: pfe-fetch(ui--border-width--active) pfe-var(ui--border-style) pfe-var(ui-accent);
+      border-bottom: 0;
     }
   }
 }
@@ -141,12 +143,12 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 :host([pfe-variant="earth"]) {
   @include browser-query(ie11) {
     background-color: pfe-fetch(surface--lighter);
-    color:            pfe-fetch(text--muted);  
+    color: pfe-fetch(text--muted);
   }
 }
 
 :host([pfe-variant="wind"]) .pfe-tab,
-:host([pfe-variant="earth"][vertical]) .pfe-tab{
+:host([pfe-variant="earth"][vertical]) .pfe-tab {
   display: inline-block !important;
 }
 
@@ -154,29 +156,32 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// WIND TAB VARIANTS / DEFAULT
 /// ===========================================================================
 
-:host{
+:host {
+  text-align: left;
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:first-of-type) {
     @include browser-query(ie11) {
-      border-bottom-color: pfe-local(BorderColor--hover);
+      border-bottom-color: pfe-local(highlight);
     }
   }
- //@at-root #{&}([pfe-variant="wind"][aria-selected="true"]) {
- //}
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:hover) {
     @include browser-query(ie11) {
       border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:first-of-type):hover {
     @include browser-query(ie11) {
       border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type) {
     @include browser-query(ie11) {
-      border-bottom: 1px solid transparent;
+      border-bottom: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent;
     }
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type):hover {
     @include browser-query(ie11) {
       border-bottom-color: pfe-local(BorderColor--hover);
@@ -184,159 +189,134 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   }
 }
 
-:host{
-  @at-root #{&}([vertical][pfe-variant="wind"]){
-    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+:host {
+  @at-root #{&}([vertical][pfe-variant="wind"]) {
+    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
     text-align: left !important;
+
     @include browser-query(ie11) {
-      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(ui--border);
+      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
     }
   }
-  @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:hover){
+
+  @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:hover) {
     border-bottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
+
     @include browser-query(ie11) {
-      border-bottom:  pfe-fetch(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(BorderColor--hover);
+      border-bottom: pfe-fetch(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(BorderColor--hover);
     }
   }
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]){
-    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
-    border-Left:  #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(highlight)};
-    padding-left:                 calc(#{pfe-var(container-padding)} - 2px);
+
+  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]) {
+    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(highlight)};
+    padding-left: calc(#{pfe-var(container-padding)} - 2px);
+
     @include browser-query(ie11) {
-      border-right:  0;
-      border-left:   pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
-      padding-left:  10px;
+      border-right: 0;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
+      padding-left: 10px;
       border-bottom: 0 !important;
     }
   }
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]){
-    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+
+  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]) {
+    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
   }
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover){
-    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+
+  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover) {
+    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
     border-Bottom: 0;
-    border-Left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
     padding-left: calc(#{pfe-var(container-padding)} - 2px);
+
     @include browser-query(ie11) {
-      border-right:  0;
+      border-right: 0;
       border-bottom: 0;
-      padding-left:  10px;
-      border-left:   pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(BorderColor--hover);
+      padding-left: 10px;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(BorderColor--hover);
     }
   }
 }
 
-/// ===========================================================================
-/// WIND TAB VARIANTS / saturated
-/// ===========================================================================
 
-:host {
-  @at-root #{&}([on="saturated"][pfe-variant="wind"]) {
-    @include browser-query(ie11) {
-      color: pfe-fetch(text) !important;
-      background-color: transparent;
-    }
-  }
-  @at-root #{&}([on="saturated"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
-    --pfe-tabs__tab--BorderBottom: 0 !important;
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--lightest)} !important;
-  }
-  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]) {
-    color: pfe-var(text--on-saturated) !important;
-    @include browser-query(ie11) {
-      color: pfe-fetch(text) !important;
-    }
-  }
-  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]:last-of-type) {
-    @include browser-query(ie11) {
-      border-left: 0 !important;
-    }
-  }
-}
-
-/// ===========================================================================
-/// EARTH TAB VARIANTS / saturated
-/// ===========================================================================
-:host([pfe-variant="wind"][on="saturated"]) {
-  color:  pfe-var(text--on-saturated);
-}
-:host([pfe-variant="earth"][on="saturated"]:hover) {
-  color:  pfe-local(focus);
-}
-:host([pfe-variant="earth"][on="saturated"][aria-selected="true"]) {
-  color:  pfe-local(focus);
-}
 
 /// ===========================================================================
 /// EARTH TAB VARIANTS
 /// ===========================================================================
+:host {
+  @at-root #{&}([pfe-variant="earth"][aria-selected="false"]) {
+    background-color: pfe-local(BackgroundColor--inactive); //@todo update to use opacity
+    border-color: pfe-var(surface--border);
+    border-top-width: pfe-local(BorderWidth);
+    border-top-color: transparent;
+    border-bottom-color: pfe-local(BorderColor--hover);
+    border-bottom-width: pfe-var(ui--border-width);
 
-// horizontal earth unselected item
-:host([pfe-variant="earth"][aria-selected="false"]) {
-    background-color:     pfe-var(surface--lighter);
-    border-color:         pfe-var(ui--border);
-    border-top-width:     pfe-local(BorderWidth);
-    border-top-color:     transparent;
-    border-bottom-color:  transparent;
- 
-  @include browser-query(ie11) {
-    border-top:    3px solid pfe-fetch(surface--lighter);
-    border-bottom: pfe-var(ui--border-width) solid pfe-fetch(ui--border);
-    border-left:   pfe-var(ui--border-width) solid pfe-fetch(ui--border);
+    @include browser-query(ie11) {
+      border-top: 3px solid pfe-fetch(surface--lighter);
+      border-bottom: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
+      border-left: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
+    }
   }
-}
-// horizontal earth hover on item
-:host([pfe-variant="earth"][aria-selected="false"]:hover){
-  border-top-color:     pfe-local(BorderColor);
-  @include browser-query(ie11) {
-    border-top-color:     pfe-local(BorderColor) !important;
-    color: pfe-fetch(focus);
-  }
-}
-// horizontal earth active item
-:host([pfe-variant="earth"][aria-selected="true"]) {
-  background-color:  pfe-var(surface--lightest);
-  border-bottom:     0;
-  border-left:       solid 1px #{pfe-var(ui--border)};
-  border-right:      solid 1px #{pfe-var(ui--border)};
-  border-top:        solid pfe-local(highlight) pfe-local(BorderWidth);
 
-  @include browser-query(ie11) {
-    color:            pfe-fetch(text--muted); // @todo replace with pfe(text-muted) in Kendall's color story
-    background-color: #fff;
-    border-left:      pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) #d2d2d2;
-    border-top:       pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
-    border-bottom:    0;
-  }
-}
-:host([pfe-variant="earth"][aria-selected="false"]:first-of-type) {
-  border-left: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
-}
-:host([pfe-variant="earth"][aria-selected="true"]:last-of-type) {
-  border-Right: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+  @at-root #{&}([pfe-variant="earth"][aria-selected="false"]:hover) {
+    border-top-color: pfe-local(BorderColor);
 
-  @include browser-query(ie11) {
-    border-right: 1px solid pfe-fetch(ui--border);
+    @include browser-query(ie11) {
+      border-top-color: pfe-local(BorderColor) !important;
+      color: pfe-fetch(focus);
+    }
+  }
+
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"]) {
+    background-color: pfe-var(surface--lightest);
+    border-bottom: 0;
+    border-left: solid 1px #{pfe-var(surface--border)};
+    border-right: solid 1px #{pfe-var(surface--border)};
+    border-top: solid pfe-local(highlight) pfe-local(BorderWidth);
+
+    @include browser-query(ie11) {
+      color: pfe-fetch(text--muted); // @todo replace with pfe(text-muted) in Kendall's color story
+      background-color: pfe-fetch(surface--lightest);
+      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
+      border-top: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
+      border-bottom: 0;
+    }
+  }
+  
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"]:last-of-type) {
+    border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
+
+    @include browser-query(ie11) {
+      border-right: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
+    }
   }
 }
+:host(:not([vertical])[pfe-variant="earth"]:first-of-type) {
+    border-left: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent;
+  }
+:host(:not([vertical])[pfe-variant="earth"]:last-of-type) {
+    border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent;
+  }
+
 
 /// ===========================================================================
 /// EARTH TAB VERTICAL ORIENTATION
 /// ===========================================================================
 
 @media screen and (min-width: #{pfe-breakpoint(md)}) {
-  // vertical earth unselected item
+
   :host([vertical][pfe-variant="earth"]) {
     border-top-width: pfe-var(ui--border-width);
-    border-top-color: pfe-var(ui--border);
+    border-top-color: pfe-var(surface--border);
     text-align: left;
+
     @include browser-query(ie11) {
-      border-top: pfe-var(ui--border-width) solid pfe-fetch(ui--border);
+      border-top: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
     }
   }
-  // vertical earth first child (add top border)
+
   :host([vertical][pfe-variant="earth"]:first-of-type) {
     border-top: 0;
 
@@ -344,159 +324,233 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       border-top: 0;
     }
   }
-  // vertical earth first child, inactive 
+
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type) {
-    border-top:  pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
+    border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
     border-left: pfe-local(BorderWidth) pfe-var(ui--border-style) transparent !important;
-    @include browser-query(ie11) {
-      border-top: 1px pfe-fetch(ui--border-style) transparent !important;
-    }
-  }
-  // vertical earth, active item
-  :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
-    border-top:         solid pfe-var(ui--border-width)  pfe-var(ui--border); 
-    border-left-color:  pfe-local(highlight);
-    border-left-width:  pfe-local(BorderWidth);
-    border-right-color: transparent;
-    margin-right:       -1px;
 
     @include browser-query(ie11) {
-      border-top:   pfe-var(ui--border-width) solid pfe-fetch(ui--border);
+      border-top: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent !important;
+    }
+  }
+
+  :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
+    border-top: solid pfe-var(ui--border-width) pfe-var(surface--border);
+    border-left-color: pfe-local(highlight);
+    border-left-width: pfe-local(BorderWidth);
+    border-right-color: transparent;
+    margin-right: #{pfe-fetch(ui--border-width) * -1};
+
+    @include browser-query(ie11) {
+      border-top: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
       border-right: 0;
-      border-left:  3px solid pfe-local(highlight);
+      border-left: pfe-fetch(ui--border-width--active) pfe-fetch(ui--border-style) pfe-local(highlight);
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]) {
-    border-right:  0;
+    border-right: 0;
     border-bottom: 0;
-    border-left:   #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
 
     @include browser-query(ie11) {
-      border-right:  1px solid pfe-fetch(ui--border);
+      border-right: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
       border-bottom: 0;
-      border-left:   3px solid pfe-fetch(surface--lighter);
+      border-left: pfe-fetch(ui--border-width--active) pfe-fetch(ui--border-style) pfe-fetch(surface--lighter);
     }
   }
 
-  :host([vertical][pfe-variant="earth"][aria-selected="false"]:hover){
-    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
-    border-top:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+  :host([vertical][pfe-variant="earth"][aria-selected="false"]:hover) {
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+    border-top: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+
     @include browser-query(ie11) {
-      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
-      border-top:  pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(surface--border) !important;
+      border-top: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border) !important;
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type:hover) {
-    border-top:  #{pfe-var(ui--border-style)} #{pfe-var(ui--border-style)} transparent;
-    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)} !important;
-    @include browser-query(ie11) {
-      border-top:  1px pfe-fetch(ui--border-style) transparent !important;
-      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
-    }
-  }
-  :host([vertical][pfe-variant="earth"][aria-selected="true"]:last-of-type) {
-    border-bottom: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+    border-top: #{pfe-var(ui--border-style)} #{pfe-var(ui--border-style)} transparent;
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;
 
     @include browser-query(ie11) {
-      border-bottom: 1px solid pfe-fetch(ui--border);
+      border-top: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(surface--border) !important;
+    }
+  }
+
+  :host([vertical][pfe-variant="earth"][aria-selected="true"]:last-of-type) {
+    border-bottom: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+
+    @include browser-query(ie11) {
+      border-bottom: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
     }
   }
 }
 
-/// In dark & saturated contexts, we override the local color vars
 
 /// ===========================================================================
 /// EARTH TAB VARIANTS ON DARK & SATURATED
 /// ===========================================================================
+/// In dark & saturated contexts, we override the local color vars
+ 
 
-:host{
+
+
+:host {
+
+  @at-root #{&}([pfe-variant="earth"][on="dark"]) {
+      border-right-color: pfe-var(surface--border--darker);
+      border-left-color: pfe-var(surface--border--darker);
+  }
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]) {
-    background-color: rgba(255, 255, 255, .2); //@todo, use opacity var
     --pfe-tabs--Color: #{pfe-var(text--muted--on-dark)};
+    background-color: pfe-var(surface--darker);
+
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
+
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
     border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent !important;
   }
-    // earth on saturated, selected item
-  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
-    --pfe-tabs--Color: #{pfe-var(text)};
-  }
-  // earth on dark, selected item
+
+
+  // earth on dark, active item
   @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="dark"]) {
     --pfe-tabs--Color: #{pfe-var(text--on-dark)};
-    background-color: transparent;
-    background-color: transparent;
-    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
+    background-color: pfe-var(surface--darkest);
+    border-bottom-color: pfe-var(surface--darkest);
+
     @include browser-query(ie11) {
-        color: pfe-fetch(surface--lightest) !important;
+      color: pfe-fetch(surface--lightest) !important;
     }
   }
+
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
     border-bottom: 0;
   }
+
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-    border-top: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)} !important; //replace with B8BBBE in kendalls story
-    color: #{pfe-var(text--on-dark)};
+    --pfe-tabs--Color: #{pfe-var(text--on-dark)};
+    border-top: pfe-local(BorderWidth) pfe-var(ui--border-style) pfe-var(surface--border--darker) !important;  
+
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
-    border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
+
+  //VERTICAL
+  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
+  //  border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
+  //}
+//
+  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
+  //  border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
+  //}
+//
+  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
+  //  border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
+  //}
+//
+  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:last-of-type) {
+  //  border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
+  //}
+//
+  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]:last-of-type) {
+  //  border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
+  //}
+
+  
+  
+  // SATURATED
+  @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="saturated"]) {
+    --pfe-tabs--BackgroundColor: #{pfe-var(surface--lighter)};
   }
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-    border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(ui--border);
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
+    color: pfe-local(focus);
   }
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-    border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
+  @at-root #{&}([pfe-variant="earth"][on="saturated"]:hover) {
+    color: pfe-local(focus);
   }
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:last-of-type) {
-    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
+ 
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
+    --pfe-tabs--Color: #{pfe-var(text)};
   }
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]:last-of-type) {
-    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(ui--border);
-  }
+
 }
 
 
 /// ===========================================================================
 /// WIND TAB VARIANTS ON DARK & SATURATED
 /// ===========================================================================
+ 
+:host {
+  @at-root #{&}([on="saturated"][pfe-variant="wind"]) {
+    color: pfe-var(text--on-saturated);
+    @include browser-query(ie11) {
+      color: pfe-fetch(text) !important;
+      background-color: transparent;
+    }
+  }
 
-:host{
-  text-align: left;
+  @at-root #{&}([on="saturated"][aria-selected="false"][pfe-variant="wind"]:hover) {
+    border-bottom-color: pfe-local(BorderColor--hover);
+  }
+
+  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]) {
+    color: pfe-var(text--on-saturated) !important;
+
+    @include browser-query(ie11) {
+      color: pfe-fetch(text) !important;
+    }
+  }
+
+  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]:last-of-type) {
+    @include browser-query(ie11) {
+      border-left: 0 !important;
+    }
+  }
+}
+
+
+:host {
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]) {
     --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
+
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"][on="dark"]) {
     --pfe-tabs--Color: #{pfe-var(surface--lightest)};
+
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="saturated"]) {
     --pfe-tabs--Color: #{pfe-var(text--muted--on-saturated)};
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"][on="saturated"]) {
     --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
   }
+
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
     color: pfe-var(surface--lightest);
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;  
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;
+
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
+
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
     border-bottom: 0;
   }
 }
- 

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -7,9 +7,9 @@ $LOCAL-VARIABLES: (
   BackgroundColor--dark: #3c3f42,
   Color:                 pfe-var(text--muted),
   Color--focus:          #151515,
-  BorderColor:           pfe-var(ui-accent),
-  BorderColor--hover:    pfe-var(surface--base),
-  BorderWidth:           pfe-var(surface--border-width--active),
+  BorderColor:           pfe-var(ui-accent),      // active is bright
+  BorderColor--hover:    pfe-var(surface--base),  // hover is gray
+  BorderWidth:           pfe-var(ui--border-width--active),
   FontSize:              pfe-var(font-size),
   PaddingTop:            pfe-var(container-padding),
   PaddingRight:          calc(#{pfe-var(container-padding)} * 2),
@@ -39,20 +39,19 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// ===========================================================================
 
 :host {
-
   position: relative;
   display: block;
   margin: pfe-local(Margin, $region: tab, $fallback: 0 0 -1px);
-
   // Padding
-  padding: pfe-local(PaddingTop, $region: tab) pfe-local(PaddingRight, $region: tab) pfe-local(PaddingBottom, $region: tab) pfe-local(PaddingLeft, $region: tab);
-
-  // Border
-  border-top:     pfe-local(BorderTop, $region: tab, $fallback: pfe-local(BorderWidth, $region: tab, $fallback: pfe-var(ui--border-width)) pfe-var(ui--border-style) pfe-local(BorderColor, transparent, $region: tab));
-  border-right:   pfe-local(BorderRight, $region: tab, $fallback: pfe-local(BorderWidth, $region: tab, $fallback: pfe-var(ui--border-width)) pfe-var(ui--border-style) pfe-local(BorderColor, transparent, $region: tab));
-  border-bottom:  pfe-local(BorderBottom, 0, $region: tab);
-  border-left:    pfe-local(BorderLeft, $region: tab, $fallback: pfe-local(BorderWidth, $region: tab, $fallback: pfe-var(ui--border-width)) pfe-var(ui--border-style) pfe-local(BorderColor, transparent, $region: tab));
-
+  padding: pfe-local(PaddingTop, $region: tab) 
+           pfe-local(PaddingRight, $region: tab) 
+           pfe-local(PaddingBottom, $region: tab) 
+           pfe-local(PaddingLeft, $region: tab);
+  // Borders         
+  border-style: pfe-var(ui--border-style);
+  border-width: pfe-var(ui--border-width);
+  border-color: transparent;
+  border-bottom-width: pfe-local(BorderWidth);
   // Inner style
   background-color: pfe-local(BackgroundColor);
   color: pfe-local(Color);
@@ -74,6 +73,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 
   @at-root #{&}(:hover) {
     --pfe-tabs--Color:  #{pfe-local(focus)};
+    border-bottom-color: pfe-var(surface--base);
     @include browser-query(ie11) {
       color: pfe-fetch(focus);
     }
@@ -83,19 +83,19 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   // TODO: ShadyCSS falls flat on this pseudo element in IE11 `:host(:focus-visible)`, add back when we drop ShadyCSS
   @at-root #{&}(:focus) {
     color: pfe-var(text);
+    outline: 0;
   }
 
   @at-root #{&}([on="dark"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    border-bottom-color: pfe-var(surface--base);
     @include browser-query(ie11) {
       color: pfe-var(text--muted);
     }
   }
 
   @at-root #{&}([aria-selected="true"]) {
-    --pfe-tabs--Color: #{pfe-local(focus)};
-    --pfe-tabs__tab--BorderColor: transparent;
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    color: pfe-local(focus);
+    border-bottom-color: pfe-local(highlight);
     @include browser-query(ie11) {
       border-bottom: pfe-fetch(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(ui-accent);
     }
@@ -108,10 +108,11 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 
 @media screen and (min-width: #{pfe-breakpoint(md)}) {
   :host([vertical]) {
-    --pfe-tabs--BorderTop: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent;
-    --pfe-tabs--BorderRight: 0;
-    --pfe-tabs--BorderBottom: 0;
-    --pfe-tabs--BorderLeft: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent;
+    border-bottom-color: transparent;
+    border-bottom-width: 0;
+    border-left-color: pfe-var(ui--border);
+    border-left-width: pfe-var(ui--border-width);
+    
     --pfe-tabs--Margin: 0 -1px 0 0;
     padding: pfe-var(container-padding);
 
@@ -125,14 +126,13 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   }
 
   :host([vertical][aria-selected="true"]) {
-    --pfe-tabs__tab--BorderTopColor: transparent;
-    --pfe-tabs__tab--BorderRight:    #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
-    --pfe-tabs__tab--BorderBottom:   0;
+    border-left-color: pfe-local(highlight);
+    border-left-width: 3px;
 
     @include browser-query(ie11) {
       color:            $pfe-color--black;
       border-top-color: transparent;
-      border-right:     pfe-fetch(surface--border-width--heavy) pfe-var(surface--border-style) pfe-var(ui-accent);
+      border-right:     pfe-fetch(ui--border-width--active) pfe-var(ui--border-style) pfe-var(ui-accent);
       border-bottom:    0;
     }
   }
@@ -141,7 +141,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 :host([pfe-variant="earth"]) {
   @include browser-query(ie11) {
     background-color: pfe-fetch(surface--lighter);
-    color:            pfe-fetch(ui-disabled--text); // @todo replace with pfe(text-muted) in Kendall's color story
+    color:            pfe-fetch(text--muted);  
   }
 }
 
@@ -154,46 +154,22 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// WIND TAB VARIANTS / DEFAULT
 /// ===========================================================================
 
-@each $theme in $THEMES { // dark, saturated, and light
-  :host([aria-selected="true"][on="#{$theme}"]),
-  :host([on="#{$theme}"]:hover),
-  :host([pfe-variant="wind"][aria-selected="true"][on="#{$theme}"]),
-  :host([pfe-variant="wind"][on="#{$theme}"]:hover) {
-    @if $theme != "light" {
-      --pfe-tabs--Color: #{pfe-var(text--on-#{$theme})};
-    }
-    @else {
-      --pfe-tabs--Color: #{pfe-var(text)};
-    }
-  }
-  :host([pfe-variant="wind"][on="#{$theme}"]:hover) {
-    @if $theme != "light" {
-      color: #fff;
-    }
-  }
-  :host([pfe-variant="wind"][aria-selected="true"][on="#{$theme}"]) {
-    @if $theme != "light" {
-      color: $pfelements--gray-light;
-    }
-  }
-}
-
 :host{
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:first-of-type) {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth) pfe-var(surface--border-style) pfe-local(highlight);
+      border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
-  @at-root #{&}([pfe-variant="wind"][aria-selected="true"]) {
-  }
+ //@at-root #{&}([pfe-variant="wind"][aria-selected="true"]) {
+ //}
   @at-root #{&}([pfe-variant="wind"][aria-selected="true"]:hover) {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth) pfe-var(surface--border-style) pfe-local(highlight);
+      border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:first-of-type):hover {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type) {
@@ -203,49 +179,49 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:last-of-type):hover {
     @include browser-query(ie11) {
-      border-bottom: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
 }
 
 :host{
   @at-root #{&}([vertical][pfe-variant="wind"]){
-    --pfe-tabs__tab--BorderLeft: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
-    --pfe-tabs__tab--TextAlign: left !important;
+    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+    text-align: left !important;
     @include browser-query(ie11) {
-      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
+      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(ui--border);
     }
   }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    border-bottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
     @include browser-query(ie11) {
-      border-bottom:  pfe-fetch(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(BorderColor--hover);
+      border-bottom:  pfe-fetch(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(BorderColor--hover);
     }
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
-    --pfe-tabs__tab--BorderLeft:  #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
+    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    border-Left:  #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(highlight)};
     padding-left:                 calc(#{pfe-var(container-padding)} - 2px);
     @include browser-query(ie11) {
       border-right:  0;
-      border-left:   pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(highlight);
+      border-left:   pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
       padding-left:  10px;
       border-bottom: 0 !important;
     }
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
+    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
   }
   @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderRight: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} transparent;
-    --pfe-tabs__tab--BorderBottom: 0;
-    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    border-Right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    border-Bottom: 0;
+    border-Left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
     padding-left: calc(#{pfe-var(container-padding)} - 2px);
     @include browser-query(ie11) {
       border-right:  0;
       border-bottom: 0;
       padding-left:  10px;
-      border-left:   pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover);
+      border-left:   pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(BorderColor--hover);
     }
   }
 }
@@ -262,10 +238,10 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
   @at-root #{&}([on="saturated"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
     --pfe-tabs__tab--BorderBottom: 0 !important;
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(BorderColor--hover)};
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--lightest)} !important;
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--lightest)} !important;
   }
   @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]) {
     color: pfe-var(text--on-saturated) !important;
@@ -281,56 +257,54 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 }
 
 /// ===========================================================================
-/// Earth TAB VARIANTS / saturated
+/// EARTH TAB VARIANTS / saturated
 /// ===========================================================================
 :host([pfe-variant="wind"][on="saturated"]) {
-  --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
+  color:  pfe-var(text--on-saturated);
 }
 :host([pfe-variant="earth"][on="saturated"]:hover) {
-  --pfe-tabs--Color: #{pfe-local(focus)};
+  color:  pfe-local(focus);
 }
 :host([pfe-variant="earth"][on="saturated"][aria-selected="true"]) {
-  --pfe-tabs--Color: #{pfe-local(focus)};
+  color:  pfe-local(focus);
 }
 
 /// ===========================================================================
 /// EARTH TAB VARIANTS
 /// ===========================================================================
 
+// horizontal earth unselected item
 :host([pfe-variant="earth"][aria-selected="false"]) {
-  $variantEarth: (
-    BackgroundColor: pfe-var(surface--lighter),
-    tab: (
-      BorderLeft:    pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border),
-      BorderBottom:  pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border),
-      BorderTop:     pfe-local(BorderWidth) pfe-var(ui--border-style) transparent,
-    )
-  );
-  @include pfe-print-local($variantEarth);
+    background-color:     pfe-var(surface--lighter);
+    border-color:         pfe-var(ui--border);
+    border-top-width:     pfe-local(BorderWidth);
+    border-top-color:     transparent;
+    border-bottom-color:  transparent;
+ 
   @include browser-query(ie11) {
     border-top:    3px solid pfe-fetch(surface--lighter);
-    border-bottom: 1px solid pfe-fetch(surface--border);
-    border-left:   1px solid pfe-fetch(surface--border);
+    border-bottom: pfe-var(ui--border-width) solid pfe-fetch(ui--border);
+    border-left:   pfe-var(ui--border-width) solid pfe-fetch(ui--border);
   }
 }
-
+// horizontal earth hover on item
 :host([pfe-variant="earth"][aria-selected="false"]:hover){
-  --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
+  border-top-color:     pfe-local(BorderColor);
   @include browser-query(ie11) {
-    border-top: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-local(BorderColor--hover) !important;
+    border-top-color:     pfe-local(BorderColor) !important;
     color: pfe-fetch(focus);
   }
 }
-
+// horizontal earth active item
 :host([pfe-variant="earth"][aria-selected="true"]) {
-  --pfe-tabs--BackgroundColor:   #{pfe-var(surface--lightest)};
-  //--pfe-tabs--Color:             pfe-local(focus); // @todo replace with pfe(text-muted) in Kendall's color story
-  --pfe-tabs__tab--BorderTop:    #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
-  --pfe-tabs__tab--BorderBottom: 0;
-  --pfe-tabs__tab--BorderLeft:   #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+  background-color:  pfe-var(surface--lightest);
+  border-bottom:     0;
+  border-left:       solid 1px #{pfe-var(ui--border)};
+  border-right:      solid 1px #{pfe-var(ui--border)};
+  border-top:        solid pfe-local(highlight) pfe-local(BorderWidth);
 
   @include browser-query(ie11) {
-    color:            pfe-fetch(ui-disabled--text); // @todo replace with pfe(text-muted) in Kendall's color story
+    color:            pfe-fetch(text--muted); // @todo replace with pfe(text-muted) in Kendall's color story
     background-color: #fff;
     border-left:      pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) #d2d2d2;
     border-top:       pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
@@ -338,13 +312,13 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   }
 }
 :host([pfe-variant="earth"][aria-selected="false"]:first-of-type) {
-  border-left: pfe-var(ui--border-width) pfe-var(surface--border-style) transparent !important;
+  border-left: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
 }
 :host([pfe-variant="earth"][aria-selected="true"]:last-of-type) {
-  --pfe-tabs__tab--BorderRight: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+  border-Right: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
 
   @include browser-query(ie11) {
-    border-right: 1px solid pfe-fetch(surface--border);
+    border-right: 1px solid pfe-fetch(ui--border);
   }
 }
 
@@ -353,21 +327,24 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// ===========================================================================
 
 @media screen and (min-width: #{pfe-breakpoint(md)}) {
+  // vertical earth unselected item
   :host([vertical][pfe-variant="earth"]) {
-    --pfe-tabs__tab--BorderTop: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+    border-top-width: pfe-var(ui--border-width);
+    border-top-color: pfe-var(ui--border);
     text-align: left;
     @include browser-query(ie11) {
-      border-top: 1px solid pfe-fetch(surface--border);
+      border-top: pfe-var(ui--border-width) solid pfe-fetch(ui--border);
     }
   }
-
+  // vertical earth first child (add top border)
   :host([vertical][pfe-variant="earth"]:first-of-type) {
-    --pfe-tabs__tab--BorderTop: 0;
+    border-top: 0;
 
     @include browser-query(ie11) {
       border-top: 0;
     }
   }
+  // vertical earth first child, inactive 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type) {
     border-top:  pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
     border-left: pfe-local(BorderWidth) pfe-var(ui--border-style) transparent !important;
@@ -375,76 +352,86 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       border-top: 1px pfe-fetch(ui--border-style) transparent !important;
     }
   }
+  // vertical earth, active item
   :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
-    --pfe-tabs__tab--BorderTop:    #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
-    --pfe-tabs__tab--BorderRight:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--lightest)};
-    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-local(highlight)};
-    margin-right: -1px;
+    border-top:         solid pfe-var(ui--border-width)  pfe-var(ui--border); 
+    border-left-color:  pfe-local(highlight);
+    border-left-width:  pfe-local(BorderWidth);
+    border-right-color: transparent;
+    margin-right:       -1px;
 
     @include browser-query(ie11) {
-      border-top:   1px solid pfe-fetch(surface--border);
+      border-top:   pfe-var(ui--border-width) solid pfe-fetch(ui--border);
       border-right: 0;
       border-left:  3px solid pfe-local(highlight);
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]) {
-    --pfe-tabs__tab--BorderRight:  0;
-    --pfe-tabs__tab--BorderBottom: 0;
-    --pfe-tabs__tab--BorderLeft:   #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    border-right:  0;
+    border-bottom: 0;
+    border-left:   #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
 
     @include browser-query(ie11) {
-      border-right:  1px solid pfe-fetch(surface--border);
+      border-right:  1px solid pfe-fetch(ui--border);
       border-bottom: 0;
       border-left:   3px solid pfe-fetch(surface--lighter);
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:hover){
-    --pfe-tabs__tab--BorderLeft: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)};
-    --pfe-tabs__tab--BorderTop:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
+    border-top:  #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
     @include browser-query(ie11) {
-      border-left: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
-      border-top:  pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border) !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
+      border-top:  pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
     }
   }
 
   :host([vertical][pfe-variant="earth"][aria-selected="false"]:first-of-type:hover) {
-    --pfe-tabs__tab--BorderTop:  #{pfe-var(ui--border-style)} #{pfe-var(ui--border-style)} transparent;
-    border-left: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important;
+    border-top:  #{pfe-var(ui--border-style)} #{pfe-var(ui--border-style)} transparent;
+    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)} !important;
     @include browser-query(ie11) {
       border-top:  1px pfe-fetch(ui--border-style) transparent !important;
-      border-left: pfe-local(BorderWidth) pfe-fetch(surface--border-style) pfe-fetch(surface--border) !important;
+      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(ui--border) !important;
     }
   }
   :host([vertical][pfe-variant="earth"][aria-selected="true"]:last-of-type) {
-    --pfe-tabs__tab--BorderBottom: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+    border-bottom: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)};
 
     @include browser-query(ie11) {
-      border-bottom: 1px solid pfe-fetch(surface--border);
+      border-bottom: 1px solid pfe-fetch(ui--border);
     }
   }
 }
 
+/// In dark & saturated contexts, we override the local color vars
+
 /// ===========================================================================
-/// EARTH TAB VARIANTS ON DARK
+/// EARTH TAB VARIANTS ON DARK & SATURATED
 /// ===========================================================================
 
 :host{
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]) {
-    --pfe-tabs--BackgroundColor: #{pfe-local(BackgroundColor--dark)}; //replace with global var color in Kendalls story
-    --pfe-tabs--Color: #{pfe-var(ui-disabled)};
+    background-color: rgba(255, 255, 255, .2); //@todo, use opacity var
+    --pfe-tabs--Color: #{pfe-var(text--muted--on-dark)};
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
-    --pfe-tabs__tab--BorderLeft: #{pfe-var(ui--border-width)} #{pfe-var(surface--border-style)} transparent !important;
+    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent !important;
   }
+    // earth on saturated, selected item
+  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
+    --pfe-tabs--Color: #{pfe-var(text)};
+  }
+  // earth on dark, selected item
   @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-    --pfe-tabs--Color: #{pfe-var(surface--lightest)};
-    --pfe-tabs--BackgroundColor: #{pfe-local(focus)};
-    border-bottom: pfe-var(ui--border-width) pfe-var(surface--border-style) pfe-var(surface--darkest);
+    --pfe-tabs--Color: #{pfe-var(text--on-dark)};
+    background-color: transparent;
+    background-color: transparent;
+    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
     @include browser-query(ie11) {
         color: pfe-fetch(surface--lightest) !important;
     }
@@ -453,32 +440,32 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     border-bottom: 0;
   }
   @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-    --pfe-tabs__tab--BorderTop: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
-    --pfe-tabs--Color: #{pfe-var(text--on-dark)};
+    border-top: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(ui--border)} !important; //replace with B8BBBE in kendalls story
+    color: #{pfe-var(text--on-dark)};
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
-    border-top: pfe-var(ui--border-width) pfe-var(surface--border-style) transparent !important;
+    border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
   }
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-    border-top: pfe-var(ui--border-width) pfe-var(surface--border-style) pfe-var(surface--border);
+    border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(ui--border);
   }
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-    border-right: pfe-var(ui--border-width) pfe-var(surface--border-style) pfe-var(surface--darkest);
+    border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
   }
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:last-of-type) {
-    border-bottom: pfe-var(ui--border-width) pfe-var(surface--border-style) transparent !important;
+    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
   }
   @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]:last-of-type) {
-    border-bottom: pfe-var(ui--border-width) pfe-var(surface--border-style) pfe-var(surface--border);
+    border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(ui--border);
   }
 }
 
 
 /// ===========================================================================
-/// WIND TAB VARIANTS ON DARK
+/// WIND TAB VARIANTS ON DARK & SATURATED
 /// ===========================================================================
 
 :host{
@@ -495,9 +482,15 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       color: pfe-fetch(text) !important;
     }
   }
+  @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="saturated"]) {
+    --pfe-tabs--Color: #{pfe-var(text--muted--on-saturated)};
+  }
+  @at-root #{&}([pfe-variant="wind"][aria-selected="true"][on="saturated"]) {
+    --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
+  }
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
     color: pfe-var(surface--lightest);
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(surface--border-style)} #{pfe-var(surface--border)} !important; //replace with B8BBBE in kendalls story
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;  
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
@@ -506,3 +499,4 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     border-bottom: 0;
   }
 }
+ 

--- a/elements/pfe-tabs/src/pfe-tab.scss
+++ b/elements/pfe-tabs/src/pfe-tab.scss
@@ -84,15 +84,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
   // TODO: ShadyCSS falls flat on this pseudo element in IE11 `:host(:focus-visible)`, add back when we drop ShadyCSS
   @at-root #{&}(:focus) {
     color: pfe-var(text);
-  }
-
-  @at-root #{&}([on="dark"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    border-bottom-color: pfe-var(surface--base);
-
-    @include browser-query(ie11) {
-      color: pfe-var(text--muted);
-    }
-  }
+  } 
 
   @at-root #{&}([aria-selected="true"]) {
     color: pfe-local(focus);
@@ -103,58 +95,99 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 }
-
+ 
 /// ===========================================================================
 /// VERTICAL TAB ORIENTATION
 /// ===========================================================================
 
-@media screen and (min-width: #{pfe-breakpoint(md)}) {
-  :host([vertical]) {
-    border-bottom-color: transparent;
-    border-bottom-width: 0;
-    border-left-color: pfe-var(surface--border);
-    border-left-width: pfe-var(ui--border-width);
-
-    --pfe-tabs--Margin: 0 -1px 0 0;
-    padding: pfe-var(container-padding);
-
-    @include browser-query(ie11) {
-      border: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent;
-      border-bottom: 0;
-      border-right: 0;
-      margin: 0 #{pfe-fetch(ui--border-width) * -1} 0 0;
-      padding-left: pfe-fetch(container-padding);
-    }
-  }
-
-  :host([vertical][aria-selected="true"]) {
-    border-left-color: pfe-local(highlight);
-    border-left-width: 3px;
-
-    @include browser-query(ie11) {
-      color: $pfe-color--black;
-      border-top-color: transparent;
-      border-right: pfe-fetch(ui--border-width--active) pfe-var(ui--border-style) pfe-var(ui-accent);
-      border-bottom: 0;
-    }
-  }
-}
-
-:host([pfe-variant="earth"]) {
-  @include browser-query(ie11) {
-    background-color: pfe-fetch(surface--lighter);
-    color: pfe-fetch(text--muted);
-  }
-}
-
-:host([pfe-variant="wind"]) .pfe-tab,
 :host([pfe-variant="earth"][vertical]) .pfe-tab {
   display: inline-block !important;
+}
+
+@media screen and (min-width: #{pfe-breakpoint(md)}) {
+
+  :host {
+    @at-root #{&}([vertical]) {
+      border-bottom-color: transparent;
+      border-bottom-width: 0;
+      border-left-color: pfe-var(surface--border);
+      border-left-width: pfe-var(ui--border-width);
+
+      --pfe-tabs--Margin: 0 -1px 0 0;
+      padding: pfe-var(container-padding);
+
+      @include browser-query(ie11) {
+        border: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) transparent;
+        border-bottom: 0;
+        border-right: 0;
+        margin: 0 #{pfe-fetch(ui--border-width) * -1} 0 0;
+        padding-left: pfe-fetch(container-padding);
+      }
+    }
+
+    @at-root #{&}([vertical][aria-selected="true"]) {
+      border-left-color: pfe-local(highlight);
+      border-left-width: 3px;
+
+      @include browser-query(ie11) {
+        color: $pfe-color--black;
+        border-top-color: transparent;
+        border-right: pfe-fetch(ui--border-width--active) pfe-var(ui--border-style) pfe-var(ui-accent);
+        border-bottom: 0;
+      }
+    }
+
+    @at-root #{&}([vertical][pfe-variant="wind"]) {
+      border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
+      text-align: left !important;
+
+      @include browser-query(ie11) {
+        border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
+      }
+    }
+
+    @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]) {
+      border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+      border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(highlight)};
+      padding-left: calc(#{pfe-var(container-padding)} - 2px);
+
+      @include browser-query(ie11) {
+        border-right: 0;
+        border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
+        padding-left: 10px;
+        border-bottom: 0 !important;
+      }
+    }
+
+    @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]) {
+      border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+    }
+
+    @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover) {
+      border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
+      border-Bottom: 0;
+      border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
+      padding-left: calc(#{pfe-var(container-padding)} - 2px);
+
+      @include browser-query(ie11) {
+        border-right: 0;
+        border-bottom: 0;
+        padding-left: 10px;
+        border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(BorderColor--hover);
+      }
+    }
+
+  }
+  
 }
 
 /// ===========================================================================
 /// WIND TAB VARIANTS / DEFAULT
 /// ===========================================================================
+
+:host([pfe-variant="wind"]) .pfe-tab {
+  display: inline-block !important;
+}
 
 :host {
   text-align: left;
@@ -187,18 +220,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       border-bottom-color: pfe-local(BorderColor--hover);
     }
   }
-}
-
-:host {
-  @at-root #{&}([vertical][pfe-variant="wind"]) {
-    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
-    text-align: left !important;
-
-    @include browser-query(ie11) {
-      border-left: pfe-fetch(ui--border-width) pfe-fetch(ui--border-style) pfe-fetch(surface--border);
-    }
-  }
-
+ 
   @at-root #{&}([pfe-variant="wind"][aria-selected="false"]:hover) {
     border-bottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
 
@@ -206,44 +228,19 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       border-bottom: pfe-fetch(BorderWidth) pfe-fetch(ui--border-style) pfe-fetch(BorderColor--hover);
     }
   }
-
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="true"]) {
-    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
-    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(highlight)};
-    padding-left: calc(#{pfe-var(container-padding)} - 2px);
-
-    @include browser-query(ie11) {
-      border-right: 0;
-      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(highlight);
-      padding-left: 10px;
-      border-bottom: 0 !important;
-    }
-  }
-
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]) {
-    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
-  }
-
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"]:hover) {
-    border-right: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} transparent;
-    border-Bottom: 0;
-    border-left: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor--hover)};
-    padding-left: calc(#{pfe-var(container-padding)} - 2px);
-
-    @include browser-query(ie11) {
-      border-right: 0;
-      border-bottom: 0;
-      padding-left: 10px;
-      border-left: pfe-local(BorderWidth) pfe-fetch(ui--border-style) pfe-local(BorderColor--hover);
-    }
-  }
 }
-
 
 
 /// ===========================================================================
 /// EARTH TAB VARIANTS
 /// ===========================================================================
+:host([pfe-variant="earth"]) {
+  @include browser-query(ie11) {
+    background-color: pfe-fetch(surface--lighter);
+    color: pfe-fetch(text--muted);
+  }
+}
+
 :host(:not([vertical])[pfe-variant="earth"]:first-of-type) {
     border-left-color: transparent;
 }
@@ -274,7 +271,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       color: pfe-fetch(focus);
     }
   }
-
+  // nth of type is needed to override first and last of type selectors above
   @at-root #{&}([pfe-variant="earth"][aria-selected="true"]:nth-of-type(n)) {
     background-color: pfe-var(surface--lightest);
     border-bottom: 0;
@@ -334,20 +331,6 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
-  :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
-    border-top: solid pfe-var(ui--border-width) pfe-var(surface--border);
-    border-left-color: pfe-local(highlight);
-    border-left-width: pfe-local(BorderWidth);
-    border-right-color: transparent;
-    margin-right: #{pfe-fetch(ui--border-width) * -1};
-
-    @include browser-query(ie11) {
-      border-top: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
-      border-right: 0;
-      border-left: pfe-fetch(ui--border-width--active) pfe-fetch(ui--border-style) pfe-local(highlight);
-    }
-  }
-
   :host([vertical][pfe-variant="earth"][aria-selected="false"]) {
     border-right: 0;
     border-bottom: 0;
@@ -380,6 +363,21 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
+
+  :host([vertical][pfe-variant="earth"][aria-selected="true"]) {
+    border-top: solid pfe-var(ui--border-width) pfe-var(surface--border);
+    border-left-color: pfe-local(highlight);
+    border-left-width: pfe-local(BorderWidth);
+    border-right-color: transparent;
+    margin-right: #{pfe-fetch(ui--border-width) * -1};
+
+    @include browser-query(ie11) {
+      border-top: pfe-var(ui--border-width) solid pfe-fetch(surface--border);
+      border-right: 0;
+      border-left: pfe-fetch(ui--border-width--active) pfe-fetch(ui--border-style) pfe-local(highlight);
+    }
+  }
+
   :host([vertical][pfe-variant="earth"][aria-selected="true"]:last-of-type) {
     border-bottom: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)};
 
@@ -395,16 +393,12 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
 /// ===========================================================================
 /// In dark & saturated contexts, we override the local color vars
  
-
-
-
 :host {
-
-  @at-root #{&}([pfe-variant="earth"][on="dark"]) {
+  @at-root #{&}([on="dark"][pfe-variant="earth"]) {
       border-right-color: pfe-var(surface--border--darker);
       border-left-color: pfe-var(surface--border--darker);
   }
-  @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]) {
+  @at-root #{&}([on="dark"][pfe-variant="earth"][aria-selected="false"]) {
     --pfe-tabs--Color: #{pfe-var(text--muted--on-dark)};
     background-color: pfe-var(surface--darker);
 
@@ -412,28 +406,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
       color: pfe-fetch(text) !important;
     }
   }
-
-  @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
-    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent !important;
-  }
-
-
-  // earth on dark, active item
-  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-    --pfe-tabs--Color: #{pfe-var(text--on-dark)};
-    background-color: pfe-var(surface--darkest);
-    border-bottom-color: pfe-var(surface--darkest);
-
-    @include browser-query(ie11) {
-      color: pfe-fetch(surface--lightest) !important;
-    }
-  }
-
-  @at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-    border-bottom: 0;
-  }
-
-  @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
+    @at-root #{&}([on="dark"][pfe-variant="earth"][aria-selected="false"]:hover) {
     --pfe-tabs--Color: #{pfe-var(text--on-dark)};
     border-top: pfe-local(BorderWidth) pfe-var(ui--border-style) pfe-var(surface--border--darker) !important;  
 
@@ -442,51 +415,46 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
-  //VERTICAL
-  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:first-of-type) {
-  //  border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
-  //}
-//
-  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:hover) {
-  //  border-top: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
-  //}
-//
-  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]) {
-  //  border-right: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--darkest);
-  //}
-//
-  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="false"][on="dark"]:last-of-type) {
-  //  border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) transparent !important;
-  //}
-//
-  //@at-root #{&}([vertical][pfe-variant="earth"][aria-selected="true"][on="dark"]:last-of-type) {
-  //  border-bottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-var(surface--border);
-  //}
+  @at-root #{&}([on="dark"][pfe-variant="earth"][aria-selected="false"]:first-of-type) {
+    border-left: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} transparent !important;
+  }
 
-  
-  
-  // SATURATED
-  @at-root #{&}([pfe-variant="earth"][aria-selected="false"][on="saturated"]) {
+  @at-root #{&}([on="dark"][pfe-variant="earth"][aria-selected="true"]) {
+    --pfe-tabs--Color: #{pfe-var(text--on-dark)};
+    background-color: pfe-var(surface--darkest);
+    border-bottom-color: pfe-var(surface--darkest);
+
+    @include browser-query(ie11) {
+      color: pfe-fetch(surface--lightest) !important;
+    }
+  }
+  @at-root #{&}([on="dark"][pfe-variant="earth"][vertical][aria-selected="true"]) {
+    border-bottom: 0;
+  }
+}
+
+// SATURATED
+:host {  
+  @at-root #{&}([pfe-variant="earth"][on="saturated"][aria-selected="false"]) {
     --pfe-tabs--BackgroundColor: #{pfe-var(surface--lighter)};
   }
-  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
+  @at-root #{&}([pfe-variant="earth"][on="saturated"][aria-selected="true"]) {
     color: pfe-local(focus);
   }
   @at-root #{&}([pfe-variant="earth"][on="saturated"]:hover) {
     color: pfe-local(focus);
   }
- 
-  @at-root #{&}([pfe-variant="earth"][aria-selected="true"][on="saturated"]) {
+  @at-root #{&}([pfe-variant="earth"][on="saturated"][aria-selected="true"]) {
     --pfe-tabs--Color: #{pfe-var(text)};
   }
 
 }
 
-
 /// ===========================================================================
 /// WIND TAB VARIANTS ON DARK & SATURATED
 /// ===========================================================================
  
+// SATURATED
 :host {
   @at-root #{&}([on="saturated"][pfe-variant="wind"]) {
     color: pfe-var(text--on-saturated);
@@ -496,36 +464,29 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
-  @at-root #{&}([on="saturated"][aria-selected="false"][pfe-variant="wind"]:hover) {
-    border-bottom-color: pfe-local(BorderColor--hover);
-  }
-
-  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]) {
-    color: pfe-var(text--on-saturated) !important;
-
-    @include browser-query(ie11) {
+  @at-root #{&}([on="saturated"][pfe-variant="wind"][aria-selected="true"]) {
+    --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
+        @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
+  @at-root #{&}([on="saturated"][pfe-variant="wind"][aria-selected="false"]) {
+    --pfe-tabs--Color: #{pfe-var(text--muted--on-saturated)};
+  }
+  @at-root #{&}([on="saturated"][pfe-variant="wind"][aria-selected="false"]:hover) {
+    border-bottom-color: pfe-local(BorderColor--hover);
+  }
 
-  @at-root #{&}([on="saturated"][aria-selected="true"][pfe-variant="wind"]:last-of-type) {
+  @at-root #{&}([on="saturated"][pfe-variant="wind"][aria-selected="true"]:last-of-type) {
     @include browser-query(ie11) {
       border-left: 0 !important;
     }
   }
 }
-
-
+ 
+// DARK
 :host {
-  @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]) {
-    --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
-
-    @include browser-query(ie11) {
-      color: pfe-fetch(text) !important;
-    }
-  }
-
-  @at-root #{&}([pfe-variant="wind"][aria-selected="true"][on="dark"]) {
+  @at-root #{&}([on="dark"][pfe-variant="wind"][aria-selected="true"]) {
     --pfe-tabs--Color: #{pfe-var(surface--lightest)};
 
     @include browser-query(ie11) {
@@ -533,24 +494,28 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, $backwards-compatibility);
     }
   }
 
-  @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="saturated"]) {
-    --pfe-tabs--Color: #{pfe-var(text--muted--on-saturated)};
-  }
-
-  @at-root #{&}([pfe-variant="wind"][aria-selected="true"][on="saturated"]) {
+  @at-root #{&}([on="dark"][pfe-variant="wind"][aria-selected="false"]) {
     --pfe-tabs--Color: #{pfe-var(text--on-saturated)};
-  }
-
-  @at-root #{&}([pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
-    color: pfe-var(surface--lightest);
-    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;
 
     @include browser-query(ie11) {
       color: pfe-fetch(text) !important;
     }
   }
 
-  @at-root #{&}([vertical][pfe-variant="wind"][aria-selected="false"][on="dark"]:hover) {
+  @at-root #{&}([on="dark"][pfe-variant="wind"][aria-selected="false"]:hover) {
+      border-bottom-color: pfe-var(surface--base);
+    color: pfe-var(surface--lightest);
+    --pfe-tabs__tab--BorderBottom: #{pfe-local(BorderWidth)} #{pfe-var(ui--border-style)} #{pfe-var(surface--border)} !important;
+
+    @include browser-query(ie11) {
+      color: pfe-fetch(text) !important;
+    }
+    //  @include browser-query(ie11) {
+      // color: pfe-var(text--muted);
+    // }
+  }
+
+  @at-root #{&}([on="dark"][pfe-variant="wind"][vertical][aria-selected="false"]:hover) {
     border-bottom: 0;
   }
 }

--- a/elements/pfe-tabs/src/pfe-tabs.scss
+++ b/elements/pfe-tabs/src/pfe-tabs.scss
@@ -78,12 +78,12 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
   :host([vertical]) {
     --pfe-tabs--Display: flex; // Sets tabs to appear to the left of the panels
     --pfe-tabs__tabs--FlexDirection: column;
-    --pfe-tabs__tabs--Width: 22.22%;
+    --pfe-tabs__tabs--Width: 20%;
 
     --pfe-tabs__tabs--BorderRight: #{pfe-var(ui--border-width)} #{pfe-var(ui--border-style)} #{pfe-local(BorderColor)};
     --pfe-tabs__tabs--BorderBottom: 0;
 
-    --pfe-tabs__panels--Width: 77.78%;
+    --pfe-tabs__panels--Width: 80%;
     --pfe-tabs__panels--PaddingRight: #{pfe-var(container-padding)};
 
     @include browser-query(ie11) {

--- a/elements/pfe-tabs/src/pfe-tabs.scss
+++ b/elements/pfe-tabs/src/pfe-tabs.scss
@@ -22,10 +22,6 @@ $LOCAL-VARIABLES: (
   ),
   panels: (
     Width: auto,
-    PaddingTop: 0,
-    PaddingRight: 0,
-    PaddingBottom: 0,
-    PaddingLeft: 0
   )
 );
 
@@ -35,6 +31,10 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
     BorderBottom: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-local(BorderColor, $region: tabs)
   )
 ));
+
+
+// DEBUGGING
+//@include pfe-local-debug; // preview local variables in pfe-tab-panel.css
 
 :host {
   display: pfe-local(Display);
@@ -55,11 +55,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
 
   .panels {
     width: pfe-local(Width, $region: panels);
-
-    padding-top: pfe-local(PaddingTop, $region: panels);
-    padding-right: pfe-local(PaddingRight, $region: panels);
-    padding-bottom: pfe-local(PaddingBottom, $region: panels);
-    padding-left: pfe-local(PaddingLeft, $region: panels);
+    // no padding here, because of the borders on vertical earth
   }
 }
 
@@ -130,9 +126,6 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
 :host([pfe-variant="earth"]) {
   --pfe-tabs__tabs--PaddingLeft: #{pfe-var(container-padding)};
 
-  // .tabs ::slotted(pfe-tab[aria-selected="false"]:not([vertical]):first-of-type) {
-  //   border-left: 0;
-  // }
 }
     
 @include browser-query(ie11) {

--- a/elements/pfe-tabs/src/pfe-tabs.scss
+++ b/elements/pfe-tabs/src/pfe-tabs.scss
@@ -130,9 +130,9 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
 :host([pfe-variant="earth"]) {
   --pfe-tabs__tabs--PaddingLeft: #{pfe-var(container-padding)};
 
-  .tabs ::slotted(pfe-tab[aria-selected="false"]:not([vertical]):first-of-type) {
-    border-left: 0;
-  }
+  // .tabs ::slotted(pfe-tab[aria-selected="false"]:not([vertical]):first-of-type) {
+  //   border-left: 0;
+  // }
 }
     
 @include browser-query(ie11) {
@@ -161,5 +161,14 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
   height: 32px;
   width: 1px;
   background-color: pfe-local(BorderColor, $region: tabs);
+  position: relative;
+}
+
+:host(:not([vertical])[pfe-variant="earth"]) .tabs-prefix {
+  left: 0px;
+  top: 0px;
+  content: " ";
+  height: 1px;
+  width: 10px;
   position: relative;
 }

--- a/elements/pfe-tabs/src/pfe-tabs.scss
+++ b/elements/pfe-tabs/src/pfe-tabs.scss
@@ -137,31 +137,36 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
 @include pfe-theme-contexts; // imports on="light" etc support
 
 
-  // Styles for vertical wind tab to have the left bad extend past the tabset 
-:host([vertical][pfe-variant="wind"]) .tabs-prefix {
-  left: 0px;
-  top: 0px;
-  content: " ";
-  height: 32px;
-  width: 1px;
-  background-color: pfe-local(BorderColor, $region: tabs);
-  position: relative;
-}
-:host([vertical][pfe-variant="wind"]) .tabs-suffix {
-  left: 0px;
-  top: 0px;
-  content: " ";
-  height: 32px;
-  width: 1px;
-  background-color: pfe-local(BorderColor, $region: tabs);
-  position: relative;
-}
+/// ===========================================================================
+/// INSET NOTCH
+/// ===========================================================================
 
-:host(:not([vertical])[pfe-variant="earth"]) .tabs-prefix {
-  left: 0px;
-  top: 0px;
-  content: " ";
-  height: 1px;
-  width: 10px;
-  position: relative;
+@media screen and (min-width: #{pfe-breakpoint(md)}) {
+  :host([vertical][pfe-variant="wind"]) .tabs-prefix {
+    left: 0px;
+    top: 0px;
+    content: " ";
+    height: 32px;
+    width: 1px;
+    background-color: pfe-local(BorderColor, $region: tabs);
+    position: relative;
+  }
+  :host([vertical][pfe-variant="wind"]) .tabs-suffix {
+    left: 0px;
+    top: 0px;
+    content: " ";
+    height: 32px;
+    width: 1px;
+    background-color: pfe-local(BorderColor, $region: tabs);
+    position: relative;
+  }
+
+  :host(:not([vertical])[pfe-variant="earth"]) .tabs-prefix {
+    left: 0px;
+    top: 0px;
+    content: " ";
+    height: 1px;
+    width: calc(#{pfe-var(container-padding)} * 2);
+    position: relative;
+  }
 }


### PR DESCRIPTION
https://web-dev-drupal-ktotten.dev.a1.vary.redhat.com/en/pfe-tab-test

### Var updates
- Remove unused variables
- Update names of variables in local map for BEM & consistency
- Move old vars to backwards-compatibility map.
- Add comments about why tab and panel variable regions are needed in local variable maps
- Deprecate unusable padding variables in parent file

### Tidy  
- Simplify border properties; use regular css properties instead of redefining local vars as often. 
- Run prettier on the pfe-tab sass. 
- Move selectors into discreet sections of the pfe-tab file and organize the selector attributes, in order to remove duplicates
    - Order:  context, variant, active/inactive, state or nth of type
    - `[on="dark"][pfe-variant="earth"][aria-selected="false"]:first-of-type`

### Demo
- Add links to pfe-tab demo to ensure tab index works in tab panels. 
- Update demo file so its full width to demonstrate spacing.
- Add weird background colors to demo so you can see where tabs have background colors.

### IE11
- Clean up ie11 styles, remove magic numbers & replace with pfe-fetch.

### Design updates
- Update tab panel colors & border placement per feedback from Corey.
- Add support for padding adjustments to panel per breakpoint; change tab width. 
- Add left side inset to earth variant to prevent odd border visuals & match pfe core

### Debugging / Testing
- Add back old "print-local-vars" mixin (renamed) to print local variables for testing & debugging.


### Outstanding item
- Solving for saturated panel content. Links are currently invisible because they are picking up the `on=saturated` broadcast colors. But since the saturated context is now defining its own background color, we need to remove this attribute from affecting the content.
![image](https://user-images.githubusercontent.com/456863/88615296-a233dd80-d05f-11ea-80f8-a2e81a36e222.png)
