### PR TITLE
CI: Reduce when automerge tries to run for API overages

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,10 +6,6 @@ on:
   workflow_run:
     workflows: ["Build & test"]
     types: [completed]
-  pull_request_review:
-    types: [submitted]
-  pull_request:
-    types: [labeled, unlabeled, unlocked]
 
 jobs:
   try_to_merge:


### PR DESCRIPTION
Reduce how often the automerge script attempts to run by limiting its trigger events.

`API rate limit exceeded for installation ID 7180918. | Try to merge the PR if allowed: .github#L1`

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
