### PR TITLE
fix: improve CLS rating in lighthouse

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,6 +1,7 @@
 ## Prerelease 55 ( TBD )
 
 - [](https://github.com/patternfly/patternfly-elements/commit/)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: improve CLS rating in lighthouse (#1020)
 
 ## Prerelease 54 ( 2020-07-31 )
 

--- a/elements/pfelement/src/pfelement.scss
+++ b/elements/pfelement/src/pfelement.scss
@@ -27,5 +27,6 @@ body[unresolved] {
   }
   100% {
     opacity: 1;
+    visibility: visible;
   }
 }

--- a/elements/pfelement/src/pfelement.scss
+++ b/elements/pfelement/src/pfelement.scss
@@ -12,15 +12,20 @@ body {
 
 body[unresolved] {
   opacity: 0;
+  visibility: hidden;
   animation: reveal var(--pfe-reveal-duration) var(--pfe-reveal-delay) 1
     forwards;
 }
 
 @keyframes reveal {
-  from {
+  0% {
+    visibility: hidden;
     opacity: 0;
   }
-  to {
+  1% {
+    visibility: visible;
+  }
+  100% {
     opacity: 1;
   }
 }

--- a/elements/pfelement/test/fouc-test.html
+++ b/elements/pfelement/test/fouc-test.html
@@ -43,7 +43,8 @@
         test('body[unresolved] should cause the page to be hidden', () => {
           document.body.setAttribute('unresolved', '');
           const styles = document.body.computedStyleMap();
-          assert.equal(styles.get('opacity').value, 0, 'body[unresolved] causes the page to be hidden');
+          assert.equal(styles.get('opacity').value, 0, 'body[unresolved] causes the page to have 0 opacity');
+          assert.equal(styles.get('visibility').value, "hidden", 'body[unresolved] causes the page to be hidden');
         });
 
         test('removing body[unresolved] should cause the page to be revealed', done => {
@@ -61,7 +62,8 @@
             if (styles.get('opacity').value === 1) {
               clearTimeout(tid);
               clearInterval(iid);
-              assert.equal(styles.get('opacity').value, 1, 'removing body[unresolved] causes the page to be revealed');
+              assert.equal(styles.get('opacity').value, 1, 'removing body[unresolved] causes the page to have 1 opacity');
+              assert.equal(styles.get('visibility').value, "visible", 'body[unresolved] causes the page to be visible');
               done();
             }
           }, 50);
@@ -69,6 +71,7 @@
           tid = setTimeout(() => {
             clearInterval(id);
             assert.equal(styles.get('opacity').value, 1, 'removing body[unresolved] causes the page to be revealed');
+            assert.equal(styles.get('visibility').value, "visible", 'body[unresolved] causes the page to be visible');
             done();
           }, 1500);
         });


### PR DESCRIPTION
### What has changed and why

Currently, we transition a page's `opacity` from 0 to 1 when the `unresolved` attribute is removed from the body element, or after 2s have elapsed (timing can be overridden with `--pfe-reveal-delay`), whichever comes first.  Recently, Google added a [Cumulative Layout Shift](https://web.dev/cls/?utm_source=lighthouse&utm_medium=devtools) metric to the Lighthouse tool, and it flags _some_ of our pages as having a moderate amount of layout shift.  @wesruv suggested this could be because while the body has opacity 0, it's still considered visible, so layout shifts are detected.  To remedy that, he suggested toggling `visibility` in addition to transitioning `opacity`.  This PR implements that change.

Our local tests showed that this reduced the CLS score on the project's root index.html page from 0.12 to 0.

### Testing instructions

Tests have been updated to make sure visibility is set correctly, however they won't pass until #1018 is merged.

#### Browser requirements

Your component should work in all of the following environments:

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [x] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [x] Latest 2 versions of Safari
- [x] Android mobile device (such as the Galaxy S9)
- [x] Apple mobile device (such as the iPhone X)
- [x] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Tests have been updated to cover these changes.
- [x] Browser testing passed.
- [x] Repository compiles and tests pass.
- [x] Changelog updated (not needed for documentation updates).
- [x] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**