### PR TITLE
style: #967: Extend line lengths in prettier to 120

### DIFF
--- a/elements/pfe-accordion/demo/pfe-accordion.story.js
+++ b/elements/pfe-accordion/demo/pfe-accordion.story.js
@@ -53,20 +53,12 @@ stories.add(PfeAccordion.tag, () => {
   });
 
   // Ask user if they want to add any custom content
-  const customContent = storybookBridge.boolean(
-    "Use custom content?",
-    false,
-    "Content"
-  );
+  const customContent = storybookBridge.boolean("Use custom content?", false, "Content");
 
   // Let the user customize the header + panel set
   if (customContent) {
     for (let i = 0; i < accordionCount; i++) {
-      headings[i] = storybookBridge.text(
-        `Heading ${i + 1}`,
-        "",
-        "accordion-set"
-      );
+      headings[i] = storybookBridge.text(`Heading ${i + 1}`, "", "accordion-set");
       panels[i] = storybookBridge.text(`Panel ${i + 1}`, "", "accordion-set");
     }
   }

--- a/elements/pfe-accordion/src/pfe-accordion.js
+++ b/elements/pfe-accordion/src/pfe-accordion.js
@@ -86,19 +86,11 @@ class PfeAccordion extends PFElement {
 
     if (attr === "pfe-disclosure") {
       if (newVal === "true") {
-        this._allHeaders().forEach(header =>
-          header.setAttribute("pfe-disclosure", "true")
-        );
-        this._allPanels().forEach(panel =>
-          panel.setAttribute("pfe-disclosure", "true")
-        );
+        this._allHeaders().forEach(header => header.setAttribute("pfe-disclosure", "true"));
+        this._allPanels().forEach(panel => panel.setAttribute("pfe-disclosure", "true"));
       } else {
-        this._allHeaders().forEach(header =>
-          header.setAttribute("pfe-disclosure", "false")
-        );
-        this._allPanels().forEach(panel =>
-          panel.setAttribute("pfe-disclosure", "false")
-        );
+        this._allHeaders().forEach(header => header.setAttribute("pfe-disclosure", "false"));
+        this._allPanels().forEach(panel => panel.setAttribute("pfe-disclosure", "false"));
       }
     }
   }
