### PR TITLE
Cpfed 3789 update aria util btns

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -57,15 +57,13 @@
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
           <a href="#" class="pfe-navigation__logo-link">
-            <img class="pfe-navigation__logo-image pfe-navigation__logo-image--small" src="assets/redhat--reverse.svg" width="400" alt="Redhat" />
+            <img class="pfe-navigation__logo-image pfe-navigation__logo-image--small" src="assets/redhat--reverse.svg" width="400" alt="Red Hat" />
           </a>
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-            <!-- @note: removed aria-haspopup attr bc it should not be used for this type of menu, changed to using a class has-dropdown but this probably needs to be implemented differently -->
-
-            <!-- @todo: move aria and has-dropdown to shadow DOM? -->
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <!-- @todo/note: removed aria-expanded attr and has-dropdown class since this is the no js version, how will this component be used? why is it called <ze-navigation>? -->
+            <a href="#" class="pfe-navigation__menu-link">
               Products
             </a>
             <div class="pfe-navigation__dropdown">
@@ -199,7 +197,7 @@
             </div> <!-- end .pfe-navigation__dropdown -->
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link">
               Solutions
             </a>
             <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
@@ -246,7 +244,7 @@
             </div> <!-- end .pfe-navigation__dropdown -->
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link">
               Learning & Support
             </a>
             <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
@@ -326,7 +324,7 @@
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
           <a href="#" class="pfe-navigation__logo-link">
-            <img class="pfe-navigation__logo-image pfe-navigation__logo-image--small" src="assets/redhat--reverse.svg" width="400" alt="Redhat" />
+            <img class="pfe-navigation__logo-image pfe-navigation__logo-image--small" src="assets/redhat--reverse.svg" width="400" alt="Red Hat" />
           </a>
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
@@ -594,7 +592,7 @@
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
           <a href="#" class="pfe-navigation__logo-link">
-            <img class="pfe-navigation__logo-image" src="assets/redhat-customer-portal--reverse.svg" width="400" alt="Redhat Customer Portal" />
+            <img class="pfe-navigation__logo-image" src="assets/redhat-customer-portal--reverse.svg" width="400" alt="Red Hat Customer Portal" />
           </a>
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -744,7 +744,8 @@
                   <a href="#">Red Hat Virtualization Example</a>
                 </li>
               </ul>
-            </div> <!-- end .pfe-navigation__dropdown -->          </li>
+            </div> <!-- end .pfe-navigation__dropdown -->
+          </li>
           <li class="pfe-navigation__menu-item">
             <a href="#" class="pfe-navigation__menu-link">
               Resources

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -13,12 +13,14 @@
       <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
       </div>
 
+      <!-- @todo: dynamically set aria-expanded for trigger buttons in shadow DOM and aria-hidden for dropdown content in shadow DOM -->
+      <!-- @todo: regroup on this, not sure why we would dynamically set the aria attrs in the shadow DOM rather than just add the attrs in the template via HTML -->
       <button class="pfe-navigation__search-toggle" id="secondary-links__button--search" aria-expanded="false" aria-controls="secondary-links__dropdown--search">
         <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
         Search
       </button>
       <!-- @todo/note: dropdowns need to be directly after the trigger buttons in the DOM order otherwise you cannot tab into the dropdown itself when using a keyboard or screen reader. Need to regroup on this if original placement of the search slot was important for current functionality, in the original location above the search button you could not tab into search dropdown slot with neither a keyboard or screen reader. -->
-      <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search">
+      <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search" aria-hidden="true">
         search slot
       </slot>
 
@@ -30,7 +32,7 @@
         <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
         All Red Hat
       </button>
-      <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
+      <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat" aria-hidden="true">
         <div class="pfe-navigation__all-red-hat-wrapper__inner">
           <div id="site-loading">
             <pfe-progress-indicator></pfe-progress-indicator>

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -10,17 +10,17 @@
   <div class="pfe-navigation__outer-menu-wrapper" id="mobile__dropdown">
     <div id="pfe-navigation__outer-menu-wrapper__inner" class="pfe-navigation__outer-menu-wrapper__inner">
 
-      <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search" aria-hidden="true">
-        search slot
-      </slot>
-
       <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
       </div>
 
-      <button class="pfe-navigation__search-toggle" id="secondary-links__button--search" aria-expanded="false">
+      <button class="pfe-navigation__search-toggle" id="secondary-links__button--search" aria-expanded="false" aria-controls="secondary-links__dropdown--search">
         <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
         Search
       </button>
+      <!-- @todo/note: dropdowns need to be directly after the trigger buttons in the DOM order otherwise you cannot tab into the dropdown itself when using a keyboard or screen reader. Need to regroup on this if original placement of the search slot was important for current functionality, in the original location above the search button you could not tab into search dropdown slot with neither a keyboard or screen reader. -->
+      <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search">
+        search slot
+      </slot>
 
       <slot name="pfe-navigation--custom-links" class="pfe-navigation__customlinks">
         customlinks slot
@@ -30,7 +30,7 @@
         <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
         All Red Hat
       </button>
