### PR TITLE
test: disabling visual regression testing in favor of manual running

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-      - uses: actions/verify-pr-label-action@v1.0.0
+      - uses: jesusvasquez333/verify-pr-label-action@v1.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: ${{ env.LABELS }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,7 +11,7 @@ on:
     status: success
 jobs:
   visual_regression_tests:
-    if: github.event.label.name == "ready to merge"
+    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,9 +39,15 @@ jobs:
         run: npm build
 
       - name: Visual regression tests
-        run: npm run e2e -- --verbose
+        uses: ianwalter/bsl@v2.1.0
+        with:
+          args: npm run e2e -- --verbose
         env:
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           CI: true
+          firefox: latest
+          chrome: stable
   try_to_merge:
     if: jobs.visual_regression_tests.outcome == "success"
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -49,7 +49,7 @@ jobs:
           firefox: latest
           chrome: stable
   try_to_merge:
-    if: jobs.visual_regression_tests.outcome == "success"
+    if: success()
     runs-on: ubuntu-latest
     steps:
       - name: Try to automerge PR ${{ github.event.number }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -43,11 +43,11 @@ jobs:
         env:
           CI: true
   try_to_merge:
+    if: jobs.visual_regression_tests.outcome == "success"
     runs-on: ubuntu-latest
     steps:
       - name: Try to automerge PR ${{ github.event.number }}
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
-        if: jobs.visual_regression_tests.outcome == "success"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
           MERGE_LABELS: ${{ env.LABELS }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,6 @@
 name: Automerge PR
-LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
+env:
+  LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/verify-pr-label-action@v1.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: ${{ LABELS }}
+          valid-labels: ${{ env.LABELS }}
       - uses: actions/checkout@v2
       - name: Visual regression tests
         uses: actions/setup-node@v1
@@ -36,7 +37,7 @@ jobs:
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
-          MERGE_LABELS: ${{ LABELS }}
+          MERGE_LABELS: ${{ env.LABELS }}
           MERGE_REMOVE_LABELS: Ready to merge
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: "pull-request-title"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [12.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Visual regression tests
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
@@ -27,8 +27,7 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: visual regression tests
-      - name: automerge
+      - name: Try to automerge PR ${{ github.event.number }}
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -47,7 +47,7 @@ jobs:
           firefox: latest
           chrome: stable
   try_to_merge:
-    if: success()
+    if: success() && contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
     steps:
       - name: Try to automerge PR ${{ github.event.number }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,16 +11,12 @@ on:
     status: success
 jobs:
   visual_regression_tests:
+    if: github.event.label.name == "ready to merge"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [12.x]
     steps:
-      - continue-on-error: false
-      - uses: jesusvasquez333/verify-pr-label-action@v1.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: ${{ env.LABELS }}
       - uses: actions/checkout@v2
 
       - name: Cache node modules

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,9 +8,26 @@ on:
     types: [completed]
     status: success
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build
+      - run: npm run e2e -- --verbose
+        env:
+          CI: true
   automerge:
     runs-on: ubuntu-latest
     steps:
+      - name: visual regression tests
       - name: automerge
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,4 @@
 name: Automerge PR
-env:
-  LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -56,7 +54,7 @@ jobs:
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
-          MERGE_LABELS: ${{ env.LABELS }}
+          MERGE_LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
           MERGE_REMOVE_LABELS: Ready to merge
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: "pull-request-title"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: automerge
+name: Automerge PR
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -8,7 +8,7 @@ on:
     types: [completed]
     status: success
 jobs:
-  build:
+  visual_regression_tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,7 +24,7 @@ jobs:
       - run: npm run e2e -- --verbose
         env:
           CI: true
-  automerge:
+  try_to_merge:
     runs-on: ubuntu-latest
     steps:
       - name: Try to automerge PR ${{ github.event.number }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,5 @@
 name: Automerge PR
-valid_labels: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
+LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -15,13 +15,15 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
+      - uses: actions/verify-pr-label-action@v1.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: ${{ LABELS }}
       - uses: actions/checkout@v2
       - name: Visual regression tests
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: ${{ valid_labels }}
       - run: npm install
       - run: npm run build
       - run: npm run e2e -- --verbose
@@ -34,7 +36,7 @@ jobs:
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
-          MERGE_LABELS: ${{ valid_labels }}
+          MERGE_LABELS: ${{ LABELS }}
           MERGE_REMOVE_LABELS: Ready to merge
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: "pull-request-title"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Try to automerge PR ${{ github.event.number }}
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
-        if: ${{ jobs.visual_regression_tests.outcome }} === "success"
+        if: jobs.visual_regression_tests.outcome == "success"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
           MERGE_LABELS: ${{ env.LABELS }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,18 +16,34 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
+      - continue-on-error: false
       - uses: jesusvasquez333/verify-pr-label-action@v1.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: ${{ env.LABELS }}
       - uses: actions/checkout@v2
-      - name: Visual regression tests
-        uses: actions/setup-node@v1
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run build
-      - run: npm run e2e -- --verbose
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm build
+
+      - name: Visual regression tests
+        run: npm run e2e -- --verbose
         env:
           CI: true
   try_to_merge:
@@ -35,6 +51,7 @@ jobs:
     steps:
       - name: Try to automerge PR ${{ github.event.number }}
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
+        if: ${{ jobs.visual_regression_tests.outcome }} === "success"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
           MERGE_LABELS: ${{ env.LABELS }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,5 @@
 name: Automerge PR
+valid_labels: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, edited, unlocked]
@@ -19,6 +20,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: ${{ valid_labels }}
       - run: npm install
       - run: npm run build
       - run: npm run e2e -- --verbose
@@ -31,7 +34,7 @@ jobs:
         uses: "pascalgn/automerge-action@4536e8847eb62fe2f0ee52c8fa92d17aa97f932f"
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS }}"
-          MERGE_LABELS: "ready to merge,!work in progress!,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
+          MERGE_LABELS: ${{ valid_labels }}
           MERGE_REMOVE_LABELS: Ready to merge
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: "pull-request-title"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -41,8 +41,8 @@ jobs:
         with:
           args: npm run e2e -- --verbose
         env:
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER }}
           CI: true
           firefox: latest
           chrome: stable

--- a/.github/workflows/visualtests.yml
+++ b/.github/workflows/visualtests.yml
@@ -1,0 +1,23 @@
+name: Visual regression testing
+on: [workflow_dispatch]
+jobs:
+  visual_regression_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: jesusvasquez333/verify-pr-label-action@v1.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: ${{ env.LABELS }}
+      - uses: actions/checkout@v2
+      - name: Visual regression tests
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build
+      - run: npm run e2e -- --verbose
+        env:
+          CI: true

--- a/.github/workflows/visualtests.yml
+++ b/.github/workflows/visualtests.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           args: npm run e2e -- --verbose
         env:
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER }}
           CI: true
           firefox: latest
           chrome: stable

--- a/.github/workflows/visualtests.yml
+++ b/.github/workflows/visualtests.yml
@@ -2,22 +2,40 @@ name: Visual regression testing
 on: [workflow_dispatch]
 jobs:
   visual_regression_tests:
+    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [12.x]
     steps:
-      - uses: jesusvasquez333/verify-pr-label-action@v1.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: ${{ env.LABELS }}
       - uses: actions/checkout@v2
-      - name: Visual regression tests
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run build
-      - run: npm run e2e -- --verbose
+
+      - name: Cache node modules
+        uses: actions/cache@v2
         env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm build
+
+      - name: Visual regression tests
+        uses: ianwalter/bsl@v2.1.0
+        with:
+          args: npm run e2e -- --verbose
+        env:
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           CI: true
+          firefox: latest
+          chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     access_key: BROWSERSTACK_KEY
 script:
   - npm test -- --verbose
-  - npm run e2e -- --verbose
+#  - npm run e2e -- --verbose
 cache:
   directories:
     - node_modules

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,7 @@
+## Prerelease 56 ( TBD )
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: move visual regression testing to merge script
+
 ## Prerelease 55 ( 2020-08-19 )
 
 - [3ee117e](https://github.com/patternfly/patternfly-elements/commit/3ee117e8a3df17f50738b9c0fa0caa3a9af9c679) feat: pfe-autocomplete - fire custom event when dropdown is shown (#1046)


### PR DESCRIPTION
Fixes #1053

Our visual regression tests continue to fail because we are trying to run too many parallel tests at once. This PR disables the visual regression tests on every PR. We'll have to run the visual regression tests manually until we figure out how to queue our BrowserStack tests better.

### Related issue
- (#1053) visual regression testing - need to set it so we're only running it manually

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
