### PR TITLE
fix: pfelement - restore pfelement tests

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,7 +1,7 @@
 ## Prerelease 55 ( TBD )
 
-- [](https://github.com/patternfly/patternfly-elements/commit/)
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: improve CLS rating in lighthouse (#1020)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfelement - restore pfelement tests (#1018)
+- [fbe4423](https://github.com/patternfly/patternfly-elements/commit/fbe442396f06b0a097366512b698dc0b6d5e1f9f) fix: improve CLS rating in lighthouse (#1020)
 
 ## Prerelease 54 ( 2020-07-31 )
 

--- a/elements/pfelement/src/pfelement.scss
+++ b/elements/pfelement/src/pfelement.scss
@@ -12,15 +12,20 @@ body {
 
 body[unresolved] {
   opacity: 0;
+  visibility: hidden;
   animation: reveal var(--pfe-reveal-duration) var(--pfe-reveal-delay) 1
     forwards;
 }
 
 @keyframes reveal {
-  from {
+  0% {
+    visibility: hidden;
     opacity: 0;
   }
-  to {
+  1% {
+    visibility: visible;
+  }
+  100% {
     opacity: 1;
   }
 }

--- a/elements/pfelement/test/pfelement_cascade_attribute_test.html
+++ b/elements/pfelement/test/pfelement_cascade_attribute_test.html
@@ -11,7 +11,7 @@
     <pfe-parent test-attr="foo"></pfe-parent>
 
     <script type="module">
-      import PFElement from "../pfelement.js";
+      import PFElement from "../dist/pfelement.js";
 
       class PfeParent extends PFElement {
         static get tag() {

--- a/elements/pfelement/test/pfelement_emitEvent.html
+++ b/elements/pfelement/test/pfelement_emitEvent.html
@@ -13,7 +13,7 @@
     </pfelement>
 
     <script type="module">
-      import PFElement from "../pfelement.js";
+      import PFElement from "../dist/pfelement.js";
 
       class TestElement extends PFElement {
         static get tag() {
@@ -27,7 +27,7 @@
         }
 
         constructor() {
-          super(TestElement.tag);
+          super(TestElement);
         }
       }
 

--- a/elements/pfelement/test/pfelement_logging_test.html
+++ b/elements/pfelement/test/pfelement_logging_test.html
@@ -11,7 +11,7 @@
     <pfe-test test-attr="1"></pfe-test>
 
     <script type="module">
-      import PFElement from "../pfelement.js";
+      import PFElement from "../dist/pfelement.js";
 
       class PfeTest extends PFElement {
         static get tag() {

--- a/elements/pfelement/test/pfelement_test.html
+++ b/elements/pfelement/test/pfelement_test.html
@@ -13,7 +13,7 @@
     </pfelement>
 
     <script type="module">
-      import PFElement from "../pfelement.js";
+      import PFElement from "../dist/pfelement.js";
 
       const colors = ["red", "yellow", "blue"];
 
@@ -29,7 +29,7 @@
         }
 
         constructor() {
-          super(TestElement.tag, { type: PFElement.PfeTypes.Content });
+          super(TestElement, { type: PFElement.PfeTypes.Content });
         }
       }
 
@@ -49,7 +49,7 @@
         }
 
         constructor() {
-          super(TestElementDelayRender.tag, { delayRender: true });
+          super(TestElementDelayRender, { delayRender: true });
         }
 
         connectedCallback() {
@@ -121,21 +121,26 @@
           });
         });
 
-        test("it should throw an error when the on attribute is manually added", done => {
+        test("it should throw an error when the on attribute is manually added", () => {
           const spy = sinon.spy(console, "warn");
 
-          const testElementEl = document.createElement("test-element");
-          testElementEl.id = "test-element";
-          testElementEl.setAttribute("on", "saturated");
-          document.body.appendChild(testElementEl);
+          // with an id
 
-          sinon.assert.calledWith(spy, `pfe-test-element[#test-element]: The "on" attribute is protected and should not be manually added to a component. The base class will manage this value for you on upgrade.`);
+          const testElementEl1 = document.createElement("test-element");
 
-          testElementEl.removeAttribute("id");
-          document.body.appendChild(testElementEl);
-          sinon.assert.calledWith(spy, `pfe-test-element: The "on" attribute is protected and should not be manually added to a component. The base class will manage this value for you on upgrade.`);
+          testElementEl1.id = "test-element";
+          testElementEl1.setAttribute("on", "saturated");
 
-          document.body.removeChild(testElementEl);
+          document.body.appendChild(testElementEl1);
+
+          sinon.assert.calledWith(spy, `test-element[#test-element]: The "on" attribute is protected and should not be manually added to a component. The base class will manage this value for you on upgrade.`);
+
+          // without an id
+
+          const testElementEl2 = document.createElement("test-element");
+          testElementEl2.setAttribute("on", "saturated");
+          document.body.appendChild(testElementEl2);
+          sinon.assert.calledWith(spy, `test-element: The "on" attribute is protected and should not be manually added to a component. The base class will manage this value for you on upgrade.`);
         });
       });
     </script>


### PR DESCRIPTION


## pfelement

The pfelement tests weren't running, this restores them so they'll be run along with the rest of the test suite.


### What has changed and why

pfelement tests weren't running, seemingly because they were attempting to import pfelement.js from the package root, instead of the dist directory.

### Testing instructions

Try running `npm test` and look for pfelement tests, or `npm test pfelement` and verify that more than 0 tests run (previously, it would "pass" with zero tests run).

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [x] Repository compiles and tests pass.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**