### PR TITLE
WIP pfe-cta:  fix text-wrapping

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -2,6 +2,7 @@
 
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfelement - restore pfelement tests (#1018)
 - [fbe4423](https://github.com/patternfly/patternfly-elements/commit/fbe442396f06b0a097366512b698dc0b6d5e1f9f) fix: improve CLS rating in lighthouse (#1020)
+- []()fix: unnecessary pfe-cta text wrapping 
 
 ## Prerelease 54 ( 2020-07-31 )
 

--- a/elements/pfe-cta/demo/index.html
+++ b/elements/pfe-cta/demo/index.html
@@ -189,7 +189,10 @@
     <pfe-band pfe-color="lightest" style="--pfe-band--Border: 1px solid #ddd">
       <h2 slot="pfe-band--header">Force wrap to test arrow line-wrap</h2>
       <div class="default-link-test resize">
-        <pfe-cta><a href="https://www.redhat.com#default">Default link cta with longer text</a></pfe-cta>
+        <pfe-cta><a href="https://www.redhat.com#default">Default link cta with longer text and more words</a></pfe-cta>
+      </div>
+      <div class="default-link-test resize">
+        <pfe-cta pfe-priority="primary"><a href="https://www.redhat.com#default">Primary link cta with longer text and more words</a></pfe-cta>
       </div>
     </pfe-band>
 

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -57,13 +57,14 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
   z-index: 0;
   vertical-align: middle;
 
-  max-width: pfe-local(MaxWidth);
-
   background-color: pfe-local(BackgroundColor);
   border-radius: pfe-local(BorderRadius);
   border: pfe-var(ui--border-width) pfe-var(ui--border-style) pfe-local(BorderColor);
 
   cursor: pointer;
+  @at-root #{&}(:not([pfe-priority])) {  
+    max-width: pfe-local(MaxWidth);
+  }
 }
 
 ::slotted(*) {
@@ -109,8 +110,9 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
   &--wrapper {
     display: block; 
     white-space: nowrap;
-    //min-width: 100%;
-
+    :host(:not([pfe-priority])) & {
+       min-width: 100%;
+    }
     :host([pfe-priority]) &,
     :host([aria-disabled="true"]) & {
       display: flex;

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -29,7 +29,7 @@ $LOCAL-VARIABLES: (
   FontFamily: pfe-var(font-family--heading),
   FontSize:   pfe-var(font-size),
   LineHeight: pfe-var(line-height),
-  MaxWidth: max-content,
+  MaxWidth: 100%,
   arrow: (
     Display: inline,
     Padding: $arrow-basic,

--- a/elements/pfe-cta/src/pfe-cta.scss
+++ b/elements/pfe-cta/src/pfe-cta.scss
@@ -109,7 +109,7 @@ $LOCAL-VARIABLES: map-deep-merge($LOCAL-VARIABLES, (
   &--wrapper {
     display: block; 
     white-space: nowrap;
-    min-width: 100%;
+    //min-width: 100%;
 
     :host([pfe-priority]) &,
     :host([aria-disabled="true"]) & {


### PR DESCRIPTION
## Component name

pfe-cta wraps text to two lines in Firefox, because of max-width property + flexbox.


### Related issue

- https://github.com/patternfly/patternfly-elements/issues/1032


### Preview
 
Link(s) to demo page(s) where this element can be viewed:
- [Link to CTA demo page](https://deploy-preview-1033--happy-galileo-ea79c4.netlify.app/elements/pfe-cta/demo/) 

 

### Testing instructions

1.  Load secondary (ghost) style CTA in a card footer slot with words "learn more". Text should not wrap.


#### Browser requirements

Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
