### PR TITLE
Cpfed 3779 add icons pfe nav menu

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -112,11 +112,12 @@
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link" aria-haspopup="true" aria-expanded="false">
+          <!-- @todo: move aria-expanded into shadow DOM? -->
+            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
               Products
             </a>
 
-            <div class="pfe-navigation__dropdown-wrapper">
+            <div class="pfe-navigation__dropdown-wrapper" aria-hidden="true">
               <div class="pfe-navigation__dropdown">
                 <section>
                   <h3>
@@ -250,7 +251,7 @@
             </div>
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link" aria-haspopup="true" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
               Solutions
             </a>
             <div class="pfe-navigation__dropdown-wrapper pfe-navigation__dropdown-wrapper--single-column">
@@ -303,7 +304,7 @@
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
 
         <a href="#" class="">
-          <pfe-icon icon="rh-icon-cube" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+          <pfe-icon icon="rh-icon-cube" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
       </div>
@@ -334,7 +335,7 @@
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link" aria-haspopup="true" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
               Products
             </a>
             <div class="pfe-navigation__dropdown-wrapper">

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -103,8 +103,6 @@
     <h2>Small Logo</h2>
 
     <pfe-navigation id="pfe-navigation">
-      <!-- todo: figure out to do the overlay in shadow DOM -->
-      <!-- <div class="pfe-navigation__overlay"></div> -->
 
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
@@ -305,18 +303,12 @@
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
 
         <a href="#" class="">
-          <pfe-icon icon="rh-icon-circle-sphere" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+          <pfe-icon icon="rh-icon-cube" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
           Custom Link
         </a>
       </div>
 
       <!-- @todo: make sure all icons are the updated redesigned versions -->
-
-      <!-- pfe-icon for All Red Hat, @todo: get into shadow DOM-->
-      <!-- <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon> -->
-
-      <!-- pfe-icon for search, @todo: get into shadow DOM -->
-      <!-- <pfe-icon icon="rh-icon-search" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon> -->
 
       <!-- @todo: add aria-hidden="true/false" toggle functionality to all buttons and top level menu items and accordion top level menu items on mobile -->
       <div slot="pfe-navigation--search" class="pfe-navigation__search">

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -37,8 +37,7 @@
 
     <script>require([
       "../dist/pfe-navigation.umd.js",
-      "../../pfe-cta/dist/pfe-cta.umd.js",
-      "../../pfe-icon/dist/pfe-icon.umd.js"
+      "../../pfe-cta/dist/pfe-cta.umd.js"
     ])</script>
 
     <style>
@@ -64,6 +63,12 @@
         cursor: pointer;
         transition: box-shadow 0.25s;
       }
+
+      pfe-icon.PFElement {
+        --pfe-icon--Color: #0066CC;
+        --pfe-icon--size: 18px;
+      }
+
       @media (min-width: 768px) {
         .pfe-navigation__custom-links a,
         .pfe-navigation__custom-links button {
@@ -93,6 +98,22 @@
           border-top: 0px dashed #fff;
           outline: 0;
         }
+
+        pfe-icon.PFElement {
+          --pfe-icon--Color: #fff;
+        }
+      }
+
+      /* @todo: figure out better way to keep custom link text from breaking to multiple lines if at all possible or figure out how to keep the breaking from looking bad */
+      /* @note: temporary style */
+      div#pfe-navigation__custom-links {
+        width: auto;
+      }
+
+      @media (min-width: 768px) {
+        div#pfe-navigation__custom-links {
+          width: 125px;
+        }
       }
 
     </style>
@@ -101,7 +122,6 @@
     <h1><code>pfe-navigation</code></h1>
 
     <h2>Small Logo</h2>
-
     <pfe-navigation id="pfe-navigation">
 
       <nav class="pfe-navigation" aria-label="Main Navigation">
@@ -112,12 +132,14 @@
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-          <!-- @todo: move aria-expanded into shadow DOM? -->
-            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
+            <!-- @note: removed aria-haspopup attr bc it should not be used for this type of menu, changed to using a class has-dropdown but this probably needs to be implemented differently -->
+
+            <!-- @todo: move aria and has-dropdown to shadow DOM? -->
+            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
               Products
             </a>
 
-            <div class="pfe-navigation__dropdown-wrapper" aria-hidden="true">
+            <div class="pfe-navigation__dropdown-wrapper">
               <div class="pfe-navigation__dropdown">
                 <section>
                   <h3>
