### PR TITLE
Cpfed 3804 search bar focus styles

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -7,7 +7,7 @@
 
     <noscript>
       <link href="../../pfelement/dist/pfelement-noscript.min.css" rel="stylesheet">
-      
+
     </noscript>
 
     <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
@@ -319,9 +319,9 @@
       <!-- @todo: move form and label for="" and label id into shadow DOM -->
       <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label for="pfe-navigation__search-label1">Search</label>
-          <input id="pfe-navigation__search-label1" type="text" placeholder="Search" />
-          <button>Search</button>
+          <label for="pfe-navigation__search-label1" class="sr-only">Search the Red Hat Customer Portal</label>
+          <input id="pfe-navigation__search-label1" type="text" placeholder="Search the Red Hat Customer Portal" />
+          <button aria-label="Submit Search">Search</button>
         </form>
       </div>
     </pfe-navigation>
@@ -508,9 +508,9 @@
       <!-- @todo: move form and label for="" and label id into shadow DOM -->
       <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label for="pfe-navigation__search-label2">Search</label>
-          <input id="pfe-navigation__search-label2" type="text" placeholder="Search" />
-          <button>Search</button>
+          <label for="pfe-navigation__search-label2" class="sr-only">Search the Red Hat Customer Portal</label>
+          <input id="pfe-navigation__search-label2" type="text" placeholder="Search the Red Hat Customer Portal" />
+          <button aria-label="Submit Search">Search</button>
         </form>
       </div>
     </pfe-navigation>
@@ -775,9 +775,9 @@
       <!-- @todo: move form and label for="" and label id into shadow DOM -->
       <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
         <form>
-          <label for="pfe-navigation__search-label1">Search</label>
-          <input id="pfe-navigation__search-label1" type="text" placeholder="Search" />
-          <button>Search</button>
+          <label for="pfe-navigation__search-label1" class="sr-only">Search the Red Hat Customer Portal</label>
+          <input id="pfe-navigation__search-label1" type="text" placeholder="Search the Red Hat Customer Portal" />
+          <button aria-label="Submit Search">Search</button>
         </form>
       </div>
     </ze-navigation>

--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -333,7 +333,7 @@
       <nav class="pfe-navigation" aria-label="Main Navigation">
         <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
           <a href="#" class="pfe-navigation__logo-link">
-            <img class="pfe-navigation__logo-image" src="assets/redhat-customer-portal--reverse.svg" alt="Redhat Customer Portal" />
+            <img class="pfe-navigation__logo-image" src="assets/redhat-customer-portal--reverse.svg" alt="Red Hat Customer Portal" />
           </a>
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
@@ -527,214 +527,19 @@
         </div>
         <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
           <li class="pfe-navigation__menu-item">
-            <!-- @note: removed aria-haspopup attr bc it should not be used for this type of menu, changed to using a class has-dropdown but this probably needs to be implemented differently -->
-
-            <!-- @todo: move aria and has-dropdown to shadow DOM? -->
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link">
               Products
             </a>
-            <div class="pfe-navigation__dropdown">
-              <section>
-                <h3>
-                  <a href="#">Platforms</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Red Hat Enterprise Linux</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat OpenStack Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat Virtualization</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  <a href="#">Ladders</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Lorem ipsum</a>
-                  </li>
-                  <li>
-                    <a href="#">Dolor sit amet</a>
-                  </li>
-                  <li>
-                    <a href="#">Wakka Wakka</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  <a href="#">Chutes</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Yakkita yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Enterprise Yakkita yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Upstream Yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Yakkita ME</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  <a href="#">Platforms</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Red Hat Enterprise Linux</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat OpenStack Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat Virtualization</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  <a href="#">Ladders</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Lorem ipsum</a>
-                  </li>
-                  <li>
-                    <a href="#">Dolor sit amet</a>
-                  </li>
-                  <li>
-                    <a href="#">Wakka Wakka</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  <a href="#">Chutes</a>
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Yakkita yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Enterprise Yakkita yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Upstream Yakkita</a>
-                  </li>
-                  <li>
-                    <a href="#">Yakkita ME</a>
-                  </li>
-                </ul>
-              </section>
-
-              <!-- documentation note: mega menu footer region can fit at most 4 ctas -->
-              <section class="pfe-navigation__footer">
-                <pfe-cta pfe-priority="primary">
-                  <a href="#">Learn more about PFElements</a>
-                </pfe-cta>
-
-                <pfe-cta>
-                  <a href="https://github.com/">GitHub</a>
-                </pfe-cta>
-
-                <pfe-cta>
-                  <a href="https://github.com/">Another CTA Example</a>
-                </pfe-cta>
-
-                <pfe-cta>
-                  <a href="#">Learn more about CTAs and How to Use Them</a>
-                </pfe-cta>
-              </section>
-            </div> <!-- end .pfe-navigation__dropdown -->
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link">
               Solutions
             </a>
