### PR TITLE
Cpfed 3809 pfe nav add overlay

### DIFF
--- a/elements/pfe-navigation/demo/single-nav.html
+++ b/elements/pfe-navigation/demo/single-nav.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>PatternFly Element | pfe-navigation Demo</title>
+
+    <noscript>
+      <link href="../../pfelement/dist/pfelement-noscript.min.css" rel="stylesheet">
+
+    </noscript>
+
+    <link href="../../pfelement/dist/pfelement.min.css" rel="stylesheet">
+
+    <!-- Stylesheets for testing light DOM styles.
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap-reboot.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/typebase.css/0.5.0/typebase.css">
+    -->
+
+    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-base.css" />
+    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-context.css" />
+    <link rel="stylesheet" href="../../pfe-styles/dist/pfe-layouts.css" />
+    <link rel="stylesheet" href="../dist/pfe-navigation--lightdom.css" />
+
+    <link type="text/css" rel="stylesheet" href="https://static.redhat.com/libs/redhat/redhat-font/2/webfonts/red-hat-font.css" media="all">
+
+    <!-- uncomment the es5-adapter if you're using the umd version -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/custom-elements-es5-adapter.js"></script>
+
+    <!-- Use webcomponents-loader when you are adding support for more modern browsers -->
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-loader.js"></script> -->
+
+    <!-- IE11 test: use bundle + require with umd files -->
+    <!-- Use webcomponents-bundle when supporting much older browsers like IE11 -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.3.0/webcomponents-bundle.js"></script>
+
+    <!-- Tests require pulling in the UMD version of the files -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+
+    <script>require([
+      "../dist/pfe-navigation.umd.js",
+      "../../pfe-cta/dist/pfe-cta.umd.js",
+    ])</script>
+  </head>
+  <body unresolved style="background-color: #ddd;">
+     <pfe-navigation id="pfe-navigation-2">
+      <nav class="pfe-navigation" aria-label="Main Navigation">
+        <div class="pfe-navigation__logo-wrapper" id="pfe-navigation__logo-wrapper">
+          <a href="#" class="pfe-navigation__logo-link">
+            <img class="pfe-navigation__logo-image" src="assets/redhat-customer-portal--reverse.svg" alt="Red Hat Customer Portal" />
+          </a>
+        </div>
+        <ul class="pfe-navigation__menu" id="pfe-navigation__menu">
+          <li class="pfe-navigation__menu-item">
+            <a href="#" class="pfe-navigation__menu-link has-dropdown" aria-expanded="false">
+              Products
+            </a>
+            <div class="pfe-navigation__dropdown">
+              <section>
+                <h3>
+                  <a href="#">Platforms</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Red Hat Enterprise Linux</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat OpenStack Platform</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat Virtualization</a>
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h3>
+                  <a href="#">Ladders</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Lorem ipsum</a>
+                  </li>
+                  <li>
+                    <a href="#">Dolor sit amet</a>
+                  </li>
+                  <li>
+                    <a href="#">Wakka Wakka</a>
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h3>
+                  <a href="#">Chutes</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Yakkita yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Enterprise Yakkita yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Upstream Yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Yakkita ME</a>
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h3>
+                  <a href="#">Platforms</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Red Hat Enterprise Linux</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat JBoss Enterprise Application Platform</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat OpenStack Platform</a>
+                  </li>
+                  <li>
+                    <a href="#">Red Hat Virtualization</a>
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h3>
+                  <a href="#">Ladders</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Lorem ipsum</a>
+                  </li>
+                  <li>
+                    <a href="#">Dolor sit amet</a>
+                  </li>
+                  <li>
+                    <a href="#">Wakka Wakka</a>
+                  </li>
+                </ul>
+              </section>
+              <section>
+                <h3>
+                  <a href="#">Chutes</a>
+                </h3>
+                <ul>
+                  <li>
+                    <a href="#">Yakkita yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Enterprise Yakkita yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Upstream Yakkita</a>
+                  </li>
+                  <li>
+                    <a href="#">Yakkita ME</a>
+                  </li>
+                </ul>
+              </section>
+            </div>
+          </li>
+          <li class="pfe-navigation__menu-item">
+            <a href="#" class="pfe-navigation__menu-link">
+              Solutions
+            </a>
+          </li>
+          <li class="pfe-navigation__menu-item">
+            <a href="#" class="pfe-navigation__menu-link">
+              Learning & Support
+            </a>
+            <div class="pfe-navigation__dropdown pfe-navigation__dropdown--single-column">
+              <!-- documentation note: single-col dropdowns CANNOT have pfe-nav footer regions -->
+              <!-- documentation note: separator class, pfe-navigation__single-column--separator -->
+              <ul>
+                <li>
+                  <a href="#">Red Hat Enterprise Linux</a>
+                </li>
+                <li>
+                  <a href="#">Red Hat JBoss Enterprise Application Platform</a>
+                </li>
+                <li>
+                  <a href="#">Red Hat OpenStack Platform</a>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <a href="#">Red Hat Virtualization</a>
+                </li>
+                <li>
+                  <a href="#">Red Hat Virtualization Example</a>
+                </li>
+              </ul>
+            </div> <!-- end .pfe-navigation__dropdown -->
+          </li>
+          <li class="pfe-navigation__menu-item">
+            <a href="#" class="pfe-navigation__menu-link">
+              Resources
+            </a>
+          </li>
+          <li class="pfe-navigation__menu-item">
+            <a href="#" class="pfe-navigation__menu-link">
+              Red Hat & Open Source
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div slot="pfe-navigation--custom-links" class="pfe-navigation__custom-links" id="pfe-navigation__custom-links">
+        <a href="#" class="">
+          <!-- @note: added web-icon-globe icon as a placeholder since it is used as the language switcher icon -->
+          <pfe-icon icon="web-icon-globe" pfe-size="sm" aria-hidden="true"></pfe-icon>
+          Custom Link
+        </a>
+      </div>
+
+      <div slot="pfe-navigation--search" class="pfe-navigation__search pfe-navigation__search--default-styles">
+      <!-- @todo: move form and label for="" and label id into shadow DOM -->
+      <!-- @todo: add a11y features to search form and submit button in shadow DOM -->
+        <form>
+          <label for="pfe-navigation__search-label2" class="sr-only">Search the Red Hat Customer Portal</label>
+          <input id="pfe-navigation__search-label2" type="text" placeholder="Search the Red Hat Customer Portal" />
+          <button aria-label="Submit Search">Search</button>
+        </form>
+      </div>
+    </pfe-navigation>
+
+    <h1><code>pfe-navigation</code></h1>
+     <h2>Large Logo</h2>
+
+  </body>
+</html>

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -54,5 +54,4 @@
 
 </nav>
 
