### PR TITLE
docs: demo homepage - adding alt tags to images and fixing cta alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,10 @@
       margin-bottom: 16px;
     }
 
+    .header-ctas pfe-cta a {
+      min-width: 250px;
+    }
+
     @media (min-width: 500px) {
       .header-ctas {
         flex-direction: row;
@@ -81,6 +85,10 @@
       .header-ctas pfe-cta:first-child {
         margin-bottom: 0;
         margin-right: 16px;
+      }
+
+      .header-ctas pfe-cta a {
+        min-width: inherit;
       }
     }
   </style>
@@ -104,7 +112,7 @@
     <pfe-band pfe-color="lightest">
       <div class="pfe-l-grid pfe-m-gutters pfe-m-all-4-col-on-xl pfe-m-all-6-col-on-lg pfe-m-all-6-col-on-sm">
         <pfe-card pfe-color="lightest" pfe-border>
-          <img pfe-overflow="top right left" src="/brand/components@2x.png">
+          <img pfe-overflow="top right left" src="/brand/components@2x.png" alt="">
           <h2>Components</h2>
           <p>View the complete inventory of PatternFly Elements components.</p>
           <pfe-cta slot="pfe-card--footer">
@@ -112,7 +120,7 @@
           </pfe-cta>
         </pfe-card>
         <pfe-card pfe-color="lightest" pfe-border>
-          <img pfe-overflow="top right left" src="/brand/develop@2x.png">
+          <img pfe-overflow="top right left" src="/brand/develop@2x.png" alt="">
           <h2>Develop</h2>
           <p>Learn how to develop components for PatternFly Elements. View the basics on how to write HTML, CSS, and JavaScript for PatternFly Elements as well as how to properly test a component.</p>
           <pfe-cta slot="pfe-card--footer">
@@ -120,7 +128,7 @@
           </pfe-cta>
         </pfe-card>
         <pfe-card pfe-color="lightest" pfe-border>
-          <img pfe-overflow="top right left" src="/brand/theming@2x.png">
+          <img pfe-overflow="top right left" src="/brand/theming@2x.png" alt="">
           <h2>Theming and styles</h2>
           <p>View the documentation on the theme palette, colors, layouts, how to theme slots, and how to write styles</p>
           <pfe-cta slot="pfe-card--footer">
@@ -133,7 +141,7 @@
       <h2 class="pfe-l--text-align--center">Learn more</h2>
       <div class="pfe-l-grid pfe-m-gutters pfe-m-all-4-col">
         <pfe-card pfe-color="lightest">
-          <img pfe-overflow="top right left" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*zHHMQQBMora88A_WQJiNtw.png">
+          <img pfe-overflow="top right left" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*zHHMQQBMora88A_WQJiNtw.png" alt="">
           <h3>
             <a href="https://medium.com/patternfly-elements/web-components-and-seo-58227413e072">Web Components and SEO</a>
           </h3>
@@ -188,7 +196,7 @@
           </pfe-cta>
         </pfe-card>
         <pfe-card pfe-color="lightest">
-          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*VxME5U0fg6jyClhZBo-O3A.png">
+          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*VxME5U0fg6jyClhZBo-O3A.png" alt="">
           <h3>
             <a href="https://medium.com/patternfly-elements/more-resilientweb-components-in-angular-or-anywhere-else-with-mutationobserver-72a91cd7cf22">More Resilient Web Components in Angular (or anywhere else) with MutationObserver</a>
           </h3>
@@ -207,7 +215,7 @@
           </pfe-cta>
         </pfe-card>
         <pfe-card pfe-color="lightest">
-          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*R29zV1u1Fj-s3gw1P_D5LQ.png">
+          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*R29zV1u1Fj-s3gw1P_D5LQ.png" alt="">
           <h3>
             <a href="https://medium.com/patternfly-elements/patternfly-elements-writing-automated-tests-e5af412931dd">Writing automated tests for PatternFly Elements</a>
           </h3>
@@ -217,7 +225,7 @@
           </pfe-cta>
         </pfe-card>
         <pfe-card pfe-color="lightest">
-          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*6TbBJFAxhhi6K5WAbY5aCg.png">
+          <img pfe-overflow="left top right" src="https://cdn-images-1.medium.com/fit/t/1600/480/1*6TbBJFAxhhi6K5WAbY5aCg.png" alt="">
           <h3>
             <a href="https://medium.com/patternfly-elements/patternfly-elements-how-to-build-a-demo-component-448c32069a21">How to build a demo component</a>
           </h3>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       }
 
       .header-ctas pfe-cta a {
-        min-width: inherit;
+        min-width: initial;
       }
     }
   </style>


### PR DESCRIPTION
### Fixes
- Fixing Lighthouse issues by adding alt tags to images. No text in the alt tags are necessary since they are purely decorative.
- Adding some additional CSS to the CTAs in the header so they are the same size on a mobile device.

Before Lighthouse fixes
![image](https://user-images.githubusercontent.com/330256/89077258-cfc6a280-d34f-11ea-8a6a-53d546f4a254.png)

After Lighthouse fixes
![image](https://user-images.githubusercontent.com/330256/89077326-eff66180-d34f-11ea-812c-63d6d447cd0c.png)

Before CTA sizing fix
![image](https://user-images.githubusercontent.com/330256/89077386-0bfa0300-d350-11ea-97c2-396ca836d15a.png)

After CTA sizing fix
![image](https://user-images.githubusercontent.com/330256/89077409-1a481f00-d350-11ea-9750-cccda6feb9f0.png)

### Preview
- [Link](https://deploy-preview-1022--happy-galileo-ea79c4.netlify.app/) 


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