-            <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
-              <!-- documentation note: single-col dropdowns CANNOT have pfe-nav footer regions -->
-              <!-- documentation note: single col headings are groups with different styles than mega menu tray headings -->
-              <section>
-                <h3>
-                  Group 1
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Red Hat Enterprise Linux</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat OpenStack Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat Virtualization</a>
-                  </li>
-                </ul>
-              </section>
-              <section>
-                <h3>
-                  Group 2
-                </h3>
-                <ul>
-                  <li>
-                    <a href="#">Red Hat Enterprise Linux</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat OpenStack Platform</a>
-                  </li>
-                  <li>
-                    <a href="#">Red Hat Virtualization</a>
-                  </li>
-                </ul>
-              </section>
-            </div> <!-- end .pfe-navigation__dropdown -->
           </li>
           <li class="pfe-navigation__menu-item">
-            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+            <a href="#" class="pfe-navigation__menu-link">
               Learning & Support
             </a>
-            <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
-              <!-- documentation note: single-col dropdowns CANNOT have pfe-nav footer regions -->
-              <!-- documentation note: separator class, pfe-navigation__sub-nav-link--separator -->
-              <ul>
-                <li>
-                  <a href="#">Red Hat Enterprise Linux</a>
-                </li>
-                <li>
-                  <a href="#">Red Hat JBoss Enterprise Application Platform</a>
-                </li>
-                <li>
-                  <a href="#">Red Hat OpenStack Platform</a>
-                </li>
-                <li class="pfe-navigation__single-column--separator">
-                  <a href="#">Red Hat Virtualization</a>
-                </li>
-                <li>
-                  <a href="#">Red Hat Virtualization Example</a>
-                </li>
-              </ul>
-            </div> <!-- end .pfe-navigation__dropdown -->
           </li>
           <li class="pfe-navigation__menu-item">
             <a href="#" class="pfe-navigation__menu-link">
@@ -764,22 +569,6 @@
           <a href="#">Log in</a>
         </li>
       </ul>
-      <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
-        <a href="#" class="#">
-          <!-- @note: added web-icon-globe icon as a placeholder since it is used as the language switcher icon -->
-          <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
-          Custom Link
-        </a>
-      </div>
-      <div slot="pfe-navigation--search" class="pfe-navigation__search">
-      <!-- @todo: move form and label for="" and label id into shadow DOM -->
-      <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
-        <form>
-          <label for="pfe-navigation__search-label1" class="sr-only">Search the Red Hat Customer Portal</label>
-          <input id="pfe-navigation__search-label1" type="text" placeholder="Search the Red Hat Customer Portal" />
-          <button aria-label="Submit Search">Search</button>
-        </form>
-      </div>
     </ze-navigation>
 
   </body>

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -60,13 +60,42 @@ $breakpoints: (
   }
 }
 
+/// sr-only class (same as Bootstrap 4 sr-only class)
+/// hide element from everyone except screen readers
+@mixin sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/// sr-only class
+/// can be used in shadow DOM and light DOM stylesheets
+.sr-only {
+  @include sr-only;
+}
+
 /// Focus indicator styles specific to pfe-navigation
 /// @param {string} $border-color Color of dashed border (white or black depending on bg-color)
-/// @param {string} $border-top-size Size of border-top (0px or 1px depending on which navigation main/mega menu
+/// @param {string} $border-top-size Size of border-top (0px or 1px depending on which navigation main/mega menu)
 @mixin focus-styles($border-color, $border-top-size) {
   border: 1px dashed $border-color;
   border-top: $border-top-size dashed $border-color;
-  outline: none;
+  outline: 0;
+}
+
+/// Focus indicator styles specific to pfe-navigation, alternative option including box-shadow bar
+/// @param {string} $border-color Color of dashed border (white or black depending on bg-color)
+/// @param {string} $box-shadow-color Color of box-shadow indicator (red or black depending on the button bg-color, border-top always needs to be the same color as the box-shadow)
+@mixin alt-focus-styles($border-color, $box-shadow-color) {
+  border: 1px dashed $border-color;
+  border-top: 1px solid $box-shadow-color;
+  box-shadow: inset 0 3px 0 0 $box-shadow-color;
+  outline: 0;
 }
 
 //