@@ -251,7 +273,7 @@
             </div>
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
               Solutions
             </a>
             <div class="pfe-navigation__dropdown-wrapper pfe-navigation__dropdown-wrapper--single-column">
@@ -302,22 +324,18 @@
         </ul>
       </nav>
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
-
         <a href="#" class="">
+          <!-- @todo: added the cube icon as a placeholder, might need to be updated -->
           <pfe-icon icon="rh-icon-cube" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
       </div>
-
-      <!-- @todo: make sure all icons are the updated redesigned versions -->
-
-      <!-- @todo: add aria-hidden="true/false" toggle functionality to all buttons and top level menu items and accordion top level menu items on mobile -->
       <div slot="pfe-navigation--search" class="pfe-navigation__search">
       <!-- @todo: move form and label for="" and label id into shadow DOM -->
       <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label for="pfe-navigation__search-label">Search</label>
-          <input id="pfe-navigation__search-label" type="text" placeholder="Search" />
+          <label for="pfe-navigation__search-label1">Search</label>
+          <input id="pfe-navigation__search-label1" type="text" placeholder="Search" />
           <button>Search</button>
         </form>
       </div>
@@ -335,7 +353,7 @@
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
               Products
             </a>
             <div class="pfe-navigation__dropdown-wrapper">
@@ -474,12 +492,19 @@
         </ul>
       </nav>
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
-        <a href="#" class="">Custom Link</a>
+        <a href="#" class="">
+          <!-- @todo: added the cube icon as a placeholder, might need to be updated -->
+          <pfe-icon icon="rh-icon-cube" pfe-size="sm" aria-hidden="true"></pfe-icon>
+          Custom Link
+        </a>
       </div>
+
       <div slot="pfe-navigation--search" class="pfe-navigation__search">
+      <!-- @todo: move form and label for="" and label id into shadow DOM -->
+      <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label>Search</label>
-          <input type="text" placeholder="Search" />
+          <label for="pfe-navigation__search-label2">Search</label>
+          <input id="pfe-navigation__search-label2" type="text" placeholder="Search" />
           <button>Search</button>
         </form>
       </div>

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -37,7 +37,8 @@
 
     <script>require([
       "../dist/pfe-navigation.umd.js",
-      "../../pfe-cta/dist/pfe-cta.umd.js"
+      "../../pfe-cta/dist/pfe-cta.umd.js",
+      "../../pfe-icon/dist/pfe-icon.umd.js"
     ])</script>
 
     <style>
@@ -100,9 +101,10 @@
     <h1><code>pfe-navigation</code></h1>
 
     <h2>Small Logo</h2>
+
     <pfe-navigation id="pfe-navigation">
-      <!-- todo: figure out to do the overlay -->
-      <div class="pfe-navigation__overlay"></div>
+      <!-- todo: figure out to do the overlay in shadow DOM -->
+      <!-- <div class="pfe-navigation__overlay"></div> -->
 
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
@@ -303,10 +305,14 @@
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
         <a href="#" class="">Custom Link</a>
       </div>
+
+      <!-- @todo: add aria-hidden="true/false" toggle functionality to all buttons and top level menu items and accordion top level menu items on mobile -->
       <div slot="pfe-navigation--search" class="pfe-navigation__search">
+      <!-- @todo: move form and label for="" and label id into shadow DOM -->
+      <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label>Search</label>
-          <input type="text" placeholder="Search" />
+          <label for="pfe-navigation__search-label">Search</label>
+          <input id="pfe-navigation__search-label" type="text" placeholder="Search" />
           <button>Search</button>
         </form>
       </div>

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -303,8 +303,20 @@
         </ul>
       </nav>
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
-        <a href="#" class="">Custom Link</a>
+
+        <a href="#" class="">
+          <pfe-icon icon="rh-icon-circle-sphere" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+          Custom Link
+        </a>
       </div>
+
+      <!-- @todo: make sure all icons are the updated redesigned versions -->
+
+      <!-- pfe-icon for All Red Hat, @todo: get into shadow DOM-->
+      <!-- <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon> -->
+
+      <!-- pfe-icon for search, @todo: get into shadow DOM -->
+      <!-- <pfe-icon icon="rh-icon-search" pfe-size="sm" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon> -->
 
       <!-- @todo: add aria-hidden="true/false" toggle functionality to all buttons and top level menu items and accordion top level menu items on mobile -->
       <div slot="pfe-navigation--search" class="pfe-navigation__search">

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -77,6 +77,7 @@ $breakpoints: (
   font-family: inherit;
   font-size: 16px;
   color: #06c;
+  text-align: center;
   text-decoration: none;
   background: transparent;
   appearance: none;

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -116,19 +116,18 @@ $breakpoints: (
     }
   }
 
