### PR TITLE
Cpfed 3847 menu back button

### DIFF
--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -272,16 +272,15 @@ $dropdown-transition: pfe-local(dropdown-transition);
 
   // added to counteract jumpiness when dashed border is visible on focus and hover
   border: 1px solid transparent;
-  // border-top: 0px;
 
   // focus styles
   &:focus,
   &:hover {
     @include alt-focus-styles(#fff, #e00);
 
-    @include breakpoint('secondary-links-expand') {
-      @include alt-focus-styles(#fff, #e00);
-    }
+    // @include breakpoint('secondary-links-expand') {
+    //   @include alt-focus-styles(#fff, #e00);
+    // }
   }
 
   &[pfe-navigation-open-toggle="main-menu--open"] {

--- a/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
+++ b/elements/pfe-navigation/src/pfe-navigation--lightdom.scss
@@ -112,6 +112,15 @@ pfe-navigation {
     a,
     button {
       @include top-level-button;
+      &:focus,
+      &:hover {
+        @include focus-styles(#000, 1px);
+        box-shadow: none;
+    
+        @include breakpoint('secondary-links-expand') {
+          @include alt-focus-styles(#fff, #e00);
+        }
+      }
     }
   }
 

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -34,6 +34,7 @@
             All Red Hat
           </button>
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
+            <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Back to Main Menu">Back to Menu</button>
             <div class="pfe-navigation__all-red-hat-wrapper__inner">
               <div id="site-loading">
                 <pfe-progress-indicator></pfe-progress-indicator>

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -30,7 +30,7 @@
         </li>
         <li>
           <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat">
-            <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm"></pfe-icon>
+            <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
             All Red Hat
           </button>
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -34,7 +34,10 @@
             All Red Hat
           </button>
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
-            <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Back to Main Menu">Back to Menu</button>
+            <div class="pfe-navigation__all-red-hat-toggle--back-wrapper">
+              <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Back to main menu">Back to menu</button>
+            </div>
+
             <div class="pfe-navigation__all-red-hat-wrapper__inner">
               <div id="site-loading">
                 <pfe-progress-indicator></pfe-progress-indicator>

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -98,8 +98,10 @@ class PfeNavigation extends PFElement {
     this._searchSpotXs = this.shadowRoot.getElementById("pfe-navigation__search-wrapper--xs");
     this._searchSpotMd = this.shadowRoot.getElementById("pfe-navigation__search-wrapper--md");
     this._allRedHatToggle = this.shadowRoot.getElementById("secondary-links__button--all-red-hat");
+    this._allRedHatToggleBack = this.shadowRoot.querySelector(`#${this.tag}__all-red-hat-toggle--back`);
     this._customLinksSlot = this.shadowRoot.getElementById("pfe-navigation--custom-links");
-    this._siteSwitcherWrapper = this.shadowRoot.querySelector(".pfe-navigation__all-red-hat-wrapper__inner");
+    this._siteSwitcherWrapperOuter = this.shadowRoot.querySelector(`.${this.tag}__all-red-hat-wrapper`);
+    this._siteSwitcherWrapper = this.shadowRoot.querySelector(`.${this.tag}__all-red-hat-wrapper__inner`);
     this._siteSwitchLoadingIndicator = this.shadowRoot.querySelector("#site-loading");
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
 
@@ -131,6 +133,7 @@ class PfeNavigation extends PFElement {
     this._toggleMobileMenu = this._toggleMobileMenu.bind(this);
     this._toggleSearch = this._toggleSearch.bind(this);
     this._toggleAllRedHat = this._toggleAllRedHat.bind(this);
+    this._allRedHatToggleBackClickHandler = this._allRedHatToggleBackClickHandler.bind(this);
     this._dropdownItemToggle = this._dropdownItemToggle.bind(this);
     this._addMenuBreakpoints = this._addMenuBreakpoints.bind(this);
     this._collapseMainMenu = this._collapseMainMenu.bind(this);
@@ -146,6 +149,9 @@ class PfeNavigation extends PFElement {
 
     // Setup mutation observer to watch for content changes
     this._observer = new MutationObserver(this._processLightDom);
+
+    // close All Red Hat menu and go back to mobile menu
+    this._allRedHatToggleBack.addEventListener("click", this._allRedHatToggleBackClickHandler);
 
     // ensure we close the whole menu and hide the overlay when the overlay is clicked
     this._overlay.addEventListener("click", this._overlayClickHandler);
@@ -267,9 +273,16 @@ class PfeNavigation extends PFElement {
    * @param {boolean} debugNavigationState
    */
   _addOpenDropdownAttributes(toggleElement, dropdownWrapper, debugNavigationState = false) {
+    // Toggle Button DOM Element ID attribute
     let toggleId = null;
+    // Dropdown wrapper DOM element ID attribute
+    let dropdownWrapperId = null;
+
     if (toggleElement) {
       toggleId = toggleElement.getAttribute("id");
+    }
+    if (dropdownWrapper) {
+      dropdownWrapperId = dropdownWrapper.getAttribute("id");
     }
     if (debugNavigationState) {
       console.log("_addOpenDropdownAttributes", toggleId, dropdownWrapper.getAttribute("id"));
@@ -277,6 +290,7 @@ class PfeNavigation extends PFElement {
 
     if (toggleElement) {
       toggleElement.setAttribute("aria-expanded", "true");
+      toggleElement.setAttribute("aria-controls", dropdownWrapperId);
 
       // Main menu specific actions
       if (toggleId.startsWith("main-menu__")) {
@@ -763,9 +777,9 @@ class PfeNavigation extends PFElement {
     this.shadowRoot.querySelector(".pfe-navigation__dropdown-wrapper").setAttribute("aria-hidden", "true");
 
     // Set initial on page load aria settings on all original buttons and their dropdowns
-    this._addCloseDropdownAttributes(this._mobileToggle, this._menuDropdownMdId);
+    this._addCloseDropdownAttributes(this._mobileToggle, this._currentMobileDropdown);
     this._addCloseDropdownAttributes(this._searchToggle, this._searchSpotMd);
-    this._addCloseDropdownAttributes(this._allRedHatToggle, this._siteSwitcherWrapperId);
+    this._addCloseDropdownAttributes(this._allRedHatToggle, this._siteSwitcherWrapperOuter);
 
     this._setCurrentMobileDropdown();
 
@@ -1074,6 +1088,15 @@ class PfeNavigation extends PFElement {
         openToggle.focus();
       }
     }
+  }
+
+  /**
+   * Back to Menu Event Handler
+   * close All Red Hat Menu and Go back to Main Mobile Menu
+   */
+  _allRedHatToggleBackClickHandler() {
+    console.log(`Back to Menu Click Handler`);
+    this._changeNavigationState("mobile__button", "open");
   }
 
   /**

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -193,13 +193,14 @@ class PfeNavigation extends PFElement {
     this._allRedHatToggleBack.removeEventListener("click", this._allRedHatToggleBackClickHandler);
     this.removeEventListener("keydown", this._generalKeyboardListener);
     // log focused element - for development only
-    this.shadowRoot.removeEventListener(
-      "focusin",
-      function(event) {
-        console.log("focused: ", event.target);
-      },
-      true
-    );
+    // @todo: change anon function to be a property on the object so we can refer to it when we add the listener and remove it
+    // this.shadowRoot.removeEventListener(
+    //   "focusin",
+    //   function(event) {
+    //     console.log("focused: ", event.target);
+    //   },
+    //   true
+    // );
   }
 
   // Process the attribute change
@@ -219,6 +220,7 @@ class PfeNavigation extends PFElement {
    * for development only, should remove for final product
    * @param {boolean} debugFocus Optional. console log focused element
    */
+  // @todo: decide if we should keep this debug feature in final product
   _isDebugFocus(debugFocus = false) {
     return debugFocus;
   }
@@ -702,16 +704,17 @@ class PfeNavigation extends PFElement {
       console.log(`${this.tag} _processLightDom: replacing shadow DOM`, mutationList);
 
       // set to true to log focused element, set to false to stop logging focused element, for development only, should remove for final product
-      if (this._isDebugFocus(false)) {
-        // log focused element
-        this.shadowRoot.addEventListener(
-          "focusin",
-          function(event) {
-            console.log("focused: ", event.target);
-          },
-          true
-        );
-      }
+      // @todo: change anon function to be a property on the object so we can refer to it when we add the listener and remove it
+      // if (this._isDebugFocus(false)) {
+      //   // log focused element
+      //   this.shadowRoot.addEventListener(
+      //     "focusin",
+      //     function(event) {
+      //       console.log("focused: ", event.target);
+      //     },
+      //     true
+      //   );
+      // }
     }
     // @todo look into only replacing markup that changed via mutationList
     const shadowWrapper = this.shadowRoot.getElementById("pfe-navigation__wrapper");
@@ -1066,7 +1069,6 @@ class PfeNavigation extends PFElement {
     if (this.isOpen("mobile__button")) {
       // if this is the mobile menu and the All Red Hat Toggle is clicked set focus to Back to Menu Button inside of All Red Hat Menu
       this._allRedHatToggleBack.focus();
-      console.log();
     }
   }
 

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -89,11 +89,6 @@ See mixin blocks before selectors that contain the selector name and the three l
 
   a {
     text-decoration: none;
-    // @todo: move these styles to be more specific with dropdown class so that logo link can be styled without conflicting
-    // &:focus,
-    // &:hover {
-    //   @include focus-styles(#000, 1px);
-    // }
   }
 
   // @todo: verify that this is a feasable way to ensure this and that this does not conflict with any other z-index rules of the nav
@@ -119,9 +114,21 @@ See mixin blocks before selectors that contain the selector name and the three l
 // --------------------------------------------------------
 .pfe-navigation__menu-toggle,
 .pfe-navigation__search-toggle,
-.pfe-navigation__all-red-hat-toggle,
 .pfe-navigation__log-in-link {
   @include top-level-button;
+}
+
+.pfe-navigation__all-red-hat-toggle {
+  @include top-level-button;
+  &:focus,
+  &:hover {
+    @include focus-styles(#000, 1px);
+    box-shadow: none;
+
+    @include breakpoint('secondary-links-expand') {
+      @include alt-focus-styles(#fff, #e00);
+    }
+  }
 }
 
 // Layout changes per breakpoint
@@ -600,10 +607,6 @@ See mixin blocks before selectors that contain the selector name and the three l
     max-width: 100%;
     box-shadow: none;
   }
-
-  // .pfe-navigation__menu-item--open > & {
-  //   display: block;
-  // }
 }
 
 // Dropdown contents - lays out dropdown internals
@@ -939,7 +942,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     // focus styles
     &:focus,
     &:hover {
-      @include focus-styles(#fff, 0px);
+      @include focus-styles(#000, 1px);
     }
 
     @include breakpoint('secondary-links-expand') {
@@ -947,7 +950,7 @@ See mixin blocks before selectors that contain the selector name and the three l
       // focus styles
       &:focus,
       &:hover {
-        @include focus-styles(#fff, 0px);
+        @include alt-focus-styles(#fff, #e00);
       }
     }
     @include collapse('secondary-links') {
@@ -962,12 +965,15 @@ See mixin blocks before selectors that contain the selector name and the three l
   [pfe-navigation-open-toggle='secondary-links__button--all-red-hat'] & {
     color: #151515;
     background: #fff;
-    box-shadow: inset 0 4px 0 0 #e00;
 
     //focus styles
     &:focus,
     &:hover {
       @include focus-styles(#000, 0px);
+      box-shadow: none;
+      @include breakpoint('md') {
+        box-shadow: inset 0 4px 0 0 #e00;
+      }
     }
   }
 }
@@ -1022,6 +1028,30 @@ See mixin blocks before selectors that contain the selector name and the three l
     padding: 16px 32px;
     color: #fff;
     background: transparent;
+  }
+}
+
+// Hide Back to Menu button everywhere but mobile
+.pfe-navigation__all-red-hat-toggle--back-wrapper {
+  display: block;
+  border-bottom: 1px solid #d2d2d2;
+
+  @include breakpoint('md') {
+    display: none;
+  }
+
+  #pfe-navigation__all-red-hat-toggle--back {
+    background-color: transparent;
+    border: 1px solid transparent;
+    font-size: 16px;
+    color: var(--pfe-broadcasted--link,#06c);
+    padding: 21px;
+    cursor: pointer;
+    
+    &:focus,
+    &:hover {
+      @include focus-styles(#000, 1px);
+    }
   }
 }
 
@@ -1121,12 +1151,6 @@ See mixin blocks before selectors that contain the selector name and the three l
 // @todo: login JS and demo example needs to be added
 [pfe-navigation-open-toggle^='log-in--open'] .pfe-navigation__all-red-hat-toggle pfe-icon {
   --pfe-icon--Color: #151515;
-}
-
-// mobile menu icon styles - make the plus sign an X
-// @todo: Wes to implement mobile menu button icons with CSS
-.pfe-navigation__menu-toggle pfe-icon[icon='web-icon-plus'] {
-  transform: rotate(-45deg);
 }
 
 // Animating CSS Icon for burger

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -226,6 +226,7 @@ See mixin blocks before selectors that contain the selector name and the three l
   max-height: calc(100vh - #{$menu-height});
   margin: 0;
   padding: 16px 32px;
+  overflow-x: hidden;
   overflow-y: auto;
   background: #fff;
   @include breakpoint('nav-expand') {

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -504,6 +504,22 @@ See mixin blocks before selectors that contain the selector name and the three l
   transform: translate(-4px, -12px);
   transition: border-color 0.25s;
 }
+// Back to menu icon
+@mixin pfe-navigation__back__before--mobile {
+  position: absolute;
+  top: 24px;
+  left: 35px;
+  right: auto;
+  display: block;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--pfe-broadcasted--link,#06c);
+  border-top: 0;
+  border-right: 0;
+  transform: rotate(45deg);
+  transform-origin: left top;
+}
+
 .pfe-navigation__menu-link--has-dropdown {
   &:before {
     @include pfe-navigation__menu-link__before--mobile;
@@ -1046,8 +1062,15 @@ See mixin blocks before selectors that contain the selector name and the three l
     border: 1px solid transparent;
     font-size: 16px;
     color: var(--pfe-broadcasted--link,#06c);
-    padding: 21px;
+    text-align: left;
+    padding: 21px 21px 21px 45px;
+    width: 100%;
     cursor: pointer;
+
+    &:before {
+      @include pfe-navigation__back__before--mobile;
+      content: '';
+    }
     
     &:focus,
     &:hover {


### PR DESCRIPTION
---
name: CPFED-3847 back to menu button
labels: "feature, ready for review"
---

## pfe-navigation

- added back to menu button feature inside of mobile all red hat menu
- added focus state management for back to menu button and added function for development to log focused element to console for debugging
- cleaned up some unneeded css
- added styles for back menu button
- updated some of the handlers to point to the original variable for the site switcher wrapper so that code was less redundant 
- added aria-hidden true for all red hat icon
- updated function for open attr function to also set the aria-controls id
- cleaned up inital state setting of aria attr for mobile menu and util buttons
- add overflow x hidden to mobile menu to make the all red hat menu not scrollable until you click on the all red hat toggle


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
