### PR TITLE
feat: pfe-autocomplete - fire custom event when dropdown is shown

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,5 +1,6 @@
 ## Prerelease 55 ( TBD )
 
+- [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-autocomplete - fire custom event when dropdown is shown
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfelement - restore pfelement tests (#1018)
 - [fbe4423](https://github.com/patternfly/patternfly-elements/commit/fbe442396f06b0a097366512b698dc0b6d5e1f9f) fix: improve CLS rating in lighthouse (#1020)
 

--- a/elements/pfe-autocomplete/src/pfe-autocomplete.js
+++ b/elements/pfe-autocomplete/src/pfe-autocomplete.js
@@ -31,6 +31,7 @@ class PfeAutocomplete extends PFElement {
     return {
       search: `${this.tag}:search-event`,
       select: `${this.tag}:option-selected`,
+      optionsShown: `${this.tag}:options-shown`,
       slotchange: `slotchange`
     };
   }
@@ -293,6 +294,9 @@ class PfeAutocomplete extends PFElement {
     this.activeIndex = null;
     this._dropdown.setAttribute("open", true);
     this._dropdown.setAttribute("active-index", null);
+    this.emitEvent(PfeAutocomplete.events.optionsShown, {
+      composed: true
+    });
   }
 
   _optionSelected(e) {

--- a/elements/pfe-autocomplete/test/pfe-autocomplete_test.html
+++ b/elements/pfe-autocomplete/test/pfe-autocomplete_test.html
@@ -133,6 +133,26 @@
           });
         });
 
+        it('should fire a pfe-autocomplete:options-shown event when the droplist is shown to the user', done => {
+          flush(() => {
+            const items = ['option 1', 'option 2'];
+
+            autocompleteElem.autocompleteRequest = function(params, callback) {
+              const regx = new RegExp("\^" + params.query, "i");
+              callback(items.filter(function (item) {
+                return regx.test(item);
+              }));
+            };
+
+            autocompleteElem.addEventListener("pfe-autocomplete:options-shown", function(event) {
+              assert.equal(droplistElem.getAttribute("open"), "true");
+              done();
+            });
+
+            autocompleteElem._sendAutocompleteRequest("o");
+          });
+        });
+
         it('should fire pfe-autocomplete:search-event after user click on an option', done => {
           flush(() => {
             droplistElem.data = ['option 1', 'option 2'];


### PR DESCRIPTION
Fixes #1045

## pfe-autocomplete
Our analytics teams have requested a custom event to be fired when the pfe-autocomplete dropdown is shown to a user. They need this to help track the usage of the component. This pull request fires a `pfe-autocomplete:options-shown` event when the dropdown is shown to the user.

### Related issue
- (#1045) pfe-autocomplete: fire custom event when dropdown is shown


### Preview
Link(s) to demo page(s) where this element can be viewed:
- [Link](https://deploy-preview-1046--happy-galileo-ea79c4.netlify.app/elements/pfe-autocomplete/demo/) 

### Testing instructions
1. [Go to the demo page](https://deploy-preview-1046--happy-galileo-ea79c4.netlify.app/elements/pfe-autocomplete/demo/)
2. Add the following code block in the developer tools console
```
const pfeAutocomplete = document.querySelector("pfe-autocomplete");
pfeAutocomplete.addEventListener("pfe-autocomplete:options-shown", e => console.log(e));
```
3. Enter the letter "i" into the first input field
4. Validate that the `pfe-autocomplete:options-shown` event fired


#### Browser requirements

Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
