### PR TITLE
bug: updating pfe-button dependency to point at pfelement 1.0.0

### DIFF
--- a/elements/pfe-button/package.json
+++ b/elements/pfe-button/package.json
@@ -51,8 +51,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-sass": "1.0.0-prerelease.40",
-    "@patternfly/pfelement": "1.0.0-prerelease.39",
-    "gh-pages": "^2.2.0"
+    "@patternfly/pfelement": "^1.0.0"
   }
 }

--- a/elements/pfe-button/package.json
+++ b/elements/pfe-button/package.json
@@ -55,5 +55,5 @@
   },
   "devDependencies": {
     "@patternfly/pfe-sass": "^1.0.0"
-  },
+  }
 }

--- a/elements/pfe-button/package.json
+++ b/elements/pfe-button/package.json
@@ -52,5 +52,8 @@
   "license": "MIT",
   "dependencies": {
     "@patternfly/pfelement": "^1.0.0"
-  }
+  },
+  "devDependencies": {
+    "@patternfly/pfe-sass": "^1.0.0"
+  },
 }


### PR DESCRIPTION
Fixes #1228

## Component name

`pfe-button` had the `@patternfly/pfelement` dependency pointing to a prerelease version of `pfelement`. 


### Related issue

- (#1228) pfe-button dependency points to prereleases of pfelement

### What has changed and why
- The `pfelement` dependency in package.json has been updated to `"@patternfly/pfelement": "^1.0.0"`
- The dependencies for `pfe-sass` and `gh-pages` have been removed

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
