### PR TITLE
CPFED-3779: updated custom link icon placeholder 

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -370,8 +370,8 @@
       </nav>
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
         <a href="#" class="">
-          <!-- @todo: added the cube icon as a placeholder, might need to be updated -->
-          <pfe-icon icon="rh-icon-cube" pfe-size="md" aria-hidden="true"></pfe-icon>
+          <!-- @note: added web-icon-globe icon as a placeholder since it is used as the language switcher icon -->
+          <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
       </div>
@@ -538,8 +538,8 @@
       </nav>
       <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
         <a href="#" class="">
-          <!-- @todo: added the cube icon as a placeholder, might need to be updated -->
-          <pfe-icon icon="rh-icon-cube" pfe-size="sm" aria-hidden="true"></pfe-icon>
+          <!-- @note: added web-icon-globe icon as a placeholder since it is used as the language switcher icon -->
+          <pfe-icon icon="web-icon-globe" pfe-size="sm" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
       </div>


### PR DESCRIPTION
updated custom link icon placeholder to globe icon, could not use bell icon yet bc it is not in avalon-docs. used globe instead for now bc it is used as the language switcher icon on redhat.com so is a realistic icon example


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