-  &:before {
-    content: '';
-    display: block;
-    width: 18px;
-    height: 18px;
-    margin: 0 16px 0 0;
-    background: rgba(126, 126, 126, 0.3);
-    @include breakpoint('secondary-links-expand') {
-      margin: 0 0 4px;
-    }
-  }
-
-  // @todo Focus styles?
+  // @todo: remove these styles once pfe-icons are added
+  // &:before {
+  //   content: '';
+  //   display: block;
+  //   width: 18px;
+  //   height: 18px;
+  //   margin: 0 16px 0 0;
+  //   background: rgba(126, 126, 126, 0.3);
+  //   @include breakpoint('secondary-links-expand') {
+  //     margin: 0 0 4px;
+  //   }
+  // }
 }
 
 @mixin dropdown-transitions($is-open: true) {

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -1,8 +1,10 @@
-<!-- todo: figure out to do the overlay in shadow DOM -->
-<!-- <div class="pfe-navigation__overlay"></div> -->
-
 <nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
-  <button class="pfe-navigation__menu-toggle" aria-expanded="false">
+  <!-- @todo: make sure all icons are the updated redesigned versions -->
+
+  <!-- @todo: add aria-hidden="true/false" toggle functionality to all buttons and top level menu items and accordion top level menu items on mobile -->
+  <button class="pfe-navigation__menu-toggle">
+    <!-- @todo: Wes to change this to be implemented with CSS and add CSS animations -->
+    <pfe-icon icon="web-icon-mobile-menu" pfe-size="sm" aria-hidden="true"></pfe-icon>
     Menu
   </button>
 
@@ -16,8 +18,8 @@
       <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
       </div>
 
-      <button class="pfe-navigation__search-toggle" aria-expanded="false">
-        <pfe-icon icon="web-search" pfe-size="md" aria-hidden="true"></pfe-icon>
+      <button class="pfe-navigation__search-toggle">
+        <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
         Search
       </button>
 
@@ -25,8 +27,8 @@
         customlinks slot
       </slot>
 
-      <button class="pfe-navigation__all-red-hat-toggle" aria-expanded="false">
-        <pfe-icon icon="web-icon-grid-3x3" pfe-size="md" aria-hidden="true"></pfe-icon>
+      <button class="pfe-navigation__all-red-hat-toggle">
+        <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
         All Red&nbsp;Hat
       </button>
       <div class="pfe-navigation__all-red-hat-wrapper">
@@ -38,9 +40,12 @@
     </div>
   </div>
 
-  <a href="#" class="pfe-navigation__log-in-link" aria-expanded="false">
-    <pfe-icon icon="web-icon-user" pfe-size="md" aria-hidden="true"></pfe-icon>
+  <a href="#" class="pfe-navigation__log-in-link">
+    <pfe-icon icon="web-icon-user" pfe-size="sm" aria-hidden="true"></pfe-icon>
     Log&nbsp;In
   </a>
 
 </nav>
+
+<!-- todo: figure out to do the overlay in shadow DOM -->
+<!-- <div class="pfe-navigation__overlay"></div> -->

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -2,7 +2,7 @@
 <!-- <div class="pfe-navigation__overlay"></div> -->
 
 <nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
-  <button class="pfe-navigation__menu-toggle">
+  <button class="pfe-navigation__menu-toggle" aria-expanded="false">
     Menu
   </button>
 
@@ -16,8 +16,8 @@
       <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
       </div>
 
-      <button class="pfe-navigation__search-toggle">
-        <pfe-icon icon="web-search" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+      <button class="pfe-navigation__search-toggle" aria-expanded="false">
+        <pfe-icon icon="web-search" pfe-size="md" aria-hidden="true"></pfe-icon>
         Search
       </button>
 
@@ -25,8 +25,8 @@
         customlinks slot
       </slot>
 
-      <button class="pfe-navigation__all-red-hat-toggle">
-        <pfe-icon icon="web-icon-grid-3x3" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+      <button class="pfe-navigation__all-red-hat-toggle" aria-expanded="false">
+        <pfe-icon icon="web-icon-grid-3x3" pfe-size="md" aria-hidden="true"></pfe-icon>
         All Red&nbsp;Hat
       </button>
       <div class="pfe-navigation__all-red-hat-wrapper">
@@ -38,8 +38,8 @@
     </div>
   </div>
 
-  <a href="#" class="pfe-navigation__log-in-link">
-    <pfe-icon icon="web-icon-user" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
+  <a href="#" class="pfe-navigation__log-in-link" aria-expanded="false">
+    <pfe-icon icon="web-icon-user" pfe-size="md" aria-hidden="true"></pfe-icon>
     Log&nbsp;In
   </a>
 

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -1,3 +1,6 @@
+<!-- todo: figure out to do the overlay in shadow DOM -->
+<!-- <div class="pfe-navigation__overlay"></div> -->
+
 <nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
   <button class="pfe-navigation__menu-toggle">
     Menu
@@ -14,6 +17,7 @@
       </div>
 
       <button class="pfe-navigation__search-toggle">
+        <pfe-icon icon="web-search" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
         Search
       </button>
 
@@ -22,6 +26,7 @@
       </slot>
 
       <button class="pfe-navigation__all-red-hat-toggle">
+        <pfe-icon icon="web-icon-grid-3x3" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
         All Red&nbsp;Hat
       </button>
       <div class="pfe-navigation__all-red-hat-wrapper">
@@ -34,6 +39,7 @@
   </div>
 
   <a href="#" class="pfe-navigation__log-in-link">
+    <pfe-icon icon="web-icon-user" pfe-size="md" aria-hidden="true" style="--pfe-icon--Color: #fff;"></pfe-icon>
     Log&nbsp;In
   </a>
 

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -1,4 +1,5 @@
 import PFElement from "../../pfelement/dist/pfelement.js";
+import PfeIcon from "../../pfe-icon/dist/pfe-icon.js";
 
 // @todo Figure out cooler way to include these utilty functions
 /**
@@ -131,8 +132,6 @@ class PfeNavigation extends PFElement {
     this._searchToggleEventListener = this._searchToggleEventListener.bind(this);
     this._allRedHatToggleEventListener = this._allRedHatToggleEventListener.bind(this);
     this._dropDownItemToggle = this._dropDownItemToggle.bind(this);
-    // a11y settings
-    this._toggleAriaState = this._toggleAriaState.bind(this);
     this._addMenuBreakpoints = this._addMenuBreakpoints.bind(this);
     this._collapseMainMenu = this._collapseMainMenu.bind(this);
     this._collapseSecondaryLinks = this._collapseSecondaryLinks.bind(this);
@@ -160,7 +159,6 @@ class PfeNavigation extends PFElement {
     // this.customlinks.addEventListener("slotchange", this._init);
   }
 
-  // @todo: figure out what needs to go into the disconnected callback
   disconnectedCallback() {}
 
   // Process the attribute change
@@ -327,20 +325,12 @@ class PfeNavigation extends PFElement {
     }
 
     // Add menu dropdown toggle behavior
-    const dropDownItems = this.shadowRoot.querySelectorAll(".pfe-navigation__menu-link[aria-expanded]");
+    // @note amd @todo: updated to use has-dropdown class instead of aria-haspopup attr, probably needs to be implemented differently
+    const dropDownItems = this.shadowRoot.querySelectorAll(".pfe-navigation__menu-link.has-dropdown");
     for (let index = 0; index < dropDownItems.length; index++) {
       const dropDownItem = dropDownItems[index];
       dropDownItem.dataset.machineName = this._createMachineName(dropDownItem.text);
       dropDownItem.addEventListener("click", this._dropDownItemToggle);
-    }
-
-    // Add top level toggle button aria behavior
-    const toggleButtons = this.shadowRoot.querySelectorAll("button[aria-expanded]");
-    console.log(toggleButtons);
-    // console.log(toggleButtons);
-    for (let index = 0; index < toggleButtons.length; index++) {
-      const toggleButton = toggleButtons[index];
-      toggleButton.addEventListener("click", this._toggleAriaState);
     }
 
     // Add menu burger behavior
@@ -354,8 +344,6 @@ class PfeNavigation extends PFElement {
     const allRedHat = this.shadowRoot.querySelector(".pfe-navigation__all-red-hat-toggle");
 
     allRedHat.addEventListener("click", this._allRedHatToggleEventListener);
-
-    // a11y settings
 
     // Give all dropdowns aria-hidden since they're shut by default
     this.shadowRoot.querySelector(".pfe-navigation__dropdown-wrapper").setAttribute("aria-hidden", true);
@@ -468,60 +456,26 @@ class PfeNavigation extends PFElement {
     const toggleId = `main-menu__dropdown--${machineName}`;
     const dropDownWrapper = dropDownItem.parentElement.querySelector(".pfe-navigation__dropdown-wrapper");
 
-    // a11y settings for aria-expanded
-    /**
-      @note: refactored aria settings:
-      aria-haspop should not be used in this menu bc it is not a true menu, use aria-expanded instead
-      refactored aria-expanded behaviour to ensure that only the open item is getting aria-expanded="true"
-    */
-
-    // todo: figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
-    const ariaExpanded = dropDownItem.getAttribute("aria-expanded") === true;
-    const ariaHidden = dropDownWrapper.getAttribute("aria-hidden") === true;
-
     // Don't navigate
     event.preventDefault();
 
-    // a11y settings
-    dropDownItem.setAttribute("aria-expanded", !ariaExpanded);
-
     // Toggle state and manage attributes for a11y and styling
     if (this._toggleNavigationState(toggleId)) {
-      // dropDownItem.setAttribute("aria-expanded", "true");
+      dropDownItem.setAttribute("aria-expanded", "true");
       // Manage class on parent li so it's easier to style any child that needs style updates
       dropDownItem.parentElement.classList.add("pfe-navigation__menu-item--open");
-      // dropDownWrapper.setAttribute("aria-hidden", false);
-      // a11y settings (needs to be opposite of aria-expanded)
-      dropDownWrapper.setAttribute("aria-hidden", ariaHidden);
+      dropDownWrapper.setAttribute("aria-hidden", false);
       if (!this.isNavigationMobileStyle() && parseInt(dropDownWrapper.dataset.height) > 30) {
         dropDownWrapper.style.setProperty("height", `${dropDownWrapper.dataset.height}px`);
       }
     } else {
-      // dropDownItem.setAttribute("aria-expanded", "false");
+      dropDownItem.setAttribute("aria-expanded", "false");
       dropDownItem.parentElement.classList.remove("pfe-navigation__menu-item--open");
-      // dropDownWrapper.setAttribute("aria-hidden", true);
-      // a11y settings (needs to be opposite of aria-expanded)
-      dropDownWrapper.setAttribute("aria-hidden", !ariaHidden);
+      dropDownWrapper.setAttribute("aria-hidden", true);
       if (dropDownWrapper.hasAttribute("style")) {
         dropDownWrapper.style.removeProperty("height");
       }
     }
-  }
-
-  /**
-   * Manages pfe-navigation top level items ARIA state
-   * @param {string} event to capture target of event
-   */
-
-  // @todo: refactor all aria-expanded and aria-hidden states to work with pfe-navigation-state="" value instead to try and fix aria-expanded states getting out of sync
-  _toggleAriaState(event) {
-    // A11y settings
-    // todo: figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
-    const targetElement = event.target;
-    const ariaExpanded = targetElement.getAttribute("aria-expanded") === "true" || false;
-
-    targetElement.setAttribute("aria-expanded", !ariaExpanded);
-    console.log(targetElement.getAttribute("aria-expanded"));
   }
 }
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -154,9 +154,10 @@ See mixin blocks before selectors that contain the selector name and the three l
     box-shadow: inset 0 4px 0 0 #e00;
   }
 