-<!-- @todo: figure out to do the overlay in shadow DOM -->
 <div class="pfe-navigation__overlay" hidden></div>

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -55,4 +55,4 @@
 </nav>
 
 <!-- @todo: figure out to do the overlay in shadow DOM -->
-<!-- <div class="pfe-navigation__overlay"></div> -->
+<div class="pfe-navigation__overlay" hidden></div>

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -81,6 +81,8 @@ class PfeNavigation extends PFElement {
     this._customlinks = this.shadowRoot.querySelector(`.${this.tag}__customlinks`);
     this._siteSwitcherWrapper = this.shadowRoot.querySelector(".pfe-navigation__all-red-hat-wrapper__inner");
     this._siteSwitchLoadingIndicator = this.shadowRoot.querySelector("#site-loading");
+    this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
+    // this._overlayWrapper = this.shadowRoot.querySelector("#pfe-navigation__wrapper");
 
     // Set default breakpoints to null (falls back to CSS)
     this.menuBreakpoints = {
@@ -119,12 +121,24 @@ class PfeNavigation extends PFElement {
     this._postResizeAdjustments = this._postResizeAdjustments.bind(this);
     this._menuToggleKeyboardListener = this._menuToggleKeyboardListener.bind(this);
     this._generalKeyboardListener = this._generalKeyboardListener.bind(this);
+    // this._toggleOverlay = this._toggleOverlay.bind(this);
+    // @todo: decide if this is needed
+    // this._overlayClickHandler = this._overlayClickHandler.bind(this);
+    // this._overlayWrapper = this._overlayWrapper.bind(this);
 
     // Handle updates to slotted search content
     this._searchSlot.addEventListener("slotchange", this._processSearchSlotChange);
 
     // Setup mutation observer to watch for content changes
     this._observer = new MutationObserver(this._processLightDom);
+
+    // @todo: decided if this is needed
+    // this.overlay = false;
+
+    // make sure we close all of the nav items and hide the overlay
+    // when it's clicked
+    // @todo: decided if this is needed
+    // this._overlay.addEventListener("click", this._overlayClickHandler);
   }
 
   connectedCallback() {
@@ -161,6 +175,8 @@ class PfeNavigation extends PFElement {
     window.removeEventListener("resize", this._debouncedPreResizeAdjustments);
     window.removeEventListener("resize", this._debouncedPostResizeAdjustments);
     this._slot.removeEventListener("slotchange", this._processSearchSlotChange);
+    // @todo: decided if this is needed
+    // this._overlay.removeEventListener("click", this._overlayClickHandler);
   }
 
   // Process the attribute change
@@ -190,10 +206,12 @@ class PfeNavigation extends PFElement {
       if (openToggleId.startsWith("main-menu") && toggleId === "mobile__button") {
         return true;
       }
+
       // Only checks for prefix so if main-menu is queried and main-menu__dropdown--Link-Name is open it still evaluates as true
       // This prevents the main-menu toggle shutting at mobile when a sub-section is opened
       return toggleId === openToggleId;
     }
+
     return false;
   }
 
@@ -456,6 +474,9 @@ class PfeNavigation extends PFElement {
       this._addOpenDropdownAttributes(toggleElement, dropdownWrapper, debugNavigationState);
 
       this.setAttribute(`${this.tag}-open-toggle`, toggleId);
+
+      // Show overlay
+      this._overlay.hidden = false;
     };
 
     /**
@@ -475,10 +496,16 @@ class PfeNavigation extends PFElement {
       if (backOut && toggleId.startsWith("main-menu") && this.isMobileMenuButtonVisible()) {
         // Back out to main-menu
         _openDropdown(this._mobileToggle, this.shadowRoot.getElementById("mobile__dropdown"));
+        // Show overlay
+        this._overlay.hidden = false;
       } else {
         // Shut it by removing state attribute
         this.removeAttribute(`${this.tag}-open-toggle`, "");
       }
+
+      // @todo: figure out how to still show overlay even when mobile dropdown menu is opened and closed
+      // Hide overlay
+      this._overlay.hidden = true;
     };
 
     // Shut any open dropdowns
@@ -509,6 +536,16 @@ class PfeNavigation extends PFElement {
     // Clone state attribute inside of Shadow DOM to avoid compound :host() selectors
     shadowDomOuterWrapper.setAttribute(`${this.tag}-open-toggle`, this.getAttribute(`${this.tag}-open-toggle`));
     return toState === "open";
+
+    if (lightDomOverlayWrapper.hasAttribute("pfe-navigation-open-toggle")) {
+      // Hide Overlay
+      this._overlay.hidden = true;
+      console.log(`menu closed`);
+    } else {
+      // Show Overlay
+      this._overlay.hidden = false;
+      console.log(`menu open`);
+    }
   }
 
   _processSearchSlotChange() {
@@ -664,6 +701,11 @@ class PfeNavigation extends PFElement {
     // Add All Red Hat toggle behavior
     this._allRedHatToggle.addEventListener("click", this._toggleAllRedHat);
 
+    // Add overlay toggle behavior
+    // this._mobileToggle.addEventListener("click", this._toggleOverlay);
+    // this._searchToggle.addEventListener("click", this._toggleOverlay);
+    // this._allRedHatToggle.addEventListener("click", this._toggleOverlay);
+
     // General keyboard listener attached to the entire component
     this.addEventListener("keydown", this._generalKeyboardListener);
 
@@ -700,7 +742,7 @@ class PfeNavigation extends PFElement {
     const postProcessLightDom = () => {
       if (this.isMobileMenuButtonVisible() && !this.isOpen("mobile__button")) {
         this._addCloseDropdownAttributes(this._mobileToggle, this._currentMobileDropdown);
-        console.log(this._currentMobileDropdown);
+        // console.log(this._currentMobileDropdown);
       }
     };
 
@@ -915,6 +957,14 @@ class PfeNavigation extends PFElement {
     this._changeNavigationState(toggleId);
   }
 
+  // _toggleOverlay() {
+  //   if (this.isOpen()) {
+  //     this._overlay.hidden = false;
+  //   } else {
+  //     this._overlay.hidden = true;
+  //   }
+  // }
+
   /**
    * Default Toggle Button Keyboard event handler
    * @param {object} event
@@ -1034,6 +1084,11 @@ class PfeNavigation extends PFElement {
       // );
     }
   }
+
+  // @todo: decide if this is needed
+  // _overlayClickHandler(event) {
+  //   this.overlay = false;
+  // }
 
   _requestSiteSwitcher() {
     const promise = new Promise((resolve, reject) => {

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -1056,6 +1056,24 @@ class PfeNavigation extends PFElement {
   _overlayClickHandler() {
     const openToggleId = this.getAttribute(`${this.tag}-open-toggle`);
     this._changeNavigationState(openToggleId, "close");
+    if (this.isSecondaryLinksSectionCollapsed()) {
+      // Mobile
+      // close mobile menu
+      this._changeNavigationState("mobile__button", "close");
+    } else if (this.isMobileMenuButtonVisible()) {
+      // Tablet-ish
+      // if it's a child of main menu (e.g. openToggleId.startsWith("main-menu") -- accordion dropdown) close mobile__button
+      // Else close openToggleId -- desktop menu
+      if (openToggleId.startsWith("main-menu")) {
+        this._changeNavigationState("mobile__button", "close");
+      } else {
+        this._changeNavigationState(openToggleId, "close");
+      }
+    } else {
+      // Desktop
+      // close desktop menu
+      this._changeNavigationState(openToggleId, "close");
+    }
   }
 
   _requestSiteSwitcher() {

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -123,7 +123,7 @@ class PfeNavigation extends PFElement {
     this._generalKeyboardListener = this._generalKeyboardListener.bind(this);
     // this._toggleOverlay = this._toggleOverlay.bind(this);
     // @todo: decide if this is needed
-    // this._overlayClickHandler = this._overlayClickHandler.bind(this);
+    this._overlayClickHandler = this._overlayClickHandler.bind(this);
     // this._overlayWrapper = this._overlayWrapper.bind(this);
 
     // Handle updates to slotted search content
@@ -135,10 +135,10 @@ class PfeNavigation extends PFElement {
     // @todo: decided if this is needed
     // this.overlay = false;
 
-    // make sure we close all of the nav items and hide the overlay
-    // when it's clicked
+    // ensure we close the whole menu and hide the overlay
+    // when the overlay is clicked
     // @todo: decided if this is needed
-    // this._overlay.addEventListener("click", this._overlayClickHandler);
+    this._overlay.addEventListener("click", this._overlayClickHandler);
   }
 
   connectedCallback() {
@@ -176,7 +176,7 @@ class PfeNavigation extends PFElement {
     window.removeEventListener("resize", this._debouncedPostResizeAdjustments);
     this._slot.removeEventListener("slotchange", this._processSearchSlotChange);
     // @todo: decided if this is needed
-    // this._overlay.removeEventListener("click", this._overlayClickHandler);
+    this._overlay.removeEventListener("click", this._overlayClickHandler);
   }
 
   // Process the attribute change
@@ -536,16 +536,6 @@ class PfeNavigation extends PFElement {
     // Clone state attribute inside of Shadow DOM to avoid compound :host() selectors
     shadowDomOuterWrapper.setAttribute(`${this.tag}-open-toggle`, this.getAttribute(`${this.tag}-open-toggle`));
     return toState === "open";
-
-    if (lightDomOverlayWrapper.hasAttribute("pfe-navigation-open-toggle")) {
-      // Hide Overlay
-      this._overlay.hidden = true;
-      console.log(`menu closed`);
-    } else {
-      // Show Overlay
-      this._overlay.hidden = false;
-      console.log(`menu open`);
-    }
   }
 
   _processSearchSlotChange() {
@@ -1085,10 +1075,14 @@ class PfeNavigation extends PFElement {
     }
   }
 
-  // @todo: decide if this is needed
-  // _overlayClickHandler(event) {
-  //   this.overlay = false;
-  // }
+  // close menu when overlay is clicked
+  _overlayClickHandler() {
+    const openToggleId = this.getAttribute(`${this.tag}-open-toggle`);
+    // if (openToggleId) {
+    //   this._changeNavigationState(openToggleId, "close");
+    // }
+    this._changeNavigationState(openToggleId, "close");
+  }
 
   _requestSiteSwitcher() {
     const promise = new Promise((resolve, reject) => {

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -128,7 +128,7 @@ class PfeNavigation extends PFElement {
     // Setup mutation observer to watch for content changes
     this._observer = new MutationObserver(this._processLightDom);
 
-    // insure we close the whole menu and hide the overlay when the overlay is clicked
+    // ensure we close the whole menu and hide the overlay when the overlay is clicked
     this._overlay.addEventListener("click", this._overlayClickHandler);
   }
 
@@ -676,11 +676,6 @@ class PfeNavigation extends PFElement {
 
     // Add All Red Hat toggle behavior
     this._allRedHatToggle.addEventListener("click", this._toggleAllRedHat);
-
-    // Add overlay toggle behavior
-    // this._mobileToggle.addEventListener("click", this._toggleOverlay);
-    // this._searchToggle.addEventListener("click", this._toggleOverlay);
-    // this._allRedHatToggle.addEventListener("click", this._toggleOverlay);
 
     // General keyboard listener attached to the entire component
     this.addEventListener("keydown", this._generalKeyboardListener);

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -486,16 +486,12 @@ class PfeNavigation extends PFElement {
       if (backOut && toggleId.startsWith("main-menu") && this.isMobileMenuButtonVisible()) {
         // Back out to main-menu
         _openDropdown(this._mobileToggle, this.shadowRoot.getElementById("mobile__dropdown"));
-        // Show overlay
-        this._overlay.hidden = false;
       } else {
         // Shut it by removing state attribute
         this.removeAttribute(`${this.tag}-open-toggle`, "");
+        // Hide overlay only when top level menu is closed
+        this._overlay.hidden = true;
       }
-
-      // @todo: figure out how to still show overlay even when mobile dropdown menu is opened and closed
-      // Hide overlay
-      this._overlay.hidden = true;
     };
 
     // Shut any open dropdowns

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -717,7 +717,6 @@ class PfeNavigation extends PFElement {
     const postProcessLightDom = () => {
       if (this.isMobileMenuButtonVisible() && !this.isOpen("mobile__button")) {
         this._addCloseDropdownAttributes(this._mobileToggle, this._currentMobileDropdown);
-        // console.log(this._currentMobileDropdown);
       }
     };
 

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -82,7 +82,6 @@ class PfeNavigation extends PFElement {
     this._siteSwitcherWrapper = this.shadowRoot.querySelector(".pfe-navigation__all-red-hat-wrapper__inner");
     this._siteSwitchLoadingIndicator = this.shadowRoot.querySelector("#site-loading");
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
-    // this._overlayWrapper = this.shadowRoot.querySelector("#pfe-navigation__wrapper");
 
     // Set default breakpoints to null (falls back to CSS)
     this.menuBreakpoints = {
@@ -121,10 +120,7 @@ class PfeNavigation extends PFElement {
     this._postResizeAdjustments = this._postResizeAdjustments.bind(this);
     this._menuToggleKeyboardListener = this._menuToggleKeyboardListener.bind(this);
     this._generalKeyboardListener = this._generalKeyboardListener.bind(this);
-    // this._toggleOverlay = this._toggleOverlay.bind(this);
-    // @todo: decide if this is needed
     this._overlayClickHandler = this._overlayClickHandler.bind(this);
-    // this._overlayWrapper = this._overlayWrapper.bind(this);
 
     // Handle updates to slotted search content
     this._searchSlot.addEventListener("slotchange", this._processSearchSlotChange);
@@ -132,12 +128,7 @@ class PfeNavigation extends PFElement {
     // Setup mutation observer to watch for content changes
     this._observer = new MutationObserver(this._processLightDom);
 
-    // @todo: decided if this is needed
-    // this.overlay = false;
-
-    // ensure we close the whole menu and hide the overlay
-    // when the overlay is clicked
-    // @todo: decided if this is needed
+    // insure we close the whole menu and hide the overlay when the overlay is clicked
     this._overlay.addEventListener("click", this._overlayClickHandler);
   }
 
@@ -175,7 +166,6 @@ class PfeNavigation extends PFElement {
     window.removeEventListener("resize", this._debouncedPreResizeAdjustments);
     window.removeEventListener("resize", this._debouncedPostResizeAdjustments);
     this._slot.removeEventListener("slotchange", this._processSearchSlotChange);
-    // @todo: decided if this is needed
     this._overlay.removeEventListener("click", this._overlayClickHandler);
   }
 
@@ -947,14 +937,6 @@ class PfeNavigation extends PFElement {
     this._changeNavigationState(toggleId);
   }
 
-  // _toggleOverlay() {
-  //   if (this.isOpen()) {
-  //     this._overlay.hidden = false;
-  //   } else {
-  //     this._overlay.hidden = true;
-  //   }
-  // }
-
   /**
    * Default Toggle Button Keyboard event handler
    * @param {object} event
@@ -1078,9 +1060,6 @@ class PfeNavigation extends PFElement {
   // close menu when overlay is clicked
   _overlayClickHandler() {
     const openToggleId = this.getAttribute(`${this.tag}-open-toggle`);
-    // if (openToggleId) {
-    //   this._changeNavigationState(openToggleId, "close");
-    // }
     this._changeNavigationState(openToggleId, "close");
   }
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -45,6 +45,20 @@ See mixin blocks before selectors that contain the selector name and the three l
 .pfe-navigation {
   display: flex;
   align-items: stretch;
+  // Overlay
+  &__overlay {
+    display: block;
+    background-color: rgba(0, 0, 0, 0.2);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: pfe-zindex(overlay);
+    &[hidden] {
+      display: none;
+    }
+  }
 }
 
 .pfe-navigation__wrapper {
@@ -73,6 +87,10 @@ See mixin blocks before selectors that contain the selector name and the three l
     //   @include focus-styles(#000, 1px);
     // }
   }
+
+  // @todo: verify that this is a feasable way to ensure this and that this does not conflict with any other z-index rules of the nav
+  // Ensure that the navigation z-index is higher than the Overlay div
+  z-index: 1000;
 }
 
 // Logo area
@@ -1021,7 +1039,6 @@ See mixin blocks before selectors that contain the selector name and the three l
 .pfe-navigation__menu-toggle pfe-icon[icon='web-icon-plus'] {
   transform: rotate(-45deg);
 }
-
 
 // Should stay at the end of the file
 @import "pfe-navigation--grid";

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -291,6 +291,10 @@ See mixin blocks before selectors that contain the selector name and the three l
 .pfe-navigation__menu {
   width: 100%;
   transition: opacity 0.1s ease-out;
+  // added to fix overflow issues on mobile accordion dropdowns
+  overflow: auto;
+  max-height: 100vh;
+
   @include breakpoint('nav-expand') {
     display: flex;
     align-items: stretch;

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -54,7 +54,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: pfe-zindex(overlay);
+    z-index: 97;
     &[hidden] {
       display: none;
     }
@@ -90,7 +90,7 @@ See mixin blocks before selectors that contain the selector name and the three l
 
   // @todo: verify that this is a feasable way to ensure this and that this does not conflict with any other z-index rules of the nav
   // Ensure that the navigation z-index is higher than the Overlay div
-  z-index: 1000;
+  z-index: 98;
 }
 
 // Logo area

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -45,19 +45,20 @@ See mixin blocks before selectors that contain the selector name and the three l
 .pfe-navigation {
   display: flex;
   align-items: stretch;
-  // Overlay
-  &__overlay {
-    display: block;
-    background-color: rgba(0, 0, 0, 0.2);
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 97;
-    &[hidden] {
-      display: none;
-    }
+}
+
+// Overlay
+.pfe-navigation__overlay {
+  display: block;
+  background-color: rgba(0, 0, 0, 0.2);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 97;
+  &[hidden] {
+    display: none;
   }
 }
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,18 +98,24 @@
 | Filename | line # | TODO
 |:------|:------:|:------
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L527) | 527 | processLightDom seems to be firing twice, need to look into this and see whether that is okay or if it needs to be fixed, seems like it is not a good thing but not sure if it is avoidable or not
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L581) | 581 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L634) | 634 | figure out if this is causing inconsistent toggling of aria-hidden
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L671) | 671 | /note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons (Search/All Red Hat), added aria-hidden attr in the pfe-nav shadow DOM template for now, need to figure out best way to do this dynamically
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L675) | 675 | added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L676) | 676 | need to figure out best way to manage the dynamic setting of aria-hidden when custom link gets used as a dropdown instead by content editors and other dev teams
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L677) | 677 | /note: tried this method of dynamically setting the aria-hidden attr for other dropdowns but I was having an issue with inconsistent toggling of the aria-hidden attr for the search dropdown so commented it out for now, this code might be conflicting with logic elsewhere for aria-hidden?
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L730) | 730 | Get Mobile menu height reliably so we can animate it
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L743) | 743 | Not working yet These other dropdowns need style & JS logic love
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L780) | 780 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L781) | 781 | Clear/update inline heights on resize
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L807) | 807 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L125) | 125 | decide if this is needed
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L135) | 135 | decided if this is needed
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L140) | 140 | decided if this is needed
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L178) | 178 | decided if this is needed
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L506) | 506 | figure out how to still show overlay even when mobile dropdown menu is opened and closed
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L554) | 554 | processLightDom seems to be firing twice, need to look into this and see whether that is okay or if it needs to be fixed, seems like it is not a good thing but not sure if it is avoidable or not
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L608) | 608 | look into only replacing markup that changed via mutationList
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L661) | 661 | figure out if this is causing inconsistent toggling of aria-hidden
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L703) | 703 | /note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons (Search/All Red Hat), added aria-hidden attr in the pfe-nav shadow DOM template for now, need to figure out best way to do this dynamically
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L707) | 707 | added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L708) | 708 | need to figure out best way to manage the dynamic setting of aria-hidden when custom link gets used as a dropdown instead by content editors and other dev teams
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L709) | 709 | /note: tried this method of dynamically setting the aria-hidden attr for other dropdowns but I was having an issue with inconsistent toggling of the aria-hidden attr for the search dropdown so commented it out for now, this code might be conflicting with logic elsewhere for aria-hidden?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L762) | 762 | Get Mobile menu height reliably so we can animate it
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L775) | 775 | Not working yet These other dropdowns need style & JS logic love
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L812) | 812 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L813) | 813 | Clear/update inline heights on resize
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L839) | 839 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L1078) | 1078 | decide if this is needed
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
 | [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,16 +98,18 @@
 | Filename | line # | TODO
 |:------|:------:|:------
 | [pfe-markdown](../elements/pfe-markdown/src/pfe-markdown.js#L49) | 49 | when we stop supporting IE11, the need to disconnect and
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L5) | 5 | Figure out cooler way to include these utilty functions
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L249) | 249 | Find reliable way to check if secondary links are collapsed (search and all red hat buttons probably aren't it)
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L467) | 467 | look into only replacing markup that changed via mutationList
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L485) | 485 | Clone Node breaks event listeners, might need to think on this, we'll need to be able to maintain the lightDOM
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L554) | 554 | added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L570) | 570 | add aria-hidden and aria-expanded attributes to appropriate elements for mobile dropdown
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L582) | 582 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L583) | 583 | Clear/update inline heights on resize
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L593) | 593 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
-| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L651) | 651 | Not working yet These other dropdowns need style & JS logic love
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L527) | 527 | processLightDom seems to be firing twice, need to look into this and see whether that is okay or if it needs to be fixed, seems like it is not a good thing but not sure if it is avoidable or not
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L581) | 581 | look into only replacing markup that changed via mutationList
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L634) | 634 | figure out if this is causing inconsistent toggling of aria-hidden
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L671) | 671 | /note: this only adds aria-hidden to the main menu dropdown links and not the utility buttons (Search/All Red Hat), added aria-hidden attr in the pfe-nav shadow DOM template for now, need to figure out best way to do this dynamically
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L675) | 675 | added this logic, uses .dropdown-content class on the dropdown content divs, need to verify that this logic is reasonable and if so add the notes to the documentation about the class
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L676) | 676 | need to figure out best way to manage the dynamic setting of aria-hidden when custom link gets used as a dropdown instead by content editors and other dev teams
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L677) | 677 | /note: tried this method of dynamically setting the aria-hidden attr for other dropdowns but I was having an issue with inconsistent toggling of the aria-hidden attr for the search dropdown so commented it out for now, this code might be conflicting with logic elsewhere for aria-hidden?
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L730) | 730 | Get Mobile menu height reliably so we can animate it
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L743) | 743 | Not working yet These other dropdowns need style & JS logic love
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L780) | 780 | Run this if layout breaks nav-expand breakpoint and secondary-links-expand breakpoint
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L781) | 781 | Clear/update inline heights on resize
+| [pfe-navigation](../elements/pfe-navigation/src/pfe-navigation.js#L807) | 807 | if Search isn't present, check for custom links, if that isn't present use All Red Hat
 | [pfelement](../elements/pfelement/src/pfelement.js#L79) | 79 | update this to use :defined?
 | [pfelement](../elements/pfelement/src/pfelement.js#L171) | 171 | maybe we should use just the attribute instead of the class?
 | [pfelement](../elements/pfelement/src/pfelement.js#L368) | 368 | This is a duplicate function to cssVariable above, combine them</div>


### PR DESCRIPTION
---
name: Add Overlay Features
labels: "feature, ready for review"
---

## pfe-navigation

- add overlay feature that is visible when menu is open and hidden when menu is closed
- add overlay feature that allows user to close entire menu when the overlay is clicked
- insure that aria states toggle appropriately when overlay is clicked to close menu
- overlay is hidden when escape key is pressed and menu closes
- add demo page that shows only one single nav on the page

### Testing instructions

1. Pull down changes from this branch
2. run `npm start`
3. run `npm run dev pfe-navigation`
4. navigate to `http://localhost:8000/elements/pfe-navigation/demo/single-nav.html`
5. Open each dropdown on desktop
6. Close each dropdown on desktop by clicking the overlay div 
7. Open the menu items on mobile
8. Close the menu items on mobile by clicking on the overlay div

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
