### PR TITLE
docs: fix broken code highlighting in docs' code blocks

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -59,6 +59,8 @@ canonifyURLs = true
   anchor = "smart"
 
 [markup]
+  [markup.highlight]
+    codeFences = false
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true


### PR DESCRIPTION
Disable the broken code highlighting in docs code blocks.  It was caused by a change in Hugo v0.60 which enabled highlighting by default, whereas we had been relying on it being false by default in previous versions.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**