-      <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat" aria-hidden="true">
+      <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
         <div class="pfe-navigation__all-red-hat-wrapper__inner">
           <div id="site-loading">
             <pfe-progress-indicator></pfe-progress-indicator>

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -354,12 +354,13 @@ class PfeNavigation extends PFElement {
         dropdownElement.style.removeProperty("height");
       }
       // Delay aria-hidden so animations can finish
-      // @todo/note: I do not think we need to delay the change of the aria-hidden state since aria-hidden hides the content of the page from screen readers, as soon as the dropdown is closed by the user the dropdown should get aria-hidden="true" immediately
+      // @todo/note: I do not think we need to delay the change of the aria-hidden state since aria-hidden hides the content of the page from screen readers, as soon as the dropdown is closed by the screen reader user the dropdown should get aria-hidden="true" immediately
       // @note: tested with a screen reader and things seem to be functioning well without the time delay.
-      window.setTimeout(() => {
-        dropdownElement.setAttribute("aria-hidden", "true");
-      }, 500);
-      // dropdownElement.setAttribute("aria-hidden", "true");
+      // @note: when the delay is on it seems to be causing issues with the toggling of the aria-hidden states sometimes
+      // window.setTimeout(() => {
+      //   dropdownElement.setAttribute("aria-hidden", "true");
+      // }, 500);
+      dropdownElement.setAttribute("aria-hidden", "true");
 
       // Main menu specific code
       if (toggleId.startsWith("main-menu")) {
@@ -523,12 +524,19 @@ class PfeNavigation extends PFElement {
 
       // Create wrapper for dropdown and give it appropriate classes and attributes
       const dropdownWrapper = document.createElement("div");
+      // Find other dropdowns by using the .dropdown-content class (such as Search/All Red Hat)
+      // @todo: figure out if this is causing inconsistent toggling of aria-hidden
+      // const otherDropDowns = this.shadowRoot.querySelector(".dropdown-content");
+
       dropdownWrapper.classList.add("pfe-navigation__dropdown-wrapper");
       if (dropdown.classList.contains("pfe-navigation__dropdown--single-column")) {
         dropdownWrapper.classList.add("pfe-navigation__dropdown-wrapper--single-column");
       }
       dropdownWrapper.setAttribute("id", dropdownId);
       dropdownWrapper.setAttribute("aria-hidden", "true");
+      // dynamically set aria-hidden="true" by default for other dropdowns bc they are closed by default
+      // @note: commented out bc it is not fully working yet
+      // otherDropDowns.setAttribute("aria-hidden", "true");
       dropdownWrapper.append(dropdown);
       dropdownButton.parentElement.append(dropdownWrapper);
       dropdownButton.parentElement.dataset.dropdownId = dropdownId;
@@ -551,20 +559,21 @@ class PfeNavigation extends PFElement {
     this.addEventListener("keydown", this._generalKeyboardListener);
 
     // Give all dropdowns aria-hidden since they're shut by default
-    // @note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons, added logic to add aria-hidden to those buttons depending on a class a few lines down
+    // @todo/note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons (Search/All Red Hat), added aria-hidden attr in the pfe-nav shadow DOM template for now, need to figure out best way to do this dynamically
     this.shadowRoot.querySelector(".pfe-navigation__dropdown-wrapper").setAttribute("aria-hidden", "true");
 
     // Give Search dropdown, All Red Hat Dropdown aria-hidden since they're shut by default
     // @todo: added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
     // @todo: need to figure out best way to manage the dynamic setting of aria-hidden when custom link gets used as a dropdown instead by content editors and other dev teams
-    this.shadowRoot.querySelectorAll(".dropdown-content").forEach(element => {
-      element.setAttribute("aria-hidden", "true");
-      // added this for local testing
-      if (document.domain === "localhost") {
-        console.log(`inside of forEach for .dropdown-content`);
-        console.log(element);
-      }
-    });
+    // @todo/note: tried this method of dynamically setting the aria-hidden attr for other dropdowns but I was having an issue with inconsistent toggling of the aria-hidden attr for the search dropdown so commented it out for now, this code might be conflicting with logic elsewhere for aria-hidden?
+    // this.shadowRoot.querySelectorAll(".dropdown-content").forEach(element => {
+    //   element.setAttribute("aria-hidden", "true");
+    //   // added this for local testing
+    //   if (document.domain === "localhost") {
+    //     console.log(`inside of forEach for .dropdown-content`);
+    //     console.log(element);
+    //   }
+    // });
 
     // Reconnecting mutationObserver for IE11 & Edge
     if (window.ShadyCSS) {

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -326,7 +326,7 @@ class PfeNavigation extends PFElement {
       const toggleId = toggleElement.getAttribute("id");
       // console.log('_openDropdown', toggleId, dropdownElement.getAttribute('id'));
       toggleElement.setAttribute("aria-expanded", "true");
-      dropdownElement.setAttribute("aria-hidden", false);
+      dropdownElement.setAttribute("aria-hidden", "false");
       // Updating height via JS so we can animate it for CSS transitions
       if (parseInt(dropdownElement.dataset.height) > 30) {
         dropdownElement.style.setProperty("height", `${dropdownElement.dataset.height}px`);
@@ -354,9 +354,12 @@ class PfeNavigation extends PFElement {
         dropdownElement.style.removeProperty("height");
       }
       // Delay aria-hidden so animations can finish
+      // @todo/note: I do not think we need to delay the change of the aria-hidden state since aria-hidden hides the content of the page from screen readers, as soon as the dropdown is closed by the user the dropdown should get aria-hidden="true" immediately
+      // @note: tested with a screen reader and things seem to be functioning well without the time delay.
       window.setTimeout(() => {
         dropdownElement.setAttribute("aria-hidden", "true");
       }, 500);
+      // dropdownElement.setAttribute("aria-hidden", "true");
 
       // Main menu specific code
       if (toggleId.startsWith("main-menu")) {
@@ -410,6 +413,7 @@ class PfeNavigation extends PFElement {
    * Clone them into the shadowRoot
    * @param {array} mutationList Provided by mutation observer
    */
+  // @todo: processLightDom seems to be firing twice, need to look into this and see whether that is okay or if it needs to be fixed, seems like it is not a good thing but not sure if it is avoidable or not
   _processLightDom(mutationList) {
     // If we're mutating because an attribute on the web component starting with pfe- changed, don't reprocess dom
     let cancelLightDomProcessing = true;
@@ -547,7 +551,20 @@ class PfeNavigation extends PFElement {
     this.addEventListener("keydown", this._generalKeyboardListener);
 
     // Give all dropdowns aria-hidden since they're shut by default
-    this.shadowRoot.querySelector(".pfe-navigation__dropdown-wrapper").setAttribute("aria-hidden", true);
+    // @note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons, added logic to add aria-hidden to those buttons depending on a class a few lines down
+    this.shadowRoot.querySelector(".pfe-navigation__dropdown-wrapper").setAttribute("aria-hidden", "true");
+
+    // Give Search dropdown, All Red Hat Dropdown aria-hidden since they're shut by default
+    // @todo: added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
+    // @todo: need to figure out best way to manage the dynamic setting of aria-hidden when custom link gets used as a dropdown instead by content editors and other dev teams
+    this.shadowRoot.querySelectorAll(".dropdown-content").forEach(element => {
+      element.setAttribute("aria-hidden", "true");
+      // added this for local testing
+      if (document.domain === "localhost") {
+        console.log(`inside of forEach for .dropdown-content`);
+        console.log(element);
+      }
+    });
 
     // Reconnecting mutationObserver for IE11 & Edge
     if (window.ShadyCSS) {
@@ -760,8 +777,8 @@ class PfeNavigation extends PFElement {
    * @param {object} event
    */
   _generalKeyboardListener(event) {
-    var target = event.target;
-    var keyCode = event.which;
+    const target = event.target;
+    const keyCode = event.which;
 
     // RIGHT
     if (keyCode === 39) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,20 +98,16 @@
 | Filename | line # | TODO
 |:------|:------:|:------
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L4) | 4 | Figure out cooler way to include these utilty functions
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L240) | 240 | figure out what needs to go into the disconnected callback
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L317) | 317 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L321) | 321 | add a persistant attr to component that shows whenever the mobile menu burger exists and is open
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L329) | 329 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L335) | 335 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L343) | 343 | figure out why this is firing even when isNavigationMobileStyle is NOT true, seems like we should only fire this change when the mobile menu is activated?
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L407) | 407 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L480) | 480 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L489) | 489 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L581) | 581 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L619) | 619 | refactor all aria-expanded and aria-hidden states to work with pfe-navigation-state="" value instead to try and fix aria-expanded states getting out of sync
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L622) | 622 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L629) | 629 | figure out how to alternate aria expanded and hidden correctly when opening a menu without closing the previous one
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L5) | 5 | Figure out cooler way to include these utilty functions
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L249) | 249 | Find reliable way to check if secondary links are collapsed (search and all red hat buttons probably aren't it)
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L467) | 467 | look into only replacing markup that changed via mutationList
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L485) | 485 | Clone Node breaks event listeners, might need to think on this, we'll need to be able to maintain the lightDOM
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L554) | 554 | added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L570) | 570 | add aria-hidden and aria-expanded attributes to appropriate elements for mobile dropdown
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L582) | 582 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L583) | 583 | Clear/update inline heights on resize
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L593) | 593 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L651) | 651 | Not working yet These other dropdowns need style & JS logic love
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
 | [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>


### PR DESCRIPTION
---
name: Cpfed 3789 update aria features for shadow DOM buttons and dropdown content
labels: "ready for review"
---

## pfe-navigation

added aria-hidden/aria-expanded to shadow DOM for the other dropdowns, added some notes on things to regroup on, did some more keyboard testing and fixed aria-hidden issue for search and all red hat buttons but not dynamically, updated alt text of images, removed aria-expanded and has-dropdown from no js menu example.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
