### PR TITLE
doc: Update contributing guidelines to emphasize issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To suggest a feature use the [feature request template](.github/ISSUE_TEMPLATE/f
 1. Check the [issue queue](https://github.com/patternfly/patternfly-elements/issues).  If your pull request does not map to an issue in the queue, please open a new issue and wait for the maintainers to reach out about prioritization.
 2. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
 3. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
-    > `git checkout -b feat-my-branch-name`
+    git checkout -b feat-my-branch-name
 4. Make your change, [add tests](https://patternfly.github.io/patternfly-elements/develop/step-3/), and make sure the automated testing passes.
 5. Push to your fork and [submit a pull request][pr].  Be sure to select from the available PR templates.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Review the documentation.
 - Follow the style/format of the existing code.
 - Write tests for your changes.
-- Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Keep your change as small and focused as possible; if there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Be responsive during code review, as much as possible.
 
 ## Resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,12 @@ To suggest a feature use the [feature request template](.github/ISSUE_TEMPLATE/f
 
 ## Submitting a pull request
 
-1. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
-2. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
+1. Ensure that there is an issue in the queue that describes what this code is solving for.
+2. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
+3. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
     > `git checkout -b feat-my-branch-name`
-3. Make your change, [add tests](https://patternfly.github.io/patternfly-elements/develop/step-3/), and make sure the automated testing passes.
-4. Push to your fork and [submit a pull request][pr].  Be sure to select from the available PR templates.
+4. Make your change, [add tests](https://patternfly.github.io/patternfly-elements/develop/step-3/), and make sure the automated testing passes.
+5. Push to your fork and [submit a pull request][pr].  Be sure to select from the available PR templates.
 
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To suggest a feature use the [feature request template](.github/ISSUE_TEMPLATE/f
 
 ## Submitting a pull request
 
-1. Check the [issue queue](https://github.com/patternfly/patternfly-elements/issues).  If your pull request does not map to an issue in the queue, please open a new issue and wait for the maintainers to reach out about prioritization.
+1. Check the [issue queue](https://github.com/patternfly/patternfly-elements/issues).  If your pull request does not map to an issue in the queue, please open a [new issue](https://github.com/patternfly/patternfly-elements/issues).
 2. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
 3. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
     git checkout -b feat-my-branch-name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,29 +5,11 @@
 [cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
 [doc]: https://patternfly.github.io/patternfly-elements/getting-started/
 
-
 Welcome Flyers!  We're so excited that you're considering contributing to PatternFly Elements, the web component implementation of the PatternFly design system.
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
 
 Please note that this project is released with a [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
-
-## Submitting a pull request
-
-1. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
-2. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
-    > `git checkout -b feat-my-branch-name`
-3. Make your change, [add tests](https://patternfly.github.io/patternfly-elements/develop/step-3/), and make sure the automated testing passes.
-4. Push to your fork and [submit a pull request][pr].  Be sure to select from the available PR templates.
-
-
-Here are a few things you can do that will increase the likelihood of your pull request being accepted:
-
-- Review the documentation.
-- Follow the style/format of the existing code.
-- Write tests for your changes.
-- Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
-- Be responsive during code review, as much as possible.
 
 ## Submitting an Issue
 
@@ -50,6 +32,22 @@ If you have a feature that you think would be a great addition to the project:
 
 To suggest a feature use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).
 
+## Submitting a pull request
+
+1. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
+2. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
+    > `git checkout -b feat-my-branch-name`
+3. Make your change, [add tests](https://patternfly.github.io/patternfly-elements/develop/step-3/), and make sure the automated testing passes.
+4. Push to your fork and [submit a pull request][pr].  Be sure to select from the available PR templates.
+
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Review the documentation.
+- Follow the style/format of the existing code.
+- Write tests for your changes.
+- Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Be responsive during code review, as much as possible.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To suggest a feature use the [feature request template](.github/ISSUE_TEMPLATE/f
 
 ## Submitting a pull request
 
-1. Ensure that there is an issue in the queue that describes what this code is solving for.
+1. Check the [issue queue](https://github.com/patternfly/patternfly-elements/issues).  If your pull request does not map to an issue in the queue, please open a new issue and wait for the maintainers to reach out about prioritization.
 2. [Fork][fork] and clone the repository (see the Quick start in the [README][README.md])
 3. Create a new branch.  Please use the [conventional commit](cc) formatting for the branch name.
     > `git checkout -b feat-my-branch-name`


### PR DESCRIPTION
Emphasize opening an issue in the contribution guidelines over opening a PR.  This is so we can prioritize issues before coding has been done.