### PR TITLE
docs: allow embedding HTML in markdown docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -57,3 +57,8 @@ canonifyURLs = true
   quality = 75
   # Valid values are Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight
   anchor = "smart"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Kendall reported that HTML was being elided from markdown docs.  Luke found in [the hugo 0.60.0 release notes](https://gohugo.io/news/0.60.0-relnotes/) that a new config option is needed to re-enable embedding HTML.

### What has changed and why

Configured hugo's new markdown parser, goldmark, to allow HTML embedding.

### Testing instructions

1. run the hugo server locally, look at docs pages with embedded HTML and ensure the HTML is rendering properly.
2. poke around other pages to be sure this change didn't break anything (there coud _potentially_ be docs pages with buggy HTML that was meant to be embedded, but never was, and once it is, the bugs will crawl out.)


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**