@@ -108,7 +137,7 @@ $breakpoints: (
   // focus styles
   &:focus,
   &:hover {
-    @include focus-styles(#fff, 1px);
+    @include alt-focus-styles(#fff, #e00);
   }
 }
 
@@ -120,6 +149,7 @@ $breakpoints: (
   padding: 10px 16px 10px 0;
 }
 
+// @todo: determine why the ..__logo-link style block is present twice, remove if duplicate is merge accident
 @mixin pfe-navigation__logo-link {
   display: block;
   padding: 6px 8px;
@@ -129,9 +159,10 @@ $breakpoints: (
   border: 1px solid transparent;
 
   // focus styles
+  transition: box-shadow 0.2s;
   &:focus,
   &:hover {
-    @include focus-styles(#fff, 1px);
+    @include alt-focus-styles(#fff, #e00);
   }
 }
 
@@ -180,23 +211,22 @@ $breakpoints: (
 
   // added to counteract jumpiness when dashed border is visible on focus and hover
   border: 1px solid transparent;
-  border-top: 0px;
+  // border-top: 0px;
 
   // focus styles
   &:focus,
   &:hover {
-    @include focus-styles(#fff, 0px);
+    @include alt-focus-styles(#fff, #e00);
 
     @include breakpoint('secondary-links-expand') {
-      box-shadow: inset 0 4px 0 0 #e00;
+      @include alt-focus-styles(#fff, #e00);
     }
   }
 
   &[pfe-navigation-open-toggle="main-menu--open"] {
-    // @todo: fix focus-styles on mobile for accordion links and menu toggle button
     &:focus,
     &:hover {
-      @include focus-styles(#000, 0px);
+      @include focus-styles(#000, 1px);
     }
   }
 }

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -100,4 +100,56 @@ pfe-navigation {
   .pfe-navigation__custom-links pfe-icon {
     @include secondary-links-icon;
   }
+
+  .pfe-navigation__search {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .pfe-navigation__search form {
+    display: flex;
+    align-items: center;
+  }
+
+  .pfe-navigation__search input,
+  .pfe-navigation__search button {
+    padding: 10px;
+    transition: box-shadow 0.2s;
+  }
+
+  .pfe-navigation__search input {
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: 0%;
+    margin-right: 8px;
+    border: 1px solid #f0f0f0;
+    border-bottom: 1px solid #8b8e91;
+    color: #717579;
+    font-size: 16px;
+  }
+
+  .pfe-navigation__search input::placeholder {
+    color: #717579;
+  }
+
+  .pfe-navigation__search button {
+    flex-grow: 0;
+    flex-shrink: 1;
+    flex-basis: auto;
+    border-radius: 2px;
+    border: 1px solid #e00;
+    background-color: #e00;
+    color: #fff;
+    font-size: 16px;
+  }
+
+  .pfe-navigation__search input:focus,
+  .pfe-navigation__search input:hover {
+    @include alt-focus-styles(#000, #e00);
+  }
+
+  .pfe-navigation__search button:focus,
+  .pfe-navigation__search button:hover {
+    @include alt-focus-styles(#fff, #000);
+  }
 }

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -418,8 +418,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     @include focus-styles(#000, 1px);
 
     @include breakpoint('nav-expand') {
-      box-shadow: inset 0 4px 0 0 #e00;
-      @include focus-styles(#fff, 0px);
+      @include alt-focus-styles(#fff, #e00);
     }
     @include collapse('nav') {
       box-shadow: none;
@@ -435,9 +434,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   &:focus,
   &:hover {
     @include breakpoint('nav-expand') {
-      @include focus-styles(#fff, 0px);
-      border-top: 1px solid #e00;
-      box-shadow: inset 0 3px 0 0 #e00;
+      @include alt-focus-styles(#fff, #e00);
     }
     @include collapse('nav') {
       box-shadow: none;
@@ -448,7 +445,6 @@ See mixin blocks before selectors that contain the selector name and the three l
     @include breakpoint('nav-expand') {
       color: #151515;
       background: #fff;
-      box-shadow: inset 0 3px 0 0 #e00;
     }
     @include collapse('nav') {
       box-shadow: none;
@@ -458,7 +454,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     &:focus,
     &:hover {
       @include breakpoint('nav-expand') {
-        @include focus-styles(#000, 0px);
+        @include alt-focus-styles(#000, #e00);
       }
     }
   }
@@ -714,6 +710,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   }
   @include collapse('nav') {
     background: transparent;
+    box-shadow: none;
   }
 
   // group feature styles


### PR DESCRIPTION
---
name: CPFED-3804 search bar focus styles
labels: ready for review
---

## pfe-navigation

- Added styles to search bar and search button
- Created a new alternative focus-styles mixin that includes the box-shadow bar and helps fix jumpiness issue when focusing/hovering an element.
- Added focus/hover styles to search bar and search button
- Updated focus/hover styles for mobile and desktop menu links and top level button mixin to fix jumpiness
- Added box-shadow to all focus/hover states outside of the dropdowns to ensure that the focus indicator meets a11y guidelines
- Made sure that the focus indicator within the dropdowns uses the border and text underline to meet a11y guidelines
- Removed all dropdowns and slots from NO JS nav
- Removed `has-dropdown` classes from NO JS nav
- Removed `aria-expanded` attributes from NO JS nav
- Updated alt text of "Red Hat" logo
- Updated aria-labels for search forms to be more descriptive and useful to screen reader users
- Add `sr-only` mixin and class and set the search form labels to screen reader only based on design
- Removed box-shadow for the `single-column` dropdowns on mobile, box-shadow only for desktop breakpoint

### Testing instructions

1. Pull down most recent changes to local
2. Tab through all the navigation options on mobile and desktop
    - open each menu item with the `enter` key
    - open each menu item with the `spacebar` 
3. Hover over all the menu items with the mouse
4. Turn on the screen reader of your choice and repeat step 3 while tabbing through with a screen reader

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
