### PR TITLE
feat: Remove build from postinstall

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,3 +1,7 @@
+## Prerelease 56 ( TBD )
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) feat: Remove build from postinstall
+
 ## Prerelease 55 ( 2020-08-19 )
 
 - [3ee117e](https://github.com/patternfly/patternfly-elements/commit/3ee117e8a3df17f50738b9c0fa0caa3a9af9c679) feat: pfe-autocomplete - fire custom event when dropdown is shown (#1046)

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ npm run live-demo [component-name(s)]
 ### Testing
 
 ```shell
-# Run tests on all components
+# Build and run tests on all components
 npm run test 
 
-# Run tests on one component
+# Build and run tests on one component
 npm run test [component-name(s)]
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "lerna bootstrap --hoist",
     "deploy-docs": "bash scripts/deploy-docs.sh",
     "release": "bash scripts/release.sh",
-    "postinstall": "npm run bootstrap && npm run build",
+    "postinstall": "npm run bootstrap",
     "test-suite-inject": "node scripts/test-suite-inject.js",
     "doc-listing-inject": "npm run leftover-check && node scripts/doc-listing-inject.js",
     "license-update": "node scripts/license-update.js",


### PR DESCRIPTION
Currently the build is run after `npm install` but our watch and test commands all include the build as well.  This makes the post-install step duplicative and no longer needed.  Remove it from post-install will be more efficient.

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.
- [x] Changelog updated (not needed for documentation updates).
- [x] Documentation (README.md, WHY.md, etc.) updated or added.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
