### PR TITLE
fix: injecting new tabs in the wrong accordion

### DIFF
--- a/elements/pfe-accordion/demo/index.html
+++ b/elements/pfe-accordion/demo/index.html
@@ -264,7 +264,7 @@
 
     <section class="light-gray-background">
       <h2>&lt;pfe-accordion&gt;</h2><br/>
-      <pfe-accordion>
+      <pfe-accordion id="pfe-accordion-light-gray">
         <pfe-accordion-header>
           <h3>Why do wizards need money if they could just create it?</h3>
         </pfe-accordion-header>
@@ -595,7 +595,7 @@
 
     <script>
       var btn = document.querySelector("#addTabAndPanelBtn");
-      var pfeAccordion = document.querySelector("pfe-accordion");
+      var pfeAccordion = document.getElementById("pfe-accordion-light-gray");
 
       btn.addEventListener("click", function() {
         var fragment = document.createDocumentFragment();


### PR DESCRIPTION
---
name: Injecting new tabs in the wrong accordion
labels: "bug, demo, priority: low"
---

## Component name

Demo | Pfe-Accordion

### Related issue

- (#928 ) pfe-accordion | demo | Add tab button firing on wrong accordion set

### Preview

<!-- Suggest linking to Netlify or a public sandbox; not a resource behind a log-in or VPN -->
Link(s) to demo page(s) where this element can be viewed:
- [Link](https://5e6089f7c8e38b0008963801--happy-galileo-ea79c4.netlify.com/elements/pfe-accordion/demo) 

### What has changed and why

Now, when click on the button 'Add Tab & Panel' the new items are inserted at the end of the 4th accordion from the top instead of the 1st.

### Testing instructions
1. Go to the Accordion component demo page
2. Click on the 'Add Tab & Panel' button
3. A new tab must be added to the 4th accordion (from the top).

#### Browser requirements

Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 68 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