-  &:before {
-    margin: 0 0 4px;
-  }
+  //@todo: decide if this is needed with pfe-icons in place
+  // &:before {
+  //   margin: 0 0 4px;
+  // }
 }
 
 // Layout changes per breakpoint
@@ -476,8 +477,8 @@ See mixin blocks before selectors that contain the selector name and the three l
 .pfe-navigation__menu-link[aria-haspopup=true] {
   position: relative;
 
-  &:hover,
-  &:focus {
+  &:focus,
+  &:hover {
     @include breakpoint('nav-expand') {
       box-shadow: inset 0 4px 0 0 #e00;
     }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -474,6 +474,7 @@ See mixin blocks before selectors that contain the selector name and the three l
 }
 
 // Top level links that have a dropdown associated with them
+// @todo: make sure all styles get fixed that were using aria-haspopup originally
 .pfe-navigation__menu-link[aria-expanded=true] {
   position: relative;
 
@@ -535,6 +536,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   transform: translate(-4px, -12px);
   transition: border-color 0.25s;
 }
+// @todo: make sure all styles get fixed that were using aria-haspopup originally
 .pfe-navigation__menu-link[aria-expanded=true]:before {
   @include pfe-navigation__menu-link__before--mobile;
   content: '';

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -475,13 +475,14 @@ See mixin blocks before selectors that contain the selector name and the three l
 
 // Top level links that have a dropdown associated with them
 // @todo: make sure all styles get fixed that were using aria-haspopup originally
-.pfe-navigation__menu-link[aria-expanded=true] {
+.pfe-navigation__menu-link.has-dropdown {
   position: relative;
 
   &:focus,
   &:hover {
     @include breakpoint('nav-expand') {
       box-shadow: inset 0 4px 0 0 #e00;
+      @include focus-styles(#fff, 0px);
     }
     @include collapse('nav') {
       box-shadow: none;
@@ -493,17 +494,21 @@ See mixin blocks before selectors that contain the selector name and the three l
       color: #151515;
       background: #fff;
       box-shadow: inset 0 4px 0 0 #e00;
+      // @todo: get the aria-expanded feature in the JS working again
+      // &[aria-expanded="true"] {
+      //   &:focus,
+      //   &:hover {
+      //     @include focus-styles(#000, 0px);
+      //   }
+      // }
+      &:focus,
+      &:hover {
+        @include focus-styles(#000, 0px);
+      }
     }
     @include collapse('nav') {
       box-shadow: none;
       background: transparent;
-    }
-  }
-
-  &[aria-expanded="true"] {
-    &:focus,
-    &:hover {
-      @include focus-styles(#000, 0px);
     }
   }
 }
@@ -537,7 +542,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   transition: border-color 0.25s;
 }
 // @todo: make sure all styles get fixed that were using aria-haspopup originally
-.pfe-navigation__menu-link[aria-expanded=true]:before {
+.pfe-navigation__menu-link.has-dropdown:before {
   @include pfe-navigation__menu-link__before--mobile;
   content: '';
 
@@ -959,24 +964,88 @@ See mixin blocks before selectors that contain the selector name and the three l
 //   }
 // }
 
-// #151515
+
 // pfe-icons
 // --------------------------------------------------------
 
-//@todo: figure out if this is the correct scoping for the icon styles
-// .pfe-navigation__wrapper pfe-icon {
-//   --pfe-icon--Color: #fff;
-// }
+//@todo: figure out if this is the best way to style the icon color states or if updates to JS need to be made to put a class or attribute on a button when it is open to target with css
 
 .pfe-navigation__menu-toggle pfe-icon,
 .pfe-navigation__search-toggle pfe-icon,
 .pfe-navigation__custom-links pfe-icon,
-.pfe-navigation__all-red-hat-toggle pfe-icon {
+.pfe-navigation__log-in-link pfe-icon {
   --pfe-icon--Color: #fff;
+  // @todo: do we need to implement this differently with theming?
+  --pfe-icon--size: 18px;
+  // @todo: figure out best spacing styles for this icon
+  padding-right: 5px;
+  padding-bottom: 0px;
+  @include breakpoint('secondary-links-expand') {
+    --pfe-icon--Color: #fff;
+    padding-right: 0px;
+    padding-bottom: 5px;
+  }
 }
 
-[pfe-navigation-state^='main-menu--open'] pfe-icon,
-[pfe-navigation-state^='search--open'] pfe-icon,
-[pfe-navigation-state^='all-red-hat--open'] pfe-icon {
+.pfe-navigation__custom-links pfe-icon {
+  --pfe-icon--Color: #0066CC;
+  @include breakpoint('secondary-links-expand') {
+    --pfe-icon--Color: #fff;
+  }
+}
+
+.pfe-navigation__all-red-hat-toggle pfe-icon {
+  --pfe-icon--Color: #0066CC;
+  --pfe-icon--size: 18px;
+  // @todo: figure out best spacing styles for this icon
+  padding-right: 5px;
+  padding-bottom: 0px;
+  @include breakpoint('secondary-links-expand') {
+    --pfe-icon--Color: #fff;
+    padding-right: 0px;
+    padding-bottom: 5px;
+  }
+}
+
+// @todo: figure out better way to keep "All Red Hat" from breaking to multiple lines
+.pfe-navigation__all-red-hat-toggle {
+  width: auto;
+  @include breakpoint('secondary-links-expand') {
+    width: 95px;
+  }
+}
+
+// @todo: figure out better way to keep custom link text from breaking to multiple lines if at all possible or figure out how to keep the breaking from looking bad
+// @note: temporary style
+div#pfe-navigation__custom-links {
+  width: auto;
+  @include breakpoint('secondary-links-expand') {
+    width: 120px;
+  }
+}
+
+[pfe-navigation-state^='main-menu--open'] .pfe-navigation__menu-toggle pfe-icon {
   --pfe-icon--Color: #151515;
+}
+
+[pfe-navigation-state^='search--open'] .pfe-navigation__search-toggle pfe-icon {
+  --pfe-icon--Color: #151515;
+}
+
+[pfe-navigation-state^='all-red-hat--open'] .pfe-navigation__all-red-hat-toggle pfe-icon {
+  --pfe-icon--Color: #0066CC;
+  @include breakpoint('secondary-links-expand') {
+    --pfe-icon--Color: #151515;
+  }
+}
+
+// @todo: login JS and demo example needs to be added
+[pfe-navigation-state^='log-in--open'] .pfe-navigation__all-red-hat-toggle pfe-icon {
+  --pfe-icon--Color: #151515;
+}
+
+// mobile menu icon styles - make the plus sign an X
+// @todo: Wes to implement mobile menu button icons with CSS
+.pfe-navigation__menu-toggle pfe-icon[icon='web-icon-plus'] {
+  transform: rotate(-45deg);
 }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -474,7 +474,7 @@ See mixin blocks before selectors that contain the selector name and the three l
 }
 
 // Top level links that have a dropdown associated with them
-.pfe-navigation__menu-link[aria-haspopup=true] {
+.pfe-navigation__menu-link[aria-expanded=true] {
   position: relative;
 
   &:focus,
@@ -535,7 +535,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   transform: translate(-4px, -12px);
   transition: border-color 0.25s;
 }
-.pfe-navigation__menu-link[aria-haspopup=true]:before {
+.pfe-navigation__menu-link[aria-expanded=true]:before {
   @include pfe-navigation__menu-link__before--mobile;
   content: '';
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -556,6 +556,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     }
   }
 
+  // @todo: figure out why transform is not working anymore
   .pfe-navigation__menu-item--open > &[class]:before { // [class] adds specificity to beat out hover/focus selector
     transform: rotate(135deg);
     @include breakpoint('nav-expand') {
@@ -955,3 +956,25 @@ See mixin blocks before selectors that contain the selector name and the three l
     // Add styles here
 //   }
 // }
+
+// #151515
+// pfe-icons
+// --------------------------------------------------------
+
+//@todo: figure out if this is the correct scoping for the icon styles
+// .pfe-navigation__wrapper pfe-icon {
+//   --pfe-icon--Color: #fff;
+// }
+
+.pfe-navigation__menu-toggle pfe-icon,
+.pfe-navigation__search-toggle pfe-icon,
+.pfe-navigation__custom-links pfe-icon,
+.pfe-navigation__all-red-hat-toggle pfe-icon {
+  --pfe-icon--Color: #fff;
+}
+
+[pfe-navigation-state^='main-menu--open'] pfe-icon,
+[pfe-navigation-state^='search--open'] pfe-icon,
+[pfe-navigation-state^='all-red-hat--open'] pfe-icon {
+  --pfe-icon--Color: #151515;
+}

--- a/elements/pfelement/src/pfelement.js
+++ b/elements/pfelement/src/pfelement.js
@@ -219,10 +219,7 @@ class PFElement extends HTMLElement {
   }
 
   _copyAttribute(name, to) {
-    const recipients = [
-      ...this.querySelectorAll(to),
-      ...this.shadowRoot.querySelectorAll(to)
-    ];
+    const recipients = [...this.querySelectorAll(to), ...this.shadowRoot.querySelectorAll(to)];
     const value = this.getAttribute(name);
     const fname = value == null ? "removeAttribute" : "setAttribute";
     for (const node of recipients) {
@@ -265,9 +262,7 @@ class PFElement extends HTMLElement {
         // Otherwise, look for a default and use that instead
         else if (data.default) {
           const dependency_exists = this._hasDependency(tag, data.options);
-          const no_dependencies =
-            !data.options ||
-            (data.options && !data.options.dependencies.length);
+          const no_dependencies = !data.options || (data.options && !data.options.dependencies.length);
           // If the dependency exists or there are no dependencies, set the default
           if (dependency_exists || no_dependencies) {
             this.setAttribute(attrName, data.default);
@@ -289,12 +284,9 @@ class PFElement extends HTMLElement {
     // Check that dependent item exists
     // Loop through the dependencies defined
     for (let i = 0; i < dependencies.length; i += 1) {
-      const slot_exists =
-        dependencies[i].type === "slot" &&
-        this.has_slots(`${tag}--${dependencies[i].id}`).length > 0;
+      const slot_exists = dependencies[i].type === "slot" && this.has_slots(`${tag}--${dependencies[i].id}`).length > 0;
       const attribute_exists =
-        dependencies[i].type === "attribute" &&
-        this.getAttribute(`${prefix}${dependencies[i].id}`);
+        dependencies[i].type === "attribute" && this.getAttribute(`${prefix}${dependencies[i].id}`);
       // If the type is slot, check that it exists OR
       // if the type is an attribute, check if the attribute is defined
       if (slot_exists || attribute_exists) {
@@ -338,9 +330,7 @@ class PFElement extends HTMLElement {
           }
           // If it's the default slot, look for direct children not assigned to a slot
         } else {
-          result = [...this.children].filter(
-            child => !child.hasAttribute("slot")
-          );
+          result = [...this.children].filter(child => !child.hasAttribute("slot"));
 
           if (result.length > 0) {
             slotObj.nodes = result;
@@ -402,10 +392,7 @@ class PFElement extends HTMLElement {
     PFElement.log(`[${this.tag}]`, ...msgs);
   }
 
-  emitEvent(
-    name,
-    { bubbles = true, cancelable = false, composed = false, detail = {} } = {}
-  ) {
+  emitEvent(name, { bubbles = true, cancelable = false, composed = false, detail = {} } = {}) {
     this.log(`Custom event: ${name}`);
     this.dispatchEvent(
       new CustomEvent(name, {

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,11 +98,20 @@
 | Filename | line # | TODO
 |:------|:------:|:------
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L3) | 3 | Figure out cooler way to include these utilty functions
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L163) | 163 | figure out what needs to go into the disconnected callback
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L303) | 303 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L377) | 377 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L386) | 386 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L4) | 4 | Figure out cooler way to include these utilty functions
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L240) | 240 | figure out what needs to go into the disconnected callback
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L317) | 317 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L321) | 321 | add a persistant attr to component that shows whenever the mobile menu burger exists and is open
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L329) | 329 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L335) | 335 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L343) | 343 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L407) | 407 | look into only replacing markup that changed via mutationList
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L480) | 480 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L489) | 489 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L581) | 581 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L619) | 619 | refactor all aria-expanded and aria-hidden states to work with pfe-navigation-state="" value instead to try and fix aria-expanded states getting out of sync
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L622) | 622 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L629) | 629 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
 | [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -69,7 +69,6 @@
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-progress-indicator/demo">pfe-progress-indicator</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-select/demo">pfe-select</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-styles/demo">pfe-styles</a></pfe-cta>
-				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-switch/demo">pfe-switch</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-tabs/demo">pfe-tabs</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-toast/demo">pfe-toast</a></pfe-cta>
 			</div>
@@ -101,10 +100,11 @@
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
 | [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L3) | 3 | Figure out cooler way to include these utilty functions
 | [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L300) | 300 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L371) | 371 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L363) | 363 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L372) | 372 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
-| [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>
+| [pfelement](../elements/pfelement/src/pfelement.js#L378) | 378 | This is a duplicate function to cssVariable above, combine them</div>
             </pfe-markdown>
         </pfe-band>
     </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -99,12 +99,13 @@
 |:------|:------:|:------
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
 | [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L3) | 3 | Figure out cooler way to include these utilty functions
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L300) | 300 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L363) | 363 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L372) | 372 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L163) | 163 | figure out what needs to go into the disconnected callback
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L303) | 303 | look into only replacing markup that changed via mutationList
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L377) | 377 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L386) | 386 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
-| [pfelement](../elements/pfelement/src/pfelement.js#L378) | 378 | This is a duplicate function to cssVariable above, combine them</div>
+| [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>
             </pfe-markdown>
         </pfe-band>
     </body>


### PR DESCRIPTION
---
name: CPFED 3779 add icons to pfe-nav menu using pfe-icon
labels: "ready for review"
---

## pfe-navigation

Added icons to the menu using `pfe-icon` and refactored the aria-haspopup feature bc we should not use it on this type of navigation menu since it is not a true application menu. Refactored to use `has-dropdown` class for now but this might need to be implemented differently.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
