### PR TITLE
feat: Fixing and refactoring resize and interaction behavior

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -7,7 +7,7 @@
 
     <noscript>
       <link href="../../pfelement/dist/pfelement-noscript.min.css" rel="stylesheet">
-      
+
     </noscript>
 
     <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
@@ -39,7 +39,7 @@
 
     <script>require([
       "../dist/pfe-navigation.umd.js",
-      "../../pfe-cta/dist/pfe-cta.umd.js"
+      "../../pfe-cta/dist/pfe-cta.umd.js",
     ])</script>
 
     <style>
@@ -260,7 +260,7 @@
             </a>
             <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
               <!-- documentation note: single-col dropdowns CANNOT have pfe-nav footer regions -->
-              <!-- documentation note: separator class, pfe-navigation__single-column--separator -->
+              <!-- documentation note: separator class, pfe-navigation__sub-nav-link--separator -->
               <ul>
                 <li>
                   <a href="#">Red Hat Enterprise Linux</a>
@@ -271,7 +271,7 @@
                 <li>
                   <a href="#">Red Hat OpenStack Platform</a>
                 </li>
-                <li class="pfe-navigation__single-column--separator">
+                <li class="pfe-navigation__sub-nav-link--separator">
                   <a href="#">Red Hat Virtualization</a>
                 </li>
                 <li>

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -14,6 +14,7 @@ $breakpoints: (
   lg: 992px,
   xl: 1200px,
   2xl: 1368px,
+
   // The below should match an above breakpoint value
   // Where the icons on the right appear
   'secondary-links-expand': 768px,
@@ -21,6 +22,8 @@ $breakpoints: (
   // Default value for when the nav expands to desktop mode
   'nav-expand': 1200px,
 );
+
+$dropdown-transition: height 0.25s ease-in-out;
 
 /// Breakpoint helper specific to pfe-navigation
 /// @param {string} $breakpoint Name of a breakpoint
@@ -152,9 +155,10 @@ $breakpoints: (
 
 /// Top level button styles
 @mixin top-level-button {
+  $padding-mobile: 8px 24px;
   display: flex;
   align-items: center;
-  padding: 8px 24px;
+  padding: $padding-mobile;
   border: 0;
   white-space: nowrap;
   font-family: inherit;
@@ -167,15 +171,22 @@ $breakpoints: (
   cursor: pointer;
   transition: box-shadow 0.25s;
   @include breakpoint('secondary-links-expand') {
-    display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
     height: $menu-height;
     margin-right: 8px;
     padding: 0 8px;
     font-size: 12px;
     color: #fff;
+  }
+  @include collapse('secondary-links') {
+    flex-direction: row;
+    justify-content: normal;
+    height: auto;
+    margin: 0;
+    padding: $padding-mobile;
+    font-size: 16px;
+    color: #06c;
   }
 
   // added to counteract jumpiness when dashed border is visible on focus and hover
@@ -198,6 +209,10 @@ $breakpoints: (
     &:hover {
       @include focus-styles(#000, 0px);
     }
+  }
+
+  pfe-icon {
+    @include secondary-links-icon;
   }
 }
 

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -10,35 +10,39 @@
   <div class="pfe-navigation__outer-menu-wrapper" id="mobile__dropdown">
     <div id="pfe-navigation__outer-menu-wrapper__inner" class="pfe-navigation__outer-menu-wrapper__inner">
 
+      <!-- Placeholder to move search form at mobile breakpoint to maintain tab order -->
+      <div id="pfe-navigation__search-wrapper--xs"></div>
+
       <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
       </div>
 
       <!-- @todo: dynamically set aria-expanded for trigger buttons in shadow DOM and aria-hidden for dropdown content in shadow DOM -->
       <!-- @todo: regroup on this, not sure why we would dynamically set the aria attrs in the shadow DOM rather than just add the attrs in the template via HTML -->
-      <button class="pfe-navigation__search-toggle" id="secondary-links__button--search" aria-expanded="false" aria-controls="secondary-links__dropdown--search">
-        <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
-        Search
-      </button>
-      <!-- @todo/note: dropdowns need to be directly after the trigger buttons in the DOM order otherwise you cannot tab into the dropdown itself when using a keyboard or screen reader. Need to regroup on this if original placement of the search slot was important for current functionality, in the original location above the search button you could not tab into search dropdown slot with neither a keyboard or screen reader. -->
-      <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search" aria-hidden="true">
-        search slot
-      </slot>
-
-      <slot name="pfe-navigation--custom-links" class="pfe-navigation__customlinks">
-        customlinks slot
-      </slot>
-
-      <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat" aria-expanded="false">
-        <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
-        All Red Hat
-      </button>
-      <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat" aria-hidden="true">
-        <div class="pfe-navigation__all-red-hat-wrapper__inner">
-          <div id="site-loading">
-            <pfe-progress-indicator></pfe-progress-indicator>
+      <ul class="pfe-navigation__secondary-links-wrapper" id="pfe-navigation__secondary-links-wrapper">
+        <li id="pfe-navigation__search-wrapper--md">
+          <button class="pfe-navigation__search-toggle" id="secondary-links__button--search" aria-expanded="false" aria-controls="secondary-links__dropdown--search">
+            <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
+            Search
+          </button>
+          <slot name="pfe-navigation--search" class="pfe-navigation__search" id="secondary-links__dropdown--search">
+          </slot>
+        </li>
+        <li>
+          <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat">
+            <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm"></pfe-icon>
+            All Red Hat
+          </button>
+          <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
+            <div class="pfe-navigation__all-red-hat-wrapper__inner">
+              <div id="site-loading">
+                <pfe-progress-indicator></pfe-progress-indicator>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        </li>
+
+        <!-- Custom links to be added here on 'connectedCallback' -->
+      </ul>
 
     </div>
   </div>

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -101,6 +101,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   margin-right: 8px;
   padding-left: 8px;
   padding-right: 8px;
+  font-size: 12px;
   color: #fff;
 
   &:focus,
@@ -122,6 +123,24 @@ See mixin blocks before selectors that contain the selector name and the three l
 @mixin pfe-navigation__menu-toggle--desktop {
   display: none;
 }
+@mixin pfe-navigation__menu-toggle--active {
+  color: #151515;
+  background: #fff;
+  box-shadow: inset 0 4px 0 0 #e00;
+  &:focus,
+  &:hover {
+    @include focus-styles(#000, 0px);
+  }
+}
+@mixin pfe-navigation__menu-toggle--inactive {
+  color: #fff;
+  background: #000;
+  box-shadow: none;
+  &:focus,
+  &:hover {
+    @include focus-styles(#fff, 0px);
+  }
+}
 .pfe-navigation__menu-toggle {
   @include pfe-navigation__menu-toggle--mobile;
 
@@ -141,12 +160,45 @@ See mixin blocks before selectors that contain the selector name and the three l
   // Active state
   [pfe-navigation-open-toggle='mobile__button'] &,
   [pfe-navigation-open-toggle^='main-menu__'] & {
-    color: #151515;
-    background: #fff;
-    box-shadow: inset 0 4px 0 0 #e00;
-    &:focus,
-    &:hover {
-      @include focus-styles(#000, 0px);
+    @include pfe-navigation__menu-toggle--active;
+  }
+
+  [pfe-navigation-open-toggle='secondary-links__button--search'] & {
+    @include pfe-navigation__menu-toggle--active;
+    @include breakpoint('secondary-links-expand') {
+      @include pfe-navigation__menu-toggle--inactive;
+    }
+    @include collapse('secondary-links') {
+      @include pfe-navigation__menu-toggle--inactive;
+    }
+  }
+}
+
+// @todo Fix my specificity issues
+.pfe-navigation__mobile-dropdown[class][class][class] {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  display: none;
+  width: 100%;
+  margin: 0;
+  max-height: calc(100vh - #{$menu-height});
+  padding: 16px 32px;
+  background: #fff;
+
+  // Open state
+  [pfe-navigation-open-toggle='mobile__button'] &,
+  [pfe-navigation-open-toggle^='main-menu__'] & {
+    display: flex;
+  }
+
+  [pfe-navigation-open-toggle='secondary-links__button--search'] & {
+    display: flex;
+    @include breakpoint('secondary-links-expand') {
+      display: none;
+    }
+    @include collapse('secondary-links') {
+      display: flex;
     }
   }
 }
@@ -160,155 +212,47 @@ See mixin blocks before selectors that contain the selector name and the three l
     display: flex;
     align-items: stretch;
   }
-  @include collapse('secondary-links') {
-    display: block;
-  }
-}
-
-// Layout changes per breakpoint
-// See comment at top of file
-@mixin pfe-navigation__outer-menu-wrapper--mobile {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  display: none;
-  width: 100%;
-  height: auto;
-  padding: 16px;
-  background: #fff;
-}
-@mixin pfe-navigation__outer-menu-wrapper--collapsed-menu {
-  position: static;
-  display: flex;
-  width: auto;
-  height: auto;
-  padding: 0;
-  background: transparent;
-}
-@mixin pfe-navigation__outer-menu-wrapper--desktop {
-  position: static;
-  display: flex;
-  width: auto;
-  height: $menu-height;
-  padding: 0;
-  background: transparent;
-}
-.pfe-navigation__outer-menu-wrapper {
-  @include pfe-navigation__outer-menu-wrapper--mobile;
-
-  @include breakpoint('secondary-links-expand') {
-    @include pfe-navigation__outer-menu-wrapper--collapsed-menu;
-  }
-  @include breakpoint('nav-expand') {
-    @include pfe-navigation__outer-menu-wrapper--desktop;
-  }
-  @include collapse('nav') {
-    @include pfe-navigation__outer-menu-wrapper--collapsed-menu;
-  }
-  @include collapse('secondary-links') {
-    @include pfe-navigation__outer-menu-wrapper--mobile;
-  }
-
-  [pfe-navigation-open-toggle='mobile__button'] &,
-  [pfe-navigation-open-toggle^='main-menu__'] & {
-    display: block;
-    @include breakpoint('secondary-links-expand') {
-      display: flex;
-    }
-    @include collapse('secondary-links') {
-      display: block;
-    }
-    @include collapse('nav') {
-      display: block;
-    }
-  }
-}
-
-.pfe-navigation__outer-menu-wrapper,
-.pfe-navigation__outer-menu-wrapper__inner {
   @include breakpoint('nav-expand') {
     flex-grow: 1;
   }
   @include collapse('nav') {
     flex-grow: 0;
   }
+  @include collapse('secondary-links') {
+    display: block;
+  }
+}
+
+// Layout changes per breakpoint
+// See comment at top of file
+.pfe-navigation__outer-menu-wrapper {
+  height: auto;
+
+  @include breakpoint('nav-expand') {
+    height: $menu-height;
+  }
+  @include collapse('nav') {
+    height: auto;
+  }
+
+  :host(:not([pfe-navigation-open-toggle])) .pfe-navigation--is-resizing & {
+    overflow: hidden;
+  }
+}
+
+.pfe-navigation__outer-menu-wrapper__inner {
+  width: 100%;
 }
 
 // Menu, List, & Items
 // --------------------------------------------------------
-// Layout changes per breakpoint
-// See comment at top of file
-@mixin pfe-navigation__menu-wrapper--mobile {
-  position: static;
-  display: block;
-  width: 100%;
-  margin: 0 0 8px;
-  padding: 0;
-  background: #fff;
-}
-@mixin pfe-navigation__menu-wrapper--collapsed-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  display: none;
-  width: 100%;
-  margin: 0;
-  padding: 16px 32px;
-  background: #fff;
-}
-@mixin pfe-navigation__menu-wrapper--desktop {
-  position: static;
-  display: flex;
-  align-items: stretch;
-  margin: 0 auto 0 0;
-  padding: 0;
-  background: transparent;
-}
-@mixin pfe-navigation__menu-wrapper--mobile--open {
-  display: block;
-}
-@mixin pfe-navigation__menu-wrapper--collapsed-menu--open {
-  display: block;
-}
-@mixin pfe-navigation__menu-wrapper--desktop--open {
-  // Since open state is default state, re-assert default styles
-  @include pfe-navigation__wrapper--desktop;
-}
 .pfe-navigation__menu-wrapper {
-  @include pfe-navigation__menu-wrapper--mobile;
-  @include breakpoint('secondary-links-expand') {
-    @include pfe-navigation__menu-wrapper--collapsed-menu;
-  }
+  display: flex;
   @include breakpoint('nav-expand') {
-    &,
-    &[class][class] {
-      @include pfe-navigation__menu-wrapper--desktop;
-    }
+    margin-right: auto;
   }
-
   @include collapse('nav') {
-    @include pfe-navigation__menu-wrapper--collapsed-menu;
-  }
-  @include collapse('secondary-links') {
-    @include pfe-navigation__menu-wrapper--mobile;
-  }
-
-  // Open state
-  [pfe-navigation-open-toggle='mobile__button'] &,
-  [pfe-navigation-open-toggle^='main-menu__'] & {
-    @include pfe-navigation__menu-wrapper--mobile--open;
-    @include breakpoint('secondary-links-expand') {
-      @include pfe-navigation__menu-wrapper--collapsed-menu--open;
-    }
-    @include breakpoint('nav-expand') {
-      @include pfe-navigation__menu-wrapper--desktop--open;
-    }
-    @include collapse('nav') {
-      @include pfe-navigation__menu-wrapper--collapsed-menu--open;
-    }
-    @include collapse('secondary-links') {
-      @include pfe-navigation__menu-wrapper--mobile--open;
-    }
+    margin-right: 0;
   }
 }
 
@@ -321,12 +265,20 @@ See mixin blocks before selectors that contain the selector name and the three l
 }
 
 .pfe-navigation__menu {
+  width: 100%;
+  transition: opacity 0.1s ease-out;
   @include breakpoint('nav-expand') {
     display: flex;
     align-items: stretch;
+    width: auto;
   }
   @include collapse('nav') {
     display: block;
+    width: 100%;
+  }
+
+  .pfe-navigation--is-resizing & {
+    opacity: 0;
   }
 }
 
@@ -548,7 +500,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   width: 100%;
   height: 0;
   overflow: hidden;
-  transition: height 0.25s ease-in-out;
+  transition: $dropdown-transition;
   will-change: height;
   @include pfe-navigation__dropdown-wrapper--mobile;
   @include breakpoint('nav-expand') {
@@ -561,17 +513,17 @@ See mixin blocks before selectors that contain the selector name and the three l
   // JS Adds aria-hidden at the appropriate time before open, or after close
   // This prevents the dropdown from showing to anyone, but also lets JS get the dropdown height
   // Unlike display: none
-  &[aria-hidden=true] {
-    visibility: hidden;
-  }
-
   .pfe-navigation__menu-item--open > &[class] { // Adding specificity to beat JS Breakpoint selector
     height: auto; // Height is set in JS, this is a fallback
   }
 }
 
+.pfe-navigation__dropdown-wrapper--invisible {
+  visibility: hidden;
+}
+
 .pfe-navigation__dropdown-wrapper--single-column {
-  padding: 0;
+  padding: 0 16px;
   @include breakpoint('nav-expand') {
     left: auto;
     width: auto;
@@ -592,11 +544,11 @@ See mixin blocks before selectors that contain the selector name and the three l
 @mixin pfe-navigation__dropdown--mobile {
   display: block;
   font-size: 16px;
-  padding: 12px 0;
+  padding: 12px 16px;
 }
 @mixin pfe-navigation__dropdown--desktop {
   display: grid;
-  padding: 32px 0;
+  padding: 32px 16px;
   // Fits as many columns as it can given the constraints
   // @todo evaluate layout needs and if this is a sane default
   // grid-template-columns:
@@ -611,6 +563,8 @@ See mixin blocks before selectors that contain the selector name and the three l
 }
 .pfe-navigation__dropdown {
   @include pfe-navigation__dropdown--mobile;
+  margin-left: -16px;
+  margin-right: -16px;
   visibility: hidden;
   transition: visibility 0s linear 0.4s;
   @include breakpoint('nav-expand') {
@@ -714,6 +668,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   }
   @include collapse('nav') {
     background: transparent;
+    box-shadow: none;
   }
 
   // group feature styles
@@ -802,8 +757,11 @@ See mixin blocks before selectors that contain the selector name and the three l
 // --------------------------------------------------------
 .pfe-navigation__search-toggle {
   display: none;
-  @include breakpoint('secondary-links-expand') {
-    display: flex;
+
+  :host(.pfe-navigation--has-search) & {
+    @include breakpoint('secondary-links-expand') {
+      display: flex;
+    }
   }
   @include collapse('secondary-links') {
     display: none;
@@ -973,17 +931,41 @@ See mixin blocks before selectors that contain the selector name and the three l
 // }
 
 
-// pfe-icons
+// Secondary Links
 // --------------------------------------------------------
 
 //@todo: figure out if this is the best way to style the icon color states or if updates to JS need to be made to put a class or attribute on a button when it is open to target with css
+.pfe-navigation__secondary-links-wrapper {
+  display: flex;
+  // @note Flex direction is used by pfeNavigation.isSecondaryLinksSectionCollapsed() to determine layout state
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  transition: opacity 0.1s ease-out;
+  @include breakpoint('secondary-links-expand') {
+    flex-direction: row;
+  }
+  @include collapse('secondary-links') {
+    flex-direction: column;
+  }
+  > li {
+    margin: 0;
+    padding: 0;
+    @include breakpoint('secondary-links-expand') {
+      margin-right: 8px;
+    }
+    @include collapse('secondary-links') {
+      margin-right: 0;
+    }
 
-.pfe-navigation__menu-toggle,
-.pfe-navigation__search-toggle,
-.pfe-navigation__custom-links,
-.pfe-navigation__log-in-link {
-  pfe-icon {
-    @include secondary-links-icon;
+    > a {
+      @include top-level-button;
+    }
+  }
+
+  .pfe-navigation--is-resizing & {
+    opacity: 0;
   }
 }
 
@@ -1000,10 +982,20 @@ See mixin blocks before selectors that contain the selector name and the three l
   }
 }
 
-[pfe-navigation-open-toggle='mobile__button'],
-[pfe-navigation-open-toggle^='main-menu__'] {
-  .pfe-navigation__menu-toggle pfe-icon {
+.pfe-navigation__menu-toggle pfe-icon {
+  [pfe-navigation-open-toggle='mobile__button'] &,
+  [pfe-navigation-open-toggle^='main-menu__'] & {
     --pfe-icon--Color: #151515;
+  }
+
+  [pfe-navigation-open-toggle='secondary-links__button--search'] & {
+    --pfe-icon--Color: #151515;
+    @include breakpoint('secondary-links-expand') {
+      --pfe-icon--Color: #fff;
+    }
+    @include collapse('secondary-links') {
+      --pfe-icon--Color: #151515;
+    }
   }
 }
 


### PR DESCRIPTION
feat: Fixing and refactoring resize and interaction behavior

Added pre- and post- resize adjustment functions to make sure element state (e.g. aria-hidden) is always set correctly and to hide jank
Added utility functions to add open/close attributes for dropdowns and remove them entirely
Added utility function to set correct mobile dropdown, because it changes depending on breakpoint
Made processLightDom function more performant by delaying write to DOM until it was finished updating the cloned section from the light DOM
Reworked markup for secondary links to be more semantic (in a ul) and added spot for search to be added to at desktop sizes
Renamed the separator class for dropdowns to follow BEM standards
Replaced debounce function with one that allows for function to run at the start or end of the debounce
Removed optimized resize since debounce is preferred in this case
Added cached pointers to important elements in constructor

Issues addressed in this update:
* CPFED-3752: Adding resize behavior to handle a resize that goes from one breakpoint to another
* CPFED-3767: Addressed tab order with search by moving it to one of two locations depending on breakpoint
* CPFED-3819: Made sure clicking mobile menu toggle always closes the entire mobile menu
* CPFED-3824: Made sure visibility state is managed correctly when interacting with menu and resize behaviors