@@ -180,10 +172,7 @@ class PfeAccordion extends PFElement {
     });
 
     if (headers.length === 1) {
-      if (
-        this.hasAttribute("pfe-disclosure") &&
-        this.getAttribute("pfe-disclosure") === "false"
-      ) {
+      if (this.hasAttribute("pfe-disclosure") && this.getAttribute("pfe-disclosure") === "false") {
         return;
       }
 
@@ -222,9 +211,7 @@ class PfeAccordion extends PFElement {
 
   _expandPanel(panel) {
     if (!panel) {
-      console.error(
-        `${PfeAccordion.tag}: Trying to expand a panel that doesn't exist`
-      );
+      console.error(`${PfeAccordion.tag}: Trying to expand a panel that doesn't exist`);
       return;
     }
 
@@ -244,9 +231,7 @@ class PfeAccordion extends PFElement {
 
   _collapsePanel(panel) {
     if (!panel) {
-      console.error(
-        `${PfeAccordion.tag}: Trying to collapse a panel that doesn't exist`
-      );
+      console.error(`${PfeAccordion.tag}: Trying to collapse a panel that doesn't exist`);
       return;
     }
 
@@ -339,9 +324,7 @@ class PfeAccordion extends PFElement {
     }
 
     if (next.tagName.toLowerCase() !== PfeAccordionPanel.tag) {
-      console.error(
-        `${PfeAccordion.tag}: Sibling element to a header needs to be a panel`
-      );
+      console.error(`${PfeAccordion.tag}: Sibling element to a header needs to be a panel`);
       return;
     }
 
@@ -350,15 +333,13 @@ class PfeAccordion extends PFElement {
 
   _previousHeader() {
     const headers = this._allHeaders();
-    let newIndex =
-      headers.findIndex(header => header === document.activeElement) - 1;
+    let newIndex = headers.findIndex(header => header === document.activeElement) - 1;
     return headers[(newIndex + headers.length) % headers.length];
   }
 
   _nextHeader() {
     const headers = this._allHeaders();
-    let newIndex =
-      headers.findIndex(header => header === document.activeElement) + 1;
+    let newIndex = headers.findIndex(header => header === document.activeElement) + 1;
     return headers[newIndex % headers.length];
   }
 

--- a/elements/pfe-autocomplete/demo/pfe-autocomplete.story.js
+++ b/elements/pfe-autocomplete/demo/pfe-autocomplete.story.js
@@ -1,10 +1,5 @@
 import { storiesOf } from "@storybook/polymer";
-import {
-  withKnobs,
-  text,
-  select,
-  boolean
-} from "@storybook/addon-knobs/polymer";
+import { withKnobs, text, select, boolean } from "@storybook/addon-knobs/polymer";
 import * as storybookBridge from "@storybook/addon-knobs/polymer";
 import PfeAutocomplete from "../dist/pfe-autocomplete";
 import * as tools from "../../../.storybook/utils.js";

--- a/elements/pfe-autocomplete/src/pfe-autocomplete.js
+++ b/elements/pfe-autocomplete/src/pfe-autocomplete.js
@@ -42,10 +42,7 @@ class PfeAutocomplete extends PFElement {
     this._slotchangeHandler = this._slotchangeHandler.bind(this);
 
     this._slot = this.shadowRoot.querySelector("slot");
-    this._slot.addEventListener(
-      PfeAutocomplete.events.slotchange,
-      this._slotchangeHandler
-    );
+    this._slot.addEventListener(PfeAutocomplete.events.slotchange, this._slotchangeHandler);
   }
 
   connectedCallback() {
@@ -53,8 +50,7 @@ class PfeAutocomplete extends PFElement {
 
     this.loading = false;
     this.debounce = this.debounce || 300;
-    this._ariaAnnounceTemplate =
-      "There are ${numOptions} suggestions. Use the up and down arrows to browse.";
+    this._ariaAnnounceTemplate = "There are ${numOptions} suggestions. Use the up and down arrows to browse.";
 
     // clear button
     this._clearBtn = this.shadowRoot.querySelector(".clear-search");
@@ -72,31 +68,16 @@ class PfeAutocomplete extends PFElement {
     this.addEventListener("keyup", this._inputKeyUp.bind(this));
 
     // these two events, fire search
-    this.addEventListener(
-      PfeAutocomplete.events.search,
-      this._closeDroplist.bind(this)
-    );
-    this.addEventListener(
-      PfeAutocomplete.events.select,
-      this._optionSelected.bind(this)
-    );
+    this.addEventListener(PfeAutocomplete.events.search, this._closeDroplist.bind(this));
+    this.addEventListener(PfeAutocomplete.events.select, this._optionSelected.bind(this));
   }
 
   disconnectedCallback() {
     this.removeEventListener("keyup", this._inputKeyUp);
 
-    this.removeEventListener(
-      PfeAutocomplete.events.search,
-      this._closeDroplist
-    );
-    this.removeEventListener(
-      PfeAutocomplete.events.select,
-      this._optionSelected
-    );
-    this._slot.removeEventListener(
-      PfeAutocomplete.events.slotchange,
-      this._slotchangeHandler
-    );
+    this.removeEventListener(PfeAutocomplete.events.search, this._closeDroplist);
+    this.removeEventListener(PfeAutocomplete.events.select, this._optionSelected);
+    this._slot.removeEventListener(PfeAutocomplete.events.slotchange, this._slotchangeHandler);
     if (this._input) {
       this._input.removeEventListener("input", this._inputChanged);
       this._input.removeEventListener("blur", this._closeDroplist);
@@ -212,9 +193,7 @@ class PfeAutocomplete extends PFElement {
     let slotElems = slotNodes.filter(n => n.nodeType === Node.ELEMENT_NODE);
 
     if (slotElems.length === 0) {
-      console.error(
-        `${PfeAutocomplete.tag}: There must be a input tag in the light DOM`
-      );
+      console.error(`${PfeAutocomplete.tag}: There must be a input tag in the light DOM`);
 
       return;
     }
@@ -222,9 +201,7 @@ class PfeAutocomplete extends PFElement {
     this._input = slotElems[0];
 
     if (this._input.tagName.toLowerCase() !== "input") {
-      console.error(
-        `${PfeAutocomplete.tag}: The only child in the light DOM must be an input tag`
-      );
+      console.error(`${PfeAutocomplete.tag}: The only child in the light DOM must be an input tag`);
 
       return;
     }
@@ -246,8 +223,7 @@ class PfeAutocomplete extends PFElement {
     this._input.setAttribute("autocapitalize", "off");
     this._input.setAttribute("spellcheck", "false");
 
-    this._dropdown._ariaAnnounceTemplate =
-      this.getAttribute("aria-announce-template") || this._ariaAnnounceTemplate;
+    this._dropdown._ariaAnnounceTemplate = this.getAttribute("aria-announce-template") || this._ariaAnnounceTemplate;
   }
 
   _inputChanged() {
@@ -321,10 +297,7 @@ class PfeAutocomplete extends PFElement {
   _sendAutocompleteRequest(input) {
     if (!this.autocompleteRequest) return;
 
-    this.autocompleteRequest(
-      { query: input },
-      this._autocompleteCallback.bind(this)
-    );
+    this.autocompleteRequest({ query: input }, this._autocompleteCallback.bind(this));
   }
 
   _autocompleteCallback(response) {
@@ -342,9 +315,7 @@ class PfeAutocomplete extends PFElement {
 
   _activeOption(activeIndex) {
     if (activeIndex === null || activeIndex === "null") return;
-    return this._dropdown.shadowRoot.querySelector(
-      "li:nth-child(" + (parseInt(activeIndex, 10) + 1) + ")"
-    ).innerHTML;
+    return this._dropdown.shadowRoot.querySelector("li:nth-child(" + (parseInt(activeIndex, 10) + 1) + ")").innerHTML;
   }
 
   _inputKeyUp(e) {
@@ -369,10 +340,7 @@ class PfeAutocomplete extends PFElement {
         return;
       }
 
-      activeIndex =
-        activeIndex === null || activeIndex === "null"
-          ? optionsLength
-          : parseInt(activeIndex, 10);
+      activeIndex = activeIndex === null || activeIndex === "null" ? optionsLength : parseInt(activeIndex, 10);
 
       activeIndex -= 1;
 
@@ -386,10 +354,7 @@ class PfeAutocomplete extends PFElement {
         return;
       }
 
-      activeIndex =
-        activeIndex === null || activeIndex === "null"
-          ? -1
-          : parseInt(activeIndex, 10);
+      activeIndex = activeIndex === null || activeIndex === "null" ? -1 : parseInt(activeIndex, 10);
       activeIndex += 1;
 
       if (activeIndex > optionsLength - 1) {
@@ -413,10 +378,7 @@ class PfeAutocomplete extends PFElement {
     }
 
     if (activeIndex !== null && activeIndex !== "null") {
-      this._input.setAttribute(
-        "aria-activedescendant",
-        "option-" + activeIndex
-      );
+      this._input.setAttribute("aria-activedescendant", "option-" + activeIndex);
     } else {
       this._input.setAttribute("aria-activedescendant", "");
     }
@@ -456,9 +418,7 @@ class PfeSearchDroplist extends PFElement {
   connectedCallback() {
     super.connectedCallback();
 
-    this._ariaAnnounce = this.shadowRoot.querySelector(
-      ".suggestions-aria-help"
-    );
+    this._ariaAnnounce = this.shadowRoot.querySelector(".suggestions-aria-help");
 
     this.activeIndex = null;
     this._ul = this.shadowRoot.querySelector("ul");
@@ -485,10 +445,7 @@ class PfeSearchDroplist extends PFElement {
     let ariaAnnounceText = "";
 
     if (this._ariaAnnounceTemplate) {
-      ariaAnnounceText = this._ariaAnnounceTemplate.replace(
-        "${numOptions}",
-        options.length
-      );
+      ariaAnnounceText = this._ariaAnnounceTemplate.replace("${numOptions}", options.length);
     }
 
     this._ariaAnnounce.textContent = ariaAnnounceText;
@@ -522,13 +479,7 @@ class PfeSearchDroplist extends PFElement {
   }
 
   _activeIndexChanged() {
-    if (
-      !this.data ||
-      this.data.length === 0 ||
-      this.activeIndex === null ||
-      this.activeIndex === "null"
-    )
-      return;
+    if (!this.data || this.data.length === 0 || this.activeIndex === null || this.activeIndex === "null") return;
 
     // remove active class
     if (this._ul.querySelector(".active")) {
@@ -536,21 +487,15 @@ class PfeSearchDroplist extends PFElement {
     }
 
     // add active class to selected option
-    let activeOption = this._ul.querySelector(
-      "li:nth-child(" + (parseInt(this.activeIndex, 10) + 1) + ")"
-    );
+    let activeOption = this._ul.querySelector("li:nth-child(" + (parseInt(this.activeIndex, 10) + 1) + ")");
 
     activeOption.classList.add("active");
 
     // scroll to selected element when selected item with keyboard is out of view
     let ulWrapper = this.shadowRoot.querySelector(".droplist");
     let activeOptionHeight = activeOption.offsetHeight;
-    activeOptionHeight += parseInt(
-      window.getComputedStyle(activeOption).getPropertyValue("margin-bottom"),
-      10
-    );
-    ulWrapper.scrollTop =
-      activeOption.offsetTop - ulWrapper.offsetHeight + activeOptionHeight;
+    activeOptionHeight += parseInt(window.getComputedStyle(activeOption).getPropertyValue("margin-bottom"), 10);
+    ulWrapper.scrollTop = activeOption.offsetTop - ulWrapper.offsetHeight + activeOptionHeight;
   }
 
   get open() {

--- a/elements/pfe-avatar/demo/pfe-avatar.story.js
+++ b/elements/pfe-avatar/demo/pfe-avatar.story.js
@@ -1,10 +1,5 @@
 import { storiesOf } from "@storybook/polymer";
-import {
-  withKnobs,
-  text,
-  select,
-  boolean
-} from "@storybook/addon-knobs/polymer";
+import { withKnobs, text, select, boolean } from "@storybook/addon-knobs/polymer";
 import "../dist/pfe-avatar";
 import { escapeHTML } from "../../../.storybook/utils.js";
 
@@ -95,9 +90,9 @@ stories.add("pfe-avatar", () => {
                 pfe-shape="${ex.shape}"
                 pfe-name="${ex.name}">
               </pfe-avatar>
-              <p>Avatar for "${ex.name}" with ${
-            ex.src ? `a user-selected image` : `patterned ${ex.pattern}`
-          }, ${ex.shape} shape.</p>
+              <p>Avatar for "${ex.name}" with ${ex.src ? `a user-selected image` : `patterned ${ex.pattern}`}, ${
+            ex.shape
+          } shape.</p>
             </pfe-card>
           `
         )

--- a/elements/pfe-avatar/src/pfe-avatar.js
+++ b/elements/pfe-avatar/src/pfe-avatar.js
@@ -62,11 +62,7 @@ class PfeAvatar extends PFElement {
 
   set pattern(name) {
     if (!PfeAvatar.patterns[name]) {
-      this.log(
-        `invalid pattern "${name}", valid patterns are: ${Object.values(
-          PfeAvatar.patterns
-        )}`
-      );
+      this.log(`invalid pattern "${name}", valid patterns are: ${Object.values(PfeAvatar.patterns)}`);
       return;
     }
     return this.setAttribute("pfe-pattern", name);
@@ -98,9 +94,7 @@ class PfeAvatar extends PFElement {
 
   _initCanvas() {
     this._canvas = this.shadowRoot.querySelector("canvas");
-    const size =
-      this.var("--pfe-avatar--width").replace(/px$/, "") ||
-      PfeAvatar.defaultSize;
+    const size = this.var("--pfe-avatar--width").replace(/px$/, "") || PfeAvatar.defaultSize;
     this._canvas.width = size;
     this._canvas.height = size;
 
@@ -128,9 +122,7 @@ class PfeAvatar extends PFElement {
           }
           break;
         case 7: // ex: "#00ffcc"
-          pattern = /^#([A-f0-9]{2})([A-f0-9]{2})([A-f0-9]{2})$/.exec(
-            colorCode
-          );
+          pattern = /^#([A-f0-9]{2})([A-f0-9]{2})([A-f0-9]{2})$/.exec(colorCode);
           if (pattern) {
             pattern.shift();
             const color = pattern.map(c => parseInt(c, 16));
@@ -170,9 +162,7 @@ class PfeAvatar extends PFElement {
     } else {
       const bitPattern = hash(this.name).toString(2);
       const arrPattern = bitPattern.split("").map(n => Number(n));
-      this._colorIndex = Math.floor(
-        (PfeAvatar.colors.length * parseInt(bitPattern, 2)) / Math.pow(2, 32)
-      );
+      this._colorIndex = Math.floor((PfeAvatar.colors.length * parseInt(bitPattern, 2)) / Math.pow(2, 32));
       this.color1 = PfeAvatar.colors[this._colorIndex].color1;
       this.color2 = PfeAvatar.colors[this._colorIndex].color2;
 
@@ -219,12 +209,7 @@ class PfeAvatar extends PFElement {
   }
 
   _drawSquare(x, y) {
-    this._ctx.fillRect(
-      this._squareSize * x,
-      this._squareSize * y,
-      this._squareSize,
-      this._squareSize
-    );
+    this._ctx.fillRect(this._squareSize * x, this._squareSize * y, this._squareSize, this._squareSize);
   }
 
   _drawTrianglePattern(pattern) {
@@ -277,11 +262,7 @@ class PfeAvatar extends PFElement {
   _drawMirroredTriangle(p1, p2, p3) {
     if (this._ctx) {
       this._drawTriangle(p1, p2, p3);
-      this._drawTriangle(
-        [4 - p1[0], p1[1]],
-        [4 - p2[0], p2[1]],
-        [4 - p3[0], p3[1]]
-      );
+      this._drawTriangle([4 - p1[0], p1[1]], [4 - p2[0], p2[1]], [4 - p3[0], p3[1]]);
     }
   }
 
@@ -296,12 +277,7 @@ class PfeAvatar extends PFElement {
   }
 
   _drawGradient() {
-    const gradient = this._ctx.createLinearGradient(
-      0,
-      this._canvas.height,
-      this._canvas.width,
-      0
-    );
+    const gradient = this._ctx.createLinearGradient(0, this._canvas.height, this._canvas.width, 0);
     const color = this.color2;
     let gradientColor1 = color;
     let gradientColor2 = color;

--- a/elements/pfe-badge/demo/pfe-badge.story.js
+++ b/elements/pfe-badge/demo/pfe-badge.story.js
@@ -23,10 +23,7 @@ stories.add(PfeBadge.tag, () => {
     PfeBadge.properties.state.enum,
     PfeBadge.properties.state.default
   );
-  const threshold = storybookBridge.number(
-    PfeBadge.properties["pfe-threshold"].title,
-    100
-  );
+  const threshold = storybookBridge.number(PfeBadge.properties["pfe-threshold"].title, 100);
 
   const staticNumberExamples = [
     {

--- a/elements/pfe-badge/src/pfe-badge.js
+++ b/elements/pfe-badge/src/pfe-badge.js
@@ -33,16 +33,10 @@ class PfeBadge extends PFElement {
   attributeChangedCallback(attr, oldVal, newVal) {
     switch (attr) {
       case "pfe-threshold":
-        this.textContent =
-          Number(this.threshold) < Number(this.textContent)
-            ? `${this.threshold}+`
-            : this.textContent;
+        this.textContent = Number(this.threshold) < Number(this.textContent) ? `${this.threshold}+` : this.textContent;
         break;
       case "number":
-        this.textContent =
-          this.threshold && Number(this.threshold) < Number(newVal)
-            ? `${this.threshold}+`
-            : newVal;
+        this.textContent = this.threshold && Number(this.threshold) < Number(newVal) ? `${this.threshold}+` : newVal;
         break;
       default:
         return;

--- a/elements/pfe-badge/src/pfe-badge.json
+++ b/elements/pfe-badge/src/pfe-badge.json
@@ -20,14 +20,7 @@
         "state": {
           "title": "Background color",
           "type": "string",
-          "enum": [
-            "default",
-            "moderate",
-            "important",
-            "critical",
-            "success",
-            "info"
-          ],
+          "enum": ["default", "moderate", "important", "critical", "success", "info"],
           "default": "default",
           "prefixed": true
         },

--- a/elements/pfe-band/demo/pfe-band.story.js
+++ b/elements/pfe-band/demo/pfe-band.story.js
@@ -23,8 +23,7 @@ stories.addParameters({
 });
 
 // Define the templates to be used
-const template = (data = {}) =>
-  tools.component(PfeBand.tag, data.prop, data.slots);
+const template = (data = {}) => tools.component(PfeBand.tag, data.prop, data.slots);
 
 // prettier-ignore
 const defaultContent = {
@@ -92,21 +91,13 @@ stories.add(PfeBand.tag, () => {
   const slots = PfeBand.slots;
 
   // Ask user if they want to add any custom content
-  const customContent = storybookBridge.boolean(
-    "Use custom content?",
-    false,
-    "Content"
-  );
+  const customContent = storybookBridge.boolean("Use custom content?", false, "Content");
 
   // -- Attach the default content for that region
   ["header", "body", "aside", "footer"].forEach(region => {
     slots[region].default = defaultContent[region];
     if (customContent) {
-      slots[region].value = storybookBridge.text(
-        `${region.replace(/^\w/, c => c.toUpperCase())}`,
-        "",
-        `${region}`
-      );
+      slots[region].value = storybookBridge.text(`${region.replace(/^\w/, c => c.toUpperCase())}`, "", `${region}`);
     }
   });
 

--- a/elements/pfe-band/src/pfe-band.js
+++ b/elements/pfe-band/src/pfe-band.js
@@ -37,13 +37,7 @@ class PfeBand extends PFElement {
   }
 
   static get observedAttributes() {
-    return [
-      "pfe-aside-desktop",
-      "pfe-aside-mobile",
-      "pfe-aside-height",
-      "pfe-color",
-      "pfe-img-src"
-    ];
+    return ["pfe-aside-desktop", "pfe-aside-mobile", "pfe-aside-height", "pfe-color", "pfe-img-src"];
   }
 
   static get cascadingAttributes() {

--- a/elements/pfe-band/src/pfe-band.json
+++ b/elements/pfe-band/src/pfe-band.json
@@ -82,14 +82,7 @@
         "color": {
           "title": "Background color",
           "type": "string",
-          "enum": [
-            "lightest",
-            "base",
-            "darker",
-            "darkest",
-            "complement",
-            "accent"
-          ],
+          "enum": ["lightest", "base", "darker", "darkest", "complement", "accent"],
           "default": "base",
           "prefixed": true,
           "observer": "_colorChanged"

--- a/elements/pfe-band/src/polyfills--pfe-band.js
+++ b/elements/pfe-band/src/polyfills--pfe-band.js
@@ -1,9 +1,7 @@
 // @POLYFILL  Element.matches
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
 if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector;
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 }
 
 // @POLYFILL  Element.closest
@@ -51,13 +49,7 @@ if (!Array.prototype.includes) {
       var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
 
       function sameValueZero(x, y) {
-        return (
-          x === y ||
-          (typeof x === "number" &&
-            typeof y === "number" &&
-            isNaN(x) &&
-            isNaN(y))
-        );
+        return x === y || (typeof x === "number" && typeof y === "number" && isNaN(x) && isNaN(y));
       }
 
       // 7. Repeat, while k < len

--- a/elements/pfe-button/src/pfe-button.js
+++ b/elements/pfe-button/src/pfe-button.js
@@ -84,10 +84,7 @@ class PfeButton extends PFElement {
     this._observer.observe(this, parentObserverConfig);
 
     if (this._externalBtn) {
-      this._externalBtnObserver.observe(
-        this._externalBtn,
-        externalBtnObserverConfig
-      );
+      this._externalBtnObserver.observe(this._externalBtn, externalBtnObserverConfig);
     }
   }
 
@@ -140,10 +137,7 @@ class PfeButton extends PFElement {
     });
 
     this._internalBtnContainer.innerHTML = clone.outerHTML;
-    this._externalBtnObserver.observe(
-      this._externalBtn,
-      externalBtnObserverConfig
-    );
+    this._externalBtnObserver.observe(this._externalBtn, externalBtnObserverConfig);
 
     this._externalBtn.addEventListener("click", this._externalBtnClickHandler);
   }
@@ -155,9 +149,7 @@ class PfeButton extends PFElement {
     }
 
     if (this.children[0].tagName !== "BUTTON") {
-      console.warn(
-        `${PfeButton.tag}: The only child in the light DOM must be a button tag`
-      );
+      console.warn(`${PfeButton.tag}: The only child in the light DOM must be a button tag`);
 
       return false;
     }

--- a/elements/pfe-card/demo/pfe-card.story.js
+++ b/elements/pfe-card/demo/pfe-card.story.js
@@ -58,11 +58,7 @@ stories.add(PfeCard.tag, () => {
   slots.body.default = defaultBody;
 
   // Manually ask user if they want an image included
-  const imageValue = storybookBridge.boolean(
-    "Include a sample image?",
-    true,
-    "Image"
-  );
+  const imageValue = storybookBridge.boolean("Include a sample image?", true, "Image");
 
   let overflowAttr = [];
   let image = "";
@@ -102,9 +98,7 @@ stories.add(PfeCard.tag, () => {
     }
 
     image = `<img src=\"https://placekitten.com/1000/300\" ${
-      overflowAttr.length > 0
-        ? `pfe-overflow=\"${overflowAttr.join(" ")}\"`
-        : ""
+      overflowAttr.length > 0 ? `pfe-overflow=\"${overflowAttr.join(" ")}\"` : ""
     }/>`;
   }
 
@@ -116,11 +110,7 @@ stories.add(PfeCard.tag, () => {
     let ctaLink;
 
     // Manually ask user if they want a CTA included
-    const ctaValue = storybookBridge.boolean(
-      "Include a call-to-action?",
-      true,
-      "Call-to-action"
-    );
+    const ctaValue = storybookBridge.boolean("Include a call-to-action?", true, "Call-to-action");
 
     // If they do, prompt them for the cta text and style
     if (ctaValue) {

--- a/elements/pfe-card/src/pfe-card.json
+++ b/elements/pfe-card/src/pfe-card.json
@@ -66,14 +66,7 @@
         "color": {
           "title": "Background color",
           "type": "string",
-          "enum": [
-            "lightest",
-            "base",
-            "darker",
-            "darkest",
-            "complement",
-            "accent"
-          ],
+          "enum": ["lightest", "base", "darker", "darkest", "complement", "accent"],
           "default": "base",
           "prefixed": true,
           "observer": "_colorChanged"

--- a/elements/pfe-card/src/polyfills--pfe-card.js
+++ b/elements/pfe-card/src/polyfills--pfe-card.js
@@ -1,9 +1,7 @@
 // @POLYFILL  Element.matches
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
 if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector;
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 }
 
 // @POLYFILL  Element.closest
@@ -51,13 +49,7 @@ if (!Array.prototype.includes) {
       var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
 
       function sameValueZero(x, y) {
-        return (
-          x === y ||
-          (typeof x === "number" &&
-            typeof y === "number" &&
-            isNaN(x) &&
-            isNaN(y))
-        );
+        return x === y || (typeof x === "number" && typeof y === "number" && isNaN(x) && isNaN(y));
       }
 
       // 7. Repeat, while k < len

--- a/elements/pfe-collapse/src/pfe-collapse.js
+++ b/elements/pfe-collapse/src/pfe-collapse.js
@@ -130,9 +130,7 @@ class PfeCollapseToggle extends PFElement {
         }
       });
     } else {
-      console.warn(
-        `${this.tag}: This toggle doesn't have a panel associated with it`
-      );
+      console.warn(`${this.tag}: This toggle doesn't have a panel associated with it`);
     }
   }
 
@@ -268,10 +266,7 @@ class PfeCollapsePanel extends PFElement {
   _transitionEndHandler(event) {
     event.target.style.height = "";
     event.target.classList.remove("animating");
-    event.target.removeEventListener(
-      "transitionend",
-      this._transitionEndHandler
-    );
+    event.target.removeEventListener("transitionend", this._transitionEndHandler);
 
     this.emitEvent(PfeCollapsePanel.events.animationEnd, {
       detail: {
@@ -332,14 +327,8 @@ class PfeCollapse extends PFElement {
     this._observer = new MutationObserver(this._linkControls);
 
     this.addEventListener(PfeCollapse.events.change, this._changeHandler);
-    this.addEventListener(
-      PfeCollapse.events.animationStart,
-      this._animationStartHandler
-    );
-    this.addEventListener(
-      PfeCollapse.events.animationEnd,
-      this._animationEndHandler
-    );
+    this.addEventListener(PfeCollapse.events.animationStart, this._animationStartHandler);
+    this.addEventListener(PfeCollapse.events.animationEnd, this._animationEndHandler);
   }
 
   connectedCallback() {
@@ -359,14 +348,8 @@ class PfeCollapse extends PFElement {
 
   disconnectedCallback() {
     this.removeEventListener(PfeCollapse.events.change, this._changeHandler);
-    this.removeEventListener(
-      PfeCollapse.events.animationStart,
-      this._animationStartHandler
-    );
-    this.removeEventListener(
-      PfeCollapse.events.animationEnd,
-      this._animationEndHandler
-    );
+    this.removeEventListener(PfeCollapse.events.animationStart, this._animationStartHandler);
+    this.removeEventListener(PfeCollapse.events.animationEnd, this._animationEndHandler);
     this._observer.disconnect();
   }
 

--- a/elements/pfe-content-set/demo/pfe-content-set.story.js
+++ b/elements/pfe-content-set/demo/pfe-content-set.story.js
@@ -51,11 +51,7 @@ stories.add(PfeContentSet.tag, () => {
   });
 
   // Ask user if they want to add any custom content
-  const customContent = storybookBridge.boolean(
-    "Use custom content?",
-    false,
-    "Content"
-  );
+  const customContent = storybookBridge.boolean("Use custom content?", false, "Content");
 
   // Let the user customize the first header + panel set
   if (customContent) {
@@ -73,9 +69,7 @@ stories.add(PfeContentSet.tag, () => {
         attributes: {
           "pfe-content-set--header": true
         },
-        content: customContent
-          ? headings[i]
-          : tools.autoHeading(true).replace(/^\w/, c => c.toUpperCase())
+        content: customContent ? headings[i] : tools.autoHeading(true).replace(/^\w/, c => c.toUpperCase())
       }) +
       tools.customTag({
         tag: "div",

--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -41,9 +41,7 @@ class PfeContentSet extends PFElement {
     } else {
       breakpointValue = 700;
     }
-    return this.parentNode
-      ? this.parentNode.offsetWidth > breakpointValue
-      : window.outerWidth > breakpointValue;
+    return this.parentNode ? this.parentNode.offsetWidth > breakpointValue : window.outerWidth > breakpointValue;
   }
 
   get contentSetId() {
@@ -96,9 +94,7 @@ class PfeContentSet extends PFElement {
     let accordion;
 
     // Use the existing accordion if it exists
-    const existingAccordion = this.querySelector(
-      `[pfe-id="${this.contentSetId}"]`
-    );
+    const existingAccordion = this.querySelector(`[pfe-id="${this.contentSetId}"]`);
 
     // Use a document fragment for efficiency
     const fragment = document.createDocumentFragment();

--- a/elements/pfe-cta/demo/pfe-cta.story.js
+++ b/elements/pfe-cta/demo/pfe-cta.story.js
@@ -46,12 +46,7 @@ stories.add(PfeCta.tag, () => {
   // Rerender select boxes
   config.prop = tools.autoPropKnobs(props, storybookBridge);
 
-  if (
-    !(
-      config.prop["pfe-priority"] === "secondary" &&
-      config.prop["pfe-variant"] === "wind"
-    )
-  ) {
+  if (!(config.prop["pfe-priority"] === "secondary" && config.prop["pfe-variant"] === "wind")) {
     // Add back colors
     props.color = color;
   }

--- a/elements/pfe-cta/src/pfe-cta.js
+++ b/elements/pfe-cta/src/pfe-cta.js
@@ -118,9 +118,7 @@ class PfeCta extends PFElement {
       this.props.priority.value === null &&
       this.getAttribute("aria-disabled") !== "true"
     ) {
-      console.warn(
-        `${PfeCta.tag}: Button tag is not supported semantically by the default link styles`
-      );
+      console.warn(`${PfeCta.tag}: Button tag is not supported semantically by the default link styles`);
     } else {
       // Capture the first child as the CTA element
       this.cta = this.firstElementChild;
@@ -133,9 +131,7 @@ class PfeCta extends PFElement {
       };
 
       // Set the value for the priority property
-      this.props.priority.value = this.isDefault
-        ? "default"
-        : this.getAttribute("pfe-priority");
+      this.props.priority.value = this.isDefault ? "default" : this.getAttribute("pfe-priority");
 
       // Add the priority value to the data set for the event
       this.data.type = this.props.priority.value;

--- a/elements/pfe-datetime/demo/pfe-datetime.story.js
+++ b/elements/pfe-datetime/demo/pfe-datetime.story.js
@@ -112,26 +112,14 @@ storiesOf("Datetime", module).add("Demo", () => {
   const now = new Date();
   let realtime = now;
 
-  const yearsago = new Date(
-    new Date().setFullYear(new Date().getFullYear() - 10)
-  );
-  const yearago = new Date(
-    new Date().setFullYear(new Date().getFullYear() - 1)
-  );
+  const yearsago = new Date(new Date().setFullYear(new Date().getFullYear() - 10));
+  const yearago = new Date(new Date().setFullYear(new Date().getFullYear() - 1));
   const hoursago = new Date(new Date().setHours(new Date().getHours() - 2));
-  const minutesago = new Date(
-    new Date().setMinutes(new Date().getMinutes() - 10)
-  );
-  const minutesuntil = new Date(
-    new Date().setMinutes(new Date().getMinutes() + 22)
-  );
+  const minutesago = new Date(new Date().setMinutes(new Date().getMinutes() - 10));
+  const minutesuntil = new Date(new Date().setMinutes(new Date().getMinutes() + 22));
   const hoursuntil = new Date(new Date().setHours(new Date().getHours() + 13));
-  const yearuntil = new Date(
-    new Date().setFullYear(new Date().getFullYear() + 1)
-  );
-  const yearsuntil = new Date(
-    new Date().setFullYear(new Date().getFullYear() + 10)
-  );
+  const yearuntil = new Date(new Date().setFullYear(new Date().getFullYear() + 1));
+  const yearsuntil = new Date(new Date().setFullYear(new Date().getFullYear() + 10));
 
   function timer() {
     document.getElementById("realtime").setAttribute("datetime", new Date());

--- a/elements/pfe-datetime/src/pfe-datetime.js
+++ b/elements/pfe-datetime/src/pfe-datetime.js
@@ -70,9 +70,7 @@ class PfeDatetime extends PFElement {
 
   setDate(date) {
     this._datetime = date;
-    this.shadowRoot.querySelector("span").innerText = window.Intl
-      ? this._getTypeString()
-      : date.toLocaleString();
+    this.shadowRoot.querySelector("span").innerText = window.Intl ? this._getTypeString() : date.toLocaleString();
   }
 
   _getOptions() {

--- a/elements/pfe-dropdown/src/pfe-dropdown.js
+++ b/elements/pfe-dropdown/src/pfe-dropdown.js
@@ -17,9 +17,7 @@ if (!Element.prototype.closest) {
 // @POLYFILL  Element.matches
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
 if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector;
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 }
 
 const KEYCODE = {
@@ -94,12 +92,11 @@ class PfeDropdown extends PFElement {
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener("click", this._outsideClickHandler);
-    Promise.all([
-      customElements.whenDefined(PfeDropdown.tag),
-      customElements.whenDefined(PfeDropdownItem.tag)
-    ]).then(() => {
-      this._init();
-    });
+    Promise.all([customElements.whenDefined(PfeDropdown.tag), customElements.whenDefined(PfeDropdownItem.tag)]).then(
+      () => {
+        this._init();
+      }
+    );
   }
 
   disconnectedCallback() {
@@ -161,9 +158,7 @@ class PfeDropdown extends PFElement {
       pfeType = event.target.attributes["pfe-item-type"].value;
     }
     // active dropdown item index
-    const currentIndex = this._allItems().findIndex(
-      item => item === document.activeElement
-    );
+    const currentIndex = this._allItems().findIndex(item => item === document.activeElement);
     switch (event.keyCode) {
       case KEYCODE.ENTER:
         this._selectItem(event.target.children[0], pfeType);
@@ -207,9 +202,7 @@ class PfeDropdown extends PFElement {
     // Check if the clicked element contains or is contained by the dropdown element
     let isChild = event.target.closest("pfe-dropdown");
     let insideWrapper =
-      event.target.tagName.indexOf("-") > -1
-        ? event.target.shadowRoot.querySelector("pfe-dropdown")
-        : null;
+      event.target.tagName.indexOf("-") > -1 ? event.target.shadowRoot.querySelector("pfe-dropdown") : null;
     // Check states to determine if the dropdown menu should close
     if (!isSelf && !(isChild || insideWrapper)) {
       this.close();
@@ -282,18 +275,11 @@ class PfeDropdown extends PFElement {
   }
 
   _allItems() {
-    return [
-      ...this.querySelectorAll(
-        `${this.tag}-item:not([pfe-item-type='separator'])`
-      )
-    ];
+    return [...this.querySelectorAll(`${this.tag}-item:not([pfe-item-type='separator'])`)];
   }
 
   _allDisabled() {
-    return (
-      this._allItems().find(item => !item.hasAttribute("is_disabled")) ===
-      undefined
-    );
+    return this._allItems().find(item => !item.hasAttribute("is_disabled")) === undefined;
   }
 
   _nextItem(currentPosition, direction) {

--- a/elements/pfe-health-index/src/pfe-health-index.js
+++ b/elements/pfe-health-index/src/pfe-health-index.js
@@ -64,15 +64,11 @@ class PfeHealthIndex extends PFElement {
     });
 
     if (this.props.size.value !== "lg") {
-      this.shadowRoot.querySelector(
-        "#healthIndex"
-      ).innerText = healthIndexUpperCase;
+      this.shadowRoot.querySelector("#healthIndex").innerText = healthIndexUpperCase;
     }
 
     if (!this.shadowRoot.querySelector(".box.active")) {
-      console.warn(
-        `${PfeHealthIndex.tag}: a valid health-index was not provided. Please use A, B, C, D, E, or F`
-      );
+      console.warn(`${PfeHealthIndex.tag}: a valid health-index was not provided. Please use A, B, C, D, E, or F`);
     }
   }
 }

--- a/elements/pfe-icon-panel/demo/pfe-icon-panel.story.js
+++ b/elements/pfe-icon-panel/demo/pfe-icon-panel.story.js
@@ -21,8 +21,7 @@ stories.addDecorator(withKnobs);
 // Log events
 stories.addDecorator(withActions("pfe-icon:add-icon-set"));
 
-const template = (data = {}) =>
-  tools.component(PfeIconPanel.tag, data.prop, data.slots, true);
+const template = (data = {}) => tools.component(PfeIconPanel.tag, data.prop, data.slots, true);
 
 const defaultHeading = tools.autoHeading(true);
 const defaultBody = tools.autoContent(1, 1);
@@ -44,11 +43,7 @@ stories.add("pfe-icon-panel", () => {
   config.prop = tools.autoPropKnobs(props, storybookBridge);
 
   if (config.prop["pfe-stacked"] === true) {
-    config.prop["pfe-centered"] = storybookBridge.boolean(
-      "Centered",
-      false,
-      "Attributes"
-    );
+    config.prop["pfe-centered"] = storybookBridge.boolean("Centered", false, "Attributes");
   }
 
   // const slots = PfeIconPanel.slots;

--- a/elements/pfe-icon/demo/icon-sets.js
+++ b/elements/pfe-icon/demo/icon-sets.js
@@ -25,9 +25,7 @@ function printIcons(setName, colors, subset, size, circled) {
   var fragment = document.createDocumentFragment();
   icons[setName].map(function(iconName, itr, arr) {
     if ((subset > 0 && itr < subset) || subset == 0) {
-      fragment.appendChild(
-        createIcon(iconName, getColor(itr, colors), size, circled)
-      );
+      fragment.appendChild(createIcon(iconName, getColor(itr, colors), size, circled));
     }
   });
   return fragment;

--- a/elements/pfe-icon/demo/pfe-icon.story.js
+++ b/elements/pfe-icon/demo/pfe-icon.story.js
@@ -21,8 +21,7 @@ stories.addDecorator(withKnobs);
 // Log events
 stories.addDecorator(withActions("pfe-icon:add-icon-set"));
 
-const template = (data = {}) =>
-  tools.component(PfeIcon.tag, data.prop, [], true);
+const template = (data = {}) => tools.component(PfeIcon.tag, data.prop, [], true);
 
 stories.add(PfeIcon.tag, () => {
   let config = {};

--- a/elements/pfe-icon/src/pfe-icon.js
+++ b/elements/pfe-icon/src/pfe-icon.js
@@ -84,9 +84,7 @@ class PfeIcon extends PFElement {
 
     // Attach a listener for the registration of an icon set
     // Leaving this attached allows for the registered set to be updated
-    document.body.addEventListener(PfeIcon.EVENTS.ADD_ICON_SET, () =>
-      this.updateIcon()
-    );
+    document.body.addEventListener(PfeIcon.EVENTS.ADD_ICON_SET, () => this.updateIcon());
   }
 
   disconnectedCallback() {
@@ -139,17 +137,12 @@ class PfeIcon extends PFElement {
       typeof this._iconSets[name]._resolveIconName === "function"
     ) {
       resolveFunction = this._iconSets[name]._resolveIconName;
-    } else if (
-      typeof resolveIconName !== "function" &&
-      typeof resolveIconName !== "undefined"
-    ) {
+    } else if (typeof resolveIconName !== "function" && typeof resolveIconName !== "undefined") {
       console.warn(
         `${this.tag}: The third input to addIconSet should be a function that parses and returns the icon's filename.`
       );
     } else {
-      console.warn(
-        `${this.tag}: The set ${name} needs a resolve function for the icon names.`
-      );
+      console.warn(`${this.tag}: The set ${name} needs a resolve function for the icon names.`);
     }
 
     // Register the icon set and set up the event indicating the change

--- a/elements/pfe-jump-links/src/pfe-jump-links.js
+++ b/elements/pfe-jump-links/src/pfe-jump-links.js
@@ -88,9 +88,7 @@ class PfeJumpLinksNav extends PFElement {
 
         let div = document.createElement("div");
 
-        div.innerHTML = `<h2 class="sr-only" hidden>${this.getAttribute(
-          "sr-text"
-        )}</h2>`;
+        div.innerHTML = `<h2 class="sr-only" hidden>${this.getAttribute("sr-text")}</h2>`;
 
         if (this.getAttribute("sr-text")) {
           this.shadowRoot.querySelector("nav").prepend(div);
@@ -98,24 +96,16 @@ class PfeJumpLinksNav extends PFElement {
 
         let html = "";
         if (this.querySelector("[slot='pfe-jump-links-nav--heading']")) {
-          html = this.querySelector(
-            "[slot='pfe-jump-links-nav--heading']"
-          ).cloneNode(true);
+          html = this.querySelector("[slot='pfe-jump-links-nav--heading']").cloneNode(true);
         }
         if (!this.hasAttribute("pfe-c-horizontal") && html !== "") {
-          this.shadowRoot
-            .querySelector("pfe-accordion-header")
-            .appendChild(html);
+          this.shadowRoot.querySelector("pfe-accordion-header").appendChild(html);
         } else {
           const heading = document.createElement("h3");
           heading.id = "pfe-jump-links-nav--heading";
 
-          this.shadowRoot
-            .querySelector("pfe-accordion-header")
-            .appendChild(heading);
-          this.shadowRoot.querySelector(
-            "#pfe-jump-links-nav--heading"
-          ).innerHTML = "Jump to section";
+          this.shadowRoot.querySelector("pfe-accordion-header").appendChild(heading);
+          this.shadowRoot.querySelector("#pfe-jump-links-nav--heading").innerHTML = "Jump to section";
         }
       }
     }
@@ -125,18 +115,12 @@ class PfeJumpLinksNav extends PFElement {
 
     this.panel = document.querySelector(`[pfe-c-scrolltarget="${this.id}"]`);
 
-    this.panel.addEventListener(
-      PfeJumpLinksPanel.events.change,
-      this._buildNav
-    );
+    this.panel.addEventListener(PfeJumpLinksPanel.events.change, this._buildNav);
   }
 
   disconnectedCallback() {
     this._observer.disconnect();
-    this.panel.removeEventListener(
-      PfeJumpLinksPanel.events.change,
-      this._buildNav
-    );
+    this.panel.removeEventListener(PfeJumpLinksPanel.events.change, this._buildNav);
     this.removeEventListener("click");
   }
 
@@ -148,13 +132,9 @@ class PfeJumpLinksNav extends PFElement {
     const buildLinkList = () => {
       let linkList = ``;
       if (!this.panel) {
-        this.panel = document.querySelector(
-          `[pfe-c-scrolltarget="${this.id}"]`
-        );
+        this.panel = document.querySelector(`[pfe-c-scrolltarget="${this.id}"]`);
       }
-      let panelSections = this.panel.querySelectorAll(
-        ".pfe-jump-links-panel__section"
-      );
+      let panelSections = this.panel.querySelectorAll(".pfe-jump-links-panel__section");
 
       for (let i = 0; i < panelSections.length; i++) {
         let arr = [...panelSections];
@@ -230,24 +210,15 @@ class PfeJumpLinksNav extends PFElement {
 
   _isValidLightDom() {
     if (!this.children.length) {
-      console.warn(
-        `${PfeJumpLinks.tag}: You must have a <ul> tag in the light DOM`
-      );
+      console.warn(`${PfeJumpLinks.tag}: You must have a <ul> tag in the light DOM`);
       return false;
     }
-    if (
-      (this.has_slot("logo") || this.has_slot("link")) &&
-      !this.hasAttribute("pfe-c-horizontal")
-    ) {
-      console.warn(
-        `${PfeJumpLinks.tag}: logo and link slots NOT supported in vertical jump links`
-      );
+    if ((this.has_slot("logo") || this.has_slot("link")) && !this.hasAttribute("pfe-c-horizontal")) {
+      console.warn(`${PfeJumpLinks.tag}: logo and link slots NOT supported in vertical jump links`);
     }
     if (this.children[1].tagName !== "UL") {
       if (!this.hasAttribute("pfe-c-horizontal")) {
-        console.warn(
-          `${PfeJumpLinks.tag}: The top-level list of links MUST be a <ul>`
-        );
+        console.warn(`${PfeJumpLinks.tag}: The top-level list of links MUST be a <ul>`);
       }
 
       return false;
@@ -358,9 +329,7 @@ class PfeJumpLinksPanel extends PFElement {
   }
 
   _getNav() {
-    return document.querySelector(
-      `pfe-jump-links-nav#${this.getAttribute("pfe-c-scrolltarget")}`
-    );
+    return document.querySelector(`pfe-jump-links-nav#${this.getAttribute("pfe-c-scrolltarget")}`);
   }
 
   _makeActive(link) {
@@ -368,13 +337,8 @@ class PfeJumpLinksPanel extends PFElement {
       // Check if this is a subnav or has subsections
       if (this.menu_links[link].classList.contains("sub-section")) {
         this.menu_links[link].setAttribute("active", "");
-        this.menu_links[link].parentNode.parentNode.parentNode.setAttribute(
-          "active",
-          ""
-        );
-        this.menu_links[link].parentNode.parentNode.parentNode.classList.add(
-          "expand"
-        );
+        this.menu_links[link].parentNode.parentNode.parentNode.setAttribute("active", "");
+        this.menu_links[link].parentNode.parentNode.parentNode.classList.add("expand");
       } else if (this.menu_links[link].classList.contains("has-sub-section")) {
         this.menu_links[link].setAttribute("active", "");
         this.menu_links[link].parentNode.setAttribute("active", "");
@@ -396,9 +360,7 @@ class PfeJumpLinksPanel extends PFElement {
   _removeActive(link) {
     if (this.menu_links[link]) {
       if (this.menu_links[link].classList.contains("sub-section")) {
-        this.menu_links[link].parentNode.parentNode.parentNode.classList.remove(
-          "expand"
-        );
+        this.menu_links[link].parentNode.parentNode.parentNode.classList.remove("expand");
       }
       this.menu_links[link].removeAttribute("active");
       this.menu_links[link].parentNode.removeAttribute("active");
@@ -408,12 +370,10 @@ class PfeJumpLinksPanel extends PFElement {
   _removeAllActive() {
     if (!Object.keys) {
       Object.keys = function(obj) {
-        if (obj !== Object(obj))
-          throw new TypeError("Object.keys called on a non-object");
+        if (obj !== Object(obj)) throw new TypeError("Object.keys called on a non-object");
         var k = [],
           p;
-        for (p in obj)
-          if (Object.prototype.hasOwnProperty.call(obj, p)) k.push(p);
+        for (p in obj) if (Object.prototype.hasOwnProperty.call(obj, p)) k.push(p);
         return k;
       };
       Object.keys.forEach = Array.forEach;
@@ -430,9 +390,7 @@ class PfeJumpLinksPanel extends PFElement {
 
     //If we didn't get nav in the constructor, grab it now
     if (!this.nav) {
-      this.nav = document.querySelector(
-        `pfe-jump-links-nav#${this.getAttribute("pfe-c-scrolltarget")}`
-      );
+      this.nav = document.querySelector(`pfe-jump-links-nav#${this.getAttribute("pfe-c-scrolltarget")}`);
     }
     //If we want the nav to be built automatically, re-init panel and rebuild nav
     if (this.nav.hasAttribute("autobuild")) {
@@ -464,9 +422,7 @@ class PfeJumpLinksPanel extends PFElement {
     // Make an array from the node list
     const sectionArr = [...sections];
     // Get all the sections that match this point in the scroll
-    const matches = sectionArr
-      .filter(section => window.scrollY >= section.offsetTop - this.offsetValue)
-      .reverse();
+    const matches = sectionArr.filter(section => window.scrollY >= section.offsetTop - this.offsetValue).reverse();
 
     //Identify the last one queried as the current section
     const current = sectionArr.indexOf(matches[0]);

--- a/elements/pfe-markdown/demo/pfe-markdown.story.js
+++ b/elements/pfe-markdown/demo/pfe-markdown.story.js
@@ -15,8 +15,7 @@ stories.addParameters({
 });
 
 // Define the templates to be used
-const template = (data = {}) =>
-  tools.component(PfeMarkdown.tag, data.prop, data.slots);
+const template = (data = {}) => tools.component(PfeMarkdown.tag, data.prop, data.slots);
 
 stories.addDecorator(storybookBridge.withKnobs);
 

--- a/elements/pfe-markdown/src/pfe-markdown.js
+++ b/elements/pfe-markdown/src/pfe-markdown.js
@@ -63,9 +63,7 @@ class PfeMarkdown extends PFElement {
 
     this.shadowRoot.querySelector("slot").addEventListener("slotchange", () => {
       if (!this._markdownContainer) {
-        this._markdownContainer = this.querySelector(
-          "[pfe-markdown-container]"
-        );
+        this._markdownContainer = this.querySelector("[pfe-markdown-container]");
         this._markdownContainer.style.display = "none";
 
         this._init();
@@ -79,10 +77,7 @@ class PfeMarkdown extends PFElement {
 
   _readyStateChangeHandler(event) {
     if (event.target.readyState === "complete") {
-      document.removeEventListener(
-        "readystatechange",
-        this._readyStateChangeHandler
-      );
+      document.removeEventListener("readystatechange", this._readyStateChangeHandler);
       this._init();
     }
   }

--- a/elements/pfe-modal/src/pfe-modal.js
+++ b/elements/pfe-modal/src/pfe-modal.js
@@ -46,9 +46,7 @@ class PfeModal extends PFElement {
     this.close = this.close.bind(this);
 
     this._modalWindow = this.shadowRoot.querySelector(`.${this.tag}__window`);
-    this._modalCloseButton = this.shadowRoot.querySelector(
-      `.${this.tag}__close`
-    );
+    this._modalCloseButton = this.shadowRoot.querySelector(`.${this.tag}__close`);
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
     this._container = this.shadowRoot.querySelector(`.${this.tag}__container`);
     this._outer = this.shadowRoot.querySelector(`.${this.tag}__outer`);

--- a/elements/pfe-navigation/demo/pfe-navigation.story.js
+++ b/elements/pfe-navigation/demo/pfe-navigation.story.js
@@ -46,9 +46,7 @@ const createItem = (mySlot, icon, label, tray) => {
           attributes: {
             hidden: true
           },
-          content: tray
-            ? tray
-            : `<div class="container"><p>${mySlot} tray content</p></div>`
+          content: tray ? tray : `<div class="container"><p>${mySlot} tray content</p></div>`
         }
       ]
     ) + mobile
@@ -194,15 +192,11 @@ stories.add(PfeNavigation.tag, () => {
   </pfe-navigation-main>
 </nav>`;
 
-  let language = slotCheck.language
-    ? createItem("language", "web-globe", "English")
-    : "";
+  let language = slotCheck.language ? createItem("language", "web-globe", "English") : "";
 
   let login = slotCheck.login ? createItem("login", "web-user", "Log in") : "";
 
-  let siteSwitcher = slotCheck["site-switcher"]
-    ? createItem("site-switcher", "web-grid-3x3", "Websites")
-    : "";
+  let siteSwitcher = slotCheck["site-switcher"] ? createItem("site-switcher", "web-grid-3x3", "Websites") : "";
 
   config.slots = [
     {

--- a/elements/pfe-navigation/src/pfe-navigation-item.js
+++ b/elements/pfe-navigation/src/pfe-navigation-item.js
@@ -119,13 +119,11 @@ class PfeNavigationItem extends PFElement {
 
     // Close the other active item(s) unless it's this item's parent
     if (this.navigationWrapper) {
-      this.navigationWrapper._activeNavigationItems = this.navigationWrapper._activeNavigationItems.filter(
-        item => {
-          let stayOpen = item === this.parent;
-          if (!stayOpen) item.close();
-          return stayOpen;
-        }
-      );
+      this.navigationWrapper._activeNavigationItems = this.navigationWrapper._activeNavigationItems.filter(item => {
+        let stayOpen = item === this.parent;
+        if (!stayOpen) item.close();
+        return stayOpen;
+      });
 
       // Open that item and add it to the active array
       this.navigationWrapper._activeNavigationItems.push(this);
@@ -148,19 +146,16 @@ class PfeNavigationItem extends PFElement {
     if (event) event.preventDefault();
 
     // Close the children elements
-    this.navigationWrapper._activeNavigationItems = this.navigationWrapper._activeNavigationItems.filter(
-      item => {
-        let close = this.nestedItems && this.nestedItems.includes(item);
-        if (close) item.close();
-        return !close && item !== this;
-      }
-    );
+    this.navigationWrapper._activeNavigationItems = this.navigationWrapper._activeNavigationItems.filter(item => {
+      let close = this.nestedItems && this.nestedItems.includes(item);
+      if (close) item.close();
+      return !close && item !== this;
+    });
 
     this.expanded = false;
 
     // Clear the overlay
-    this.navigationWrapper.overlay =
-      this.navigationWrapper._activeNavigationItems.length > 0;
+    this.navigationWrapper.overlay = this.navigationWrapper._activeNavigationItems.length > 0;
 
     this.focus();
 
@@ -230,8 +225,7 @@ class PfeNavigationItem extends PFElement {
     this._init__tray();
 
     // Add a slotchange listeners to the lightDOM elements
-    if (this.trigger)
-      this.trigger.addEventListener("slotchange", this._init__trigger);
+    if (this.trigger) this.trigger.addEventListener("slotchange", this._init__trigger);
     if (this.tray) this.tray.addEventListener("slotchange", this._init__tray);
   }
 
@@ -254,9 +248,7 @@ class PfeNavigationItem extends PFElement {
 
   _init__trigger() {
     // If no slots have been assigned, assign it to the trigger slot
-    const unassigned = [...this.children].filter(
-      child => !child.hasAttribute("slot")
-    );
+    const unassigned = [...this.children].filter(child => !child.hasAttribute("slot"));
     unassigned.map(item => item.setAttribute("slot", "trigger"));
 
     // Get the LightDOM trigger & tray content
@@ -293,9 +285,7 @@ class PfeNavigationItem extends PFElement {
     //-- Check for any nested navigation items
     // If a light DOM tray exists, check for descendents
     if (this.tray) {
-      this.nestedItems = this.nestedItems.concat([
-        ...this.tray.querySelectorAll(`${this.tag}`)
-      ]);
+      this.nestedItems = this.nestedItems.concat([...this.tray.querySelectorAll(`${this.tag}`)]);
       let array = [];
 
       // Search the tray for nested slots

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -76,17 +76,11 @@ class PfeNavigation extends PFElement {
     // Capture shadow elements
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
     this._wrapper = this.shadowRoot.querySelector(`.${this.tag}__wrapper`);
-    this._menuItem = this.shadowRoot.querySelector(
-      `${PfeNavigationItem.tag}[pfe-icon="web-mobile-menu"]`
-    );
+    this._menuItem = this.shadowRoot.querySelector(`${PfeNavigationItem.tag}[pfe-icon="web-mobile-menu"]`);
 
     this._slots = {
-      language: this.shadowRoot.querySelector(
-        `${PfeNavigationItem.tag}[pfe-icon="web-user"]`
-      ),
-      login: this.shadowRoot.querySelector(
-        `${PfeNavigationItem.tag}[pfe-icon="web-globe"]`
-      )
+      language: this.shadowRoot.querySelector(`${PfeNavigationItem.tag}[pfe-icon="web-user"]`),
+      login: this.shadowRoot.querySelector(`${PfeNavigationItem.tag}[pfe-icon="web-globe"]`)
     };
 
     // Initialize active navigation item to empty array
@@ -143,17 +137,11 @@ class PfeNavigation extends PFElement {
     // Remove the scroll, resize, and outside click event listeners
     window.removeEventListener("resize", this._resizeHandler);
 
-    if (
-      this.hasAttribute("pfe-close-on-click") &&
-      this.getAttribute("pfe-close-on-click") === "external"
-    ) {
+    if (this.hasAttribute("pfe-close-on-click") && this.getAttribute("pfe-close-on-click") === "external") {
       document.removeEventListener("click", this._outsideListener);
     }
 
-    if (
-      this.hasAttribute("pfe-sticky") &&
-      this.getAttribute("pfe-sticky") != "false"
-    ) {
+    if (this.hasAttribute("pfe-sticky") && this.getAttribute("pfe-sticky") != "false") {
       window.removeEventListener("scroll", this._stickyHandler);
     }
 
@@ -174,16 +162,11 @@ class PfeNavigation extends PFElement {
       // If the item is open but not visible, update it to hidden
       if (item.expanded && !item.visible) {
         item.expanded = false;
-        this._activeNavigationItems = this._activeNavigationItems.filter(
-          i => i !== item
-        );
+        this._activeNavigationItems = this._activeNavigationItems.filter(i => i !== item);
       } else if (item.expanded && item.parent && item.parent.visible) {
         // if the parent is the mobile menu item and the size of the window is within
         // the main breakpoint, make sure that the mobile menu is expanded
-        if (
-          item.parent === this._menuItem &&
-          window.innerWidth <= this.breakpoints.main[1]
-        ) {
+        if (item.parent === this._menuItem && window.innerWidth <= this.breakpoints.main[1]) {
           item.parent.expanded = true; // Ensure the parent is open
           // If the parent item doesn't exist in the active array, add it
           if (!this._activeNavigationItems.includes(item.parent)) {
@@ -230,11 +213,7 @@ class PfeNavigation extends PFElement {
       let isVisible = false;
 
       // If the slot exists, set attribute based on supported breakpoints
-      if (
-        this.slots[label] &&
-        this.slots[label].nodes &&
-        this.slots[label].nodes.length > 0
-      ) {
+      if (this.slots[label] && this.slots[label].nodes && this.slots[label].nodes.length > 0) {
         if (width >= start && (!end || (end && width <= end))) {
           isVisible = true;
         }
@@ -251,9 +230,7 @@ class PfeNavigation extends PFElement {
                 this._menuItem.expanded = false;
                 this._menuItem.tray.removeAttribute("hidden");
                 // Remove menuItem from active items
-                this._activeNavigationItems = this._activeNavigationItems.filter(
-                  item => item !== this._menuItem
-                );
+                this._activeNavigationItems = this._activeNavigationItems.filter(item => item !== this._menuItem);
               }
               node.navItems.forEach(item => {
                 if (isVisible) {
@@ -267,13 +244,11 @@ class PfeNavigation extends PFElement {
               if (isVisible) {
                 // Set an attribute to show this region (strip the mobile prefix)
                 this._menuItem.setAttribute(`show_${label.slice(7)}`, "");
-                if (this._slots[label.slice(7)])
-                  this._slots[label.slice(7)].removeAttribute("hidden");
+                if (this._slots[label.slice(7)]) this._slots[label.slice(7)].removeAttribute("hidden");
                 node.removeAttribute("hidden");
               } else {
                 this._menuItem.removeAttribute(`show_${label.slice(7)}`);
-                if (this._slots[label.slice(7)])
-                  this._slots[label.slice(7)].setAttribute("hidden", "");
+                if (this._slots[label.slice(7)]) this._slots[label.slice(7)].setAttribute("hidden", "");
                 node.setAttribute("hidden", "");
               }
               break;
@@ -319,10 +294,7 @@ class PfeNavigation extends PFElement {
     this._setVisibility(this.offsetWidth);
 
     // If the nav is set to sticky, inject the height of the nav to the next element in the DOM
-    if (
-      this.hasAttribute("pfe-sticky") &&
-      this.getAttribute("pfe-sticky") != "false"
-    ) {
+    if (this.hasAttribute("pfe-sticky") && this.getAttribute("pfe-sticky") != "false") {
       // Run the sticky check on first page load
       this._stickyHandler();
 
@@ -331,10 +303,7 @@ class PfeNavigation extends PFElement {
     }
 
     // Listen for clicks outside the navigation element
-    if (
-      this.hasAttribute("pfe-close-on-click") &&
-      this.getAttribute("pfe-close-on-click") === "external"
-    ) {
+    if (this.hasAttribute("pfe-close-on-click") && this.getAttribute("pfe-close-on-click") === "external") {
       document.addEventListener("click", this._outsideListener);
     }
 

--- a/elements/pfe-navigation/src/polyfills--pfe-navigation.js
+++ b/elements/pfe-navigation/src/polyfills--pfe-navigation.js
@@ -3,8 +3,7 @@
 if (!Array.prototype.filter) {
   Array.prototype.filter = function(func, thisArg) {
     "use strict";
-    if (!((typeof func === "Function" || typeof func === "function") && this))
-      throw new TypeError();
+    if (!((typeof func === "Function" || typeof func === "function") && this)) throw new TypeError();
 
     var len = this.length >>> 0,
       res = new Array(len), // preallocate array
@@ -43,9 +42,7 @@ if (!Array.prototype.filter) {
 // @POLYFILL  Element.prototype.matches
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
 if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector;
+  Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 }
 
 // @POLYFILL  Element.prototype.closest
@@ -94,13 +91,7 @@ if (!Array.prototype.includes) {
       var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
 
       function sameValueZero(x, y) {
-        return (
-          x === y ||
-          (typeof x === "number" &&
-            typeof y === "number" &&
-            isNaN(x) &&
-            isNaN(y))
-        );
+        return x === y || (typeof x === "number" && typeof y === "number" && isNaN(x) && isNaN(y));
       }
 
       // 7. Repeat, while k < len
@@ -131,8 +122,7 @@ if (!("path" in Event.prototype)) {
         path.push(currentElem);
         currentElem = currentElem.parentElement;
       }
-      if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
-        path.push(document);
+      if (path.indexOf(window) === -1 && path.indexOf(document) === -1) path.push(document);
       if (path.indexOf(window) === -1) path.push(window);
       return path;
     }

--- a/elements/pfe-page-status/demo/pfe-page-status.story.js
+++ b/elements/pfe-page-status/demo/pfe-page-status.story.js
@@ -16,8 +16,7 @@ stories.addParameters({
 
 stories.addDecorator(storybookBridge.withKnobs);
 
-const template = (data = {}) =>
-  tools.component(PfePageStatus.tag, data.prop, data.slots);
+const template = (data = {}) => tools.component(PfePageStatus.tag, data.prop, data.slots);
 
 stories.add(PfePageStatus.tag, () => {
   let config = {};

--- a/elements/pfe-progress-indicator/src/pfe-progress-indicator.js
+++ b/elements/pfe-progress-indicator/src/pfe-progress-indicator.js
@@ -36,9 +36,7 @@ class PfeProgressIndicator extends PFElement {
     const firstChild = this.children[0];
 
     if (!firstChild) {
-      console.warn(
-        `${PfeProgressIndicator.tag}: You do not have a backup loading message.`
-      );
+      console.warn(`${PfeProgressIndicator.tag}: You do not have a backup loading message.`);
     }
   }
 }

--- a/elements/pfe-select/demo/pfe-select.story.js
+++ b/elements/pfe-select/demo/pfe-select.story.js
@@ -45,18 +45,10 @@ stories.add(PfeSelect.tag, () => {
   };
 
   // Ask user if they want to add any custom options via pfeOptions setter method
-  const isCustomOptions = storybookBridge.boolean(
-    "Use custom options via pfeOptions setter?",
-    false,
-    "Content"
-  );
+  const isCustomOptions = storybookBridge.boolean("Use custom options via pfeOptions setter?", false, "Content");
 
   // Ask user if they want to append any options via addOptions API
-  const isAppendOptions = storybookBridge.boolean(
-    "Append custom options via addOptions API?",
-    false,
-    "API"
-  );
+  const isAppendOptions = storybookBridge.boolean("Append custom options via addOptions API?", false, "API");
 
   if (isCustomOptions) {
     const data = [];

--- a/elements/pfe-select/src/pfe-select.js
+++ b/elements/pfe-select/src/pfe-select.js
@@ -22,9 +22,7 @@ class PfeSelect extends PFElement {
 
   set pfeOptions(options) {
     this._pfeOptions =
-      options.filter(el => el.selected).length > 1
-        ? this._handleMultipleSelectedValues(options)
-        : options;
+      options.filter(el => el.selected).length > 1 ? this._handleMultipleSelectedValues(options) : options;
     this._modifyDOM();
   }
 
@@ -68,9 +66,7 @@ class PfeSelect extends PFElement {
         if (this.children.length) {
           this._init();
         } else {
-          console.warn(
-            `${PfeSelect.tag}: The first child in the light DOM must be a supported select tag`
-          );
+          console.warn(`${PfeSelect.tag}: The first child in the light DOM must be a supported select tag`);
         }
       }
     });
@@ -89,9 +85,7 @@ class PfeSelect extends PFElement {
 
   addOptions(options) {
     // Reset the pfeOptions by concatenating newly added options with _pfeOptions
-    this._pfeOptions = this._pfeOptions
-      ? this._pfeOptions.concat(options)
-      : options;
+    this._pfeOptions = this._pfeOptions ? this._pfeOptions.concat(options) : options;
   }
 
   _handleMultipleSelectedValues(options) {
@@ -111,9 +105,7 @@ class PfeSelect extends PFElement {
   _init() {
     this._input = this.querySelector("select");
     if (!this._input) {
-      console.warn(
-        `${PfeSelect.tag}: The first child needs to be a select element`
-      );
+      console.warn(`${PfeSelect.tag}: The first child needs to be a select element`);
       return;
     }
     this._input.addEventListener("change", this._inputChanged);

--- a/elements/pfe-tabs/demo/pfe-tabs.story.js
+++ b/elements/pfe-tabs/demo/pfe-tabs.story.js
@@ -49,11 +49,7 @@ stories.add(PfeTabs.tag, () => {
   });
 
   // Ask user if they want to add any custom content
-  const customContent = storybookBridge.boolean(
-    "Use custom content?",
-    false,
-    "Content"
-  );
+  const customContent = storybookBridge.boolean("Use custom content?", false, "Content");
 
   // Let the user customize the first header + panel set
   if (customContent) {
@@ -88,9 +84,7 @@ stories.add(PfeTabs.tag, () => {
         },
         [
           {
-            content: customContent
-              ? panels[i]
-              : tools.autoContent(3, 3) + defaultCTA
+            content: customContent ? panels[i] : tools.autoContent(3, 3) + defaultCTA
           }
         ]
       )

--- a/elements/pfe-tabs/src/pfe-tabs.js
+++ b/elements/pfe-tabs/src/pfe-tabs.js
@@ -91,10 +91,7 @@ class PfeTabs extends PFElement {
     this.addEventListener("keydown", this._onKeyDown);
     this.addEventListener("click", this._onClick);
 
-    Promise.all([
-      customElements.whenDefined(PfeTab.tag),
-      customElements.whenDefined(PfeTabPanel.tag)
-    ]).then(() => {
+    Promise.all([customElements.whenDefined(PfeTab.tag), customElements.whenDefined(PfeTabPanel.tag)]).then(() => {
       if (this.children.length) {
         this._init();
       }
@@ -105,9 +102,7 @@ class PfeTabs extends PFElement {
 
   disconnectedCallback() {
     this.removeEventListener("keydown", this._onKeyDown);
-    this._allTabs().forEach(tab =>
-      tab.removeEventListener("click", this._onClick)
-    );
+    this._allTabs().forEach(tab => tab.removeEventListener("click", this._onClick));
     this._observer.disconnect();
 
     if (this.tabHistory) {
@@ -119,28 +114,18 @@ class PfeTabs extends PFElement {
     switch (attr) {
       case "pfe-variant":
         if (this.getAttribute("pfe-variant") === "wind") {
-          this._allTabs().forEach(tab =>
-            tab.setAttribute("pfe-variant", "wind")
-          );
-          this._allPanels().forEach(panel =>
-            panel.setAttribute("pfe-variant", "wind")
-          );
+          this._allTabs().forEach(tab => tab.setAttribute("pfe-variant", "wind"));
+          this._allPanels().forEach(panel => panel.setAttribute("pfe-variant", "wind"));
         } else if (this.getAttribute("pfe-variant") === "earth") {
-          this._allTabs().forEach(tab =>
-            tab.setAttribute("pfe-variant", "earth")
-          );
-          this._allPanels().forEach(panel =>
-            panel.setAttribute("pfe-variant", "earth")
-          );
+          this._allTabs().forEach(tab => tab.setAttribute("pfe-variant", "earth"));
+          this._allPanels().forEach(panel => panel.setAttribute("pfe-variant", "earth"));
         }
         break;
 
       case "vertical":
         if (this.hasAttribute("vertical")) {
           this.setAttribute("aria-orientation", "vertical");
-          this._allPanels().forEach(panel =>
-            panel.setAttribute("vertical", "")
-          );
+          this._allPanels().forEach(panel => panel.setAttribute("vertical", ""));
           this._allTabs().forEach(tab => tab.setAttribute("vertical", ""));
         } else {
           this.removeAttribute("aria-orientation");
@@ -150,10 +135,7 @@ class PfeTabs extends PFElement {
         break;
 
       case "selected-index":
-        Promise.all([
-          customElements.whenDefined(PfeTab.tag),
-          customElements.whenDefined(PfeTabPanel.tag)
-        ]).then(() => {
+        Promise.all([customElements.whenDefined(PfeTab.tag), customElements.whenDefined(PfeTabPanel.tag)]).then(() => {
           this._linkPanels();
           this.selectIndex(newValue);
           this._updateHistory = true;
@@ -198,12 +180,7 @@ class PfeTabs extends PFElement {
 
     // @IE11 doesn't support URLSearchParams
     // https://caniuse.com/#search=urlsearchparams
-    if (
-      this.selected &&
-      this.tabHistory &&
-      this._updateHistory &&
-      CAN_USE_URLSEARCHPARAMS
-    ) {
+    if (this.selected && this.tabHistory && this._updateHistory && CAN_USE_URLSEARCHPARAMS) {
       // rebuild the url
       const pathname = window.location.pathname;
       const urlParams = new URLSearchParams(window.location.search);
@@ -251,10 +228,7 @@ class PfeTabs extends PFElement {
               return;
             }
 
-            if (
-              addedNode.tagName.toLowerCase() === PfeTab.tag ||
-              addedNode.tagName.toLowerCase() === PfeTabPanel.tag
-            ) {
+            if (addedNode.tagName.toLowerCase() === PfeTab.tag || addedNode.tagName.toLowerCase() === PfeTabPanel.tag) {
               if (this.variant.value) {
                 addedNode.setAttribute("pfe-variant", this.variant.value);
               }
@@ -279,9 +253,7 @@ class PfeTabs extends PFElement {
     tabs.forEach(tab => {
       const panel = tab.nextElementSibling;
       if (panel.tagName.toLowerCase() !== "pfe-tab-panel") {
-        console.warn(
-          `${PfeTabs.tag}: tab #${tab.pfeId} is not a sibling of a <pfe-tab-panel>`
-        );
+        console.warn(`${PfeTabs.tag}: tab #${tab.pfeId} is not a sibling of a <pfe-tab-panel>`);
         return;
       }
 
@@ -459,15 +431,11 @@ class PfeTabs extends PFElement {
       // and fallback to urlParams.has(`pfe-${this.id}`) if it exists. We should
       // be able to remove the || part of the if statement in the future
       const tabsetInUrl =
-        urlParams.has(`${this.id}`) ||
-        urlParams.has(this.getAttribute("pfe-id")) ||
-        urlParams.has(`pfe-${this.id}`); // remove this condition when it's no longer used in production
+        urlParams.has(`${this.id}`) || urlParams.has(this.getAttribute("pfe-id")) || urlParams.has(`pfe-${this.id}`); // remove this condition when it's no longer used in production
 
       if (urlParams && tabsetInUrl) {
         const id =
-          urlParams.get(`${this.id}`) ||
-          urlParams.get(this.getAttribute("pfe-id")) ||
-          urlParams.get(`pfe-${this.id}`); // remove this condition when it's no longer used in production
+          urlParams.get(`${this.id}`) || urlParams.get(this.getAttribute("pfe-id")) || urlParams.get(`pfe-${this.id}`); // remove this condition when it's no longer used in production
 
         tabIndex = this._allTabs().findIndex(tab => {
           const tabId = tab.id || tab.getAttribute("pfe-id");
@@ -593,9 +561,7 @@ class PfeTab extends PFElement {
     const label = this.textContent.trim().replace(/\s+/g, " ");
 
     if (!label) {
-      console.warn(
-        `${this.tag}: There does not appear to be any content in the tab region.`
-      );
+      console.warn(`${this.tag}: There does not appear to be any content in the tab region.`);
       return;
     }
 
@@ -603,10 +569,7 @@ class PfeTab extends PFElement {
     // Get the semantics of the content
     if (this.children.length > 0) {
       // We only care about the first child that is a tag
-      if (
-        this.firstElementChild &&
-        this.firstElementChild.tagName.match(/^H[1-6]/)
-      ) {
+      if (this.firstElementChild && this.firstElementChild.tagName.match(/^H[1-6]/)) {
         semantics = this.firstElementChild.tagName.toLowerCase();
       }
     }

--- a/elements/pfe-toast/src/pfe-toast.js
+++ b/elements/pfe-toast/src/pfe-toast.js
@@ -39,9 +39,7 @@ class PfeToast extends PFElement {
     // elements
     this._container = this.shadowRoot.querySelector(`.${this.tag}__container`);
     this._content = this.shadowRoot.querySelector(`.${this.tag}__content`);
-    this._toastCloseButton = this.shadowRoot.querySelector(
-      `.${this.tag}__close`
-    );
+    this._toastCloseButton = this.shadowRoot.querySelector(`.${this.tag}__close`);
 
     // events
     this.open = this.open.bind(this);

--- a/elements/pfelement/src/pfelement.js
+++ b/elements/pfelement/src/pfelement.js
@@ -222,10 +222,7 @@ class PFElement extends HTMLElement {
   }
 
   _copyAttribute(name, to) {
-    const recipients = [
-      ...this.querySelectorAll(to),
-      ...this.shadowRoot.querySelectorAll(to)
-    ];
+    const recipients = [...this.querySelectorAll(to), ...this.shadowRoot.querySelectorAll(to)];
     const value = this.getAttribute(name);
     const fname = value == null ? "removeAttribute" : "setAttribute";
     for (const node of recipients) {
@@ -268,9 +265,7 @@ class PFElement extends HTMLElement {
         // Otherwise, look for a default and use that instead
         else if (data.default) {
           const dependency_exists = this._hasDependency(tag, data.options);
-          const no_dependencies =
-            !data.options ||
-            (data.options && !data.options.dependencies.length);
+          const no_dependencies = !data.options || (data.options && !data.options.dependencies.length);
           // If the dependency exists or there are no dependencies, set the default
           if (dependency_exists || no_dependencies) {
             this.setAttribute(attrName, data.default);
@@ -292,12 +287,9 @@ class PFElement extends HTMLElement {
     // Check that dependent item exists
     // Loop through the dependencies defined
     for (let i = 0; i < dependencies.length; i += 1) {
-      const slot_exists =
-        dependencies[i].type === "slot" &&
-        this.has_slots(`${tag}--${dependencies[i].id}`).length > 0;
+      const slot_exists = dependencies[i].type === "slot" && this.has_slots(`${tag}--${dependencies[i].id}`).length > 0;
       const attribute_exists =
-        dependencies[i].type === "attribute" &&
-        this.getAttribute(`${prefix}${dependencies[i].id}`);
+        dependencies[i].type === "attribute" && this.getAttribute(`${prefix}${dependencies[i].id}`);
       // If the type is slot, check that it exists OR
       // if the type is an attribute, check if the attribute is defined
       if (slot_exists || attribute_exists) {
@@ -341,9 +333,7 @@ class PFElement extends HTMLElement {
           }
           // If it's the default slot, look for direct children not assigned to a slot
         } else {
-          result = [...this.children].filter(
-            child => !child.hasAttribute("slot")
-          );
+          result = [...this.children].filter(child => !child.hasAttribute("slot"));
 
           if (result.length > 0) {
             slotObj.nodes = result;
@@ -405,10 +395,7 @@ class PFElement extends HTMLElement {
     PFElement.log(`[${this.tag}]`, ...msgs);
   }
 
-  emitEvent(
-    name,
-    { bubbles = true, cancelable = false, composed = false, detail = {} } = {}
-  ) {
+  emitEvent(name, { bubbles = true, cancelable = false, composed = false, detail = {} } = {}) {
     this.log(`Custom event: ${name}`);
     this.dispatchEvent(
       new CustomEvent(name, {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,3 @@
-module.exports = {};
+module.exports = {
+  printWidth: 120
+};


### PR DESCRIPTION
### Related issue

- (#967 ) Update prettier config to extend line length to 120


### What has changed and why

Developer experience, line length was set to 80 (the default) which felt small (to me)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Browser testing passed (regression testing only).
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
