### PR TITLE
Cpfed 3851 keyboard trap all redhat menu

### DIFF
--- a/elements/pfe-navigation/demo/index.html
+++ b/elements/pfe-navigation/demo/index.html
@@ -415,22 +415,22 @@
         </li>
       </ul>
 
-      <li slot="pfe-navigation--custom-links">
+      <div slot="pfe-navigation--custom-links">
         <a href="#">
           <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
-      </li>
-      <li slot="pfe-navigation--custom-links">
+      </div>
+      <div slot="pfe-navigation--custom-links">
         <pfe-navigation-dropdown pfe-width="single" pfe-icon="web-cart" pfe-name="Cart" pfe-alerts="1">
           <h2>This is pfe-navigation-dropdown</h2>
           <pfe-cta pfe-priority="primary">
             <a href="#">Learn more about PFElements</a>
           </pfe-cta>
         </pfe-navigation-dropdown>
-      </li>
+      </div>
 
-      <li slot="pfe-navigation--custom-links">
+      <div slot="pfe-navigation--custom-links">
         <pfe-navigation-dropdown pfe-width="full" pfe-icon="web-globe" pfe-name="Language">
           <div class="language-picker">
             <h3>Select a language</h3>
@@ -483,7 +483,8 @@
             </ul>
           </div>
         </pfe-navigation-dropdown>
-      </li>
+      </div>
+
 
       <div slot="pfe-navigation--search" class="pfe-navigation__search pfe-navigation__search--default-styles">
       <!-- @todo: move form and label for="" and label id into shadow DOM -->

--- a/elements/pfe-navigation/demo/index_react.html
+++ b/elements/pfe-navigation/demo/index_react.html
@@ -262,18 +262,18 @@
             </li>
           </ul>
 
-          <li slot="pfe-navigation--custom-links">
+          <div slot="pfe-navigation--custom-links">
             <a href="#">
               <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
               Custom Link
             </a>
-          </li>
-          <li slot="pfe-navigation--custom-links">
+          </div>
+          <div slot="pfe-navigation--custom-links">
             <button>
               <pfe-icon icon="web-cart" pfe-size="md" aria-hidden="true"></pfe-icon>
               Cart
             </button>
-          </li>
+          </div>
 
           <div slot="pfe-navigation--search" className="pfe-navigation__search pfe-navigation__search--default-styles">
             <form>

--- a/elements/pfe-navigation/demo/index_vue.html
+++ b/elements/pfe-navigation/demo/index_vue.html
@@ -271,18 +271,18 @@
             </li>
           </ul>
 
-          <li slot="pfe-navigation--custom-links">
+          <div slot="pfe-navigation--custom-links">
             <a href="#">
               <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
               Custom Link
             </a>
-          </li>
-          <li slot="pfe-navigation--custom-links">
+          </div>
+          <div slot="pfe-navigation--custom-links">
             <button>
               <pfe-icon icon="web-cart" pfe-size="md" aria-hidden="true"></pfe-icon>
               Cart
             </button>
-          </li>
+          </div>
 
           <div slot="pfe-navigation--search" class="pfe-navigation__search pfe-navigation__search--default-styles">
           <!-- @todo: move form and label for="" and label id into shadow DOM -->

--- a/elements/pfe-navigation/demo/single-nav-sticky.html
+++ b/elements/pfe-navigation/demo/single-nav-sticky.html
@@ -72,7 +72,7 @@
                       </div>
                       <div id="rhel-collapsed-links" class="rhel-links col-12 col-sm-3 mb-2 mb-sm-0 justify-content-sm-end align-items-center d-flex">
                           <p class="my-0 font-size-16">
-                              <a href="#" class="rhel-toggle text-nowrap pr-2">Learn more<span class="font-weight-bold font-size-20 position-absolute ml-1">&gt;</span></a>
+                              <a href="#" class="rhel-toggle text-nowrap pr-2">Learn more<span class="font-weight-bold font-size-20 position-absolute ml-1" aria-hidden="true">&gt;</span></a>
                           </p>
                       </div>
                       <div id="rhel-expanded-links" class="rhel-links col-12 col-sm-4 mb-2 mb-sm-0 justify-content-sm-end align-items-center text-nowrap d-none">

--- a/elements/pfe-navigation/demo/single-nav-sticky.html
+++ b/elements/pfe-navigation/demo/single-nav-sticky.html
@@ -505,12 +505,12 @@
           </form>
       </div>
 
-      <li slot="pfe-navigation--custom-links">
+      <div slot="pfe-navigation--custom-links">
         <a href="#">
           <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
-      </li>
+      </div>
 
     </pfe-navigation>
 

--- a/elements/pfe-navigation/demo/single-nav-sticky.html
+++ b/elements/pfe-navigation/demo/single-nav-sticky.html
@@ -62,11 +62,11 @@
               <div class="container">
                   <div class="row justify-items-between d-flex" id="rhel-header">
                       <div id="rhel-collapsed-title" class="col-12 py-1 py-lg-2 col-sm-9 d-flex align-items-center">
-                          <h4 class="m-0 mr-2 text-nowrap text-uppercase font-weight-bold">Red Hat Insights</h4>
+                          <h2 class="m-0 mr-2 text-nowrap text-uppercase font-weight-bold">Red Hat Insights</h2>
                           <p class="d-none d-lg-block border-left mb-0 pl-2 font-size-14">Your organization is using Insights to manage Red Hat Enterprise Linux!<br>Find out how to get even more value.</p>
                       </div>
                       <div id="rhel-expanded-title" class="d-none py-1 mt-0 col-8 align-items-center">
-                          <h4 class="m-0 mr-2 text-nowrap text-uppercase font-weight-bold">Red Hat Insights</h4>
+                          <h2 class="m-0 mr-2 text-nowrap text-uppercase font-weight-bold">Red Hat Insights</h2>
                           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="rhel-insights-logo">
                           <path d="M29 10.77a.76.76 0 0 0 .75-.75V7a.75.75 0 0 0-.75-.73H7a.74.74 0 0 0-.75.73v14a.75.75 0 0 0 1.5 0V7.77h20.5V10a.75.75 0 0 0 .75.77zM7 26.27a.74.74 0 0 0-.75.75v2a.75.75 0 0 0 .75.75h22a.76.76 0 0 0 .75-.75V17a.75.75 0 1 0-1.5 0v11.27H7.75V27a.75.75 0 0 0-.75-.73z"/><path d="M30.47 10.87l-12 11.84-5-5a.74.74 0 0 0-1.05 0l-6.95 6.77A.75.75 0 0 0 6 25.77a.74.74 0 0 0 .52-.22l6.41-6.29 5 5a.75.75 0 0 0 1.06 0l12.5-12.36a.75.75 0 0 0 0-1.06.75.75 0 0 0-1.02.03zM11.25 10v4a.75.75 0 0 0 1.5 0v-4a.75.75 0 0 0-1.5 0z"/><path d="M17.25 10v8a.75.75 0 0 0 1.5 0v-8a.75.75 0 0 0-1.5 0zM23.25 10v4a.75.75 0 0 0 1.5 0v-4a.75.75 0 1 0-1.5 0z"/></svg>
                       </div>

--- a/elements/pfe-navigation/demo/single-nav.html
+++ b/elements/pfe-navigation/demo/single-nav.html
@@ -393,12 +393,12 @@
         </li>
       </ul>
 
-      <li slot="pfe-navigation--custom-links">
+      <div slot="pfe-navigation--custom-links">
         <a href="#">
           <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
-      </li>
+      </div>
 
       <div slot="pfe-navigation--search" class="pfe-navigation__search pfe-navigation__search--default-styles">
       <!-- @todo: move form and label for="" and label id into shadow DOM -->

--- a/elements/pfe-navigation/demo/variations.html
+++ b/elements/pfe-navigation/demo/variations.html
@@ -311,18 +311,18 @@
         </li>
       </ul>
 
-      <li slot="pfe-navigation--custom-links">
+      <div slot="pfe-navigation--custom-links">
         <a href="#">
           <pfe-icon icon="web-icon-globe" pfe-size="md" aria-hidden="true"></pfe-icon>
           Custom Link
         </a>
-      </li>
-      <li slot="pfe-navigation--custom-links">
+      </div>
+      <div slot="pfe-navigation--custom-links">
         <button>
           <pfe-icon icon="web-cart" pfe-size="md" aria-hidden="true"></pfe-icon>
           Cart
         </button>
-      </li>
+      </div>
 
       <div slot="pfe-navigation--search" class="pfe-navigation__search pfe-navigation__search--default-styles">
       <!-- @todo: move form and label for="" and label id into shadow DOM -->

--- a/elements/pfe-navigation/mock/site-switcher.html
+++ b/elements/pfe-navigation/mock/site-switcher.html
@@ -66,7 +66,7 @@
                       </ul>
                       <!-- -->
 
-                      <hr>
+                      <hr aria-hidden="true">
 
                       <ul class="site-switcher-secondary-list">
                         <li>

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -102,6 +102,7 @@ $gutter: pfe-local(gutter);
 @mixin focus-styles($border-color, $border-top-size) {
   border: 1px dashed $border-color;
   border-top: $border-top-size dashed $border-color;
+  border-radius: 0;
   outline: 0;
 }
 
@@ -119,6 +120,7 @@ $gutter: pfe-local(gutter);
     left:0;
     display: block;
     border: 1px dashed $border-color;
+    border-radius: 0;
     @if not $show-border-top {
       border-top: none;
     }
@@ -156,21 +158,6 @@ $gutter: pfe-local(gutter);
   padding: 0 32px;
 }
 
-
-@mixin pfe-navigation__logo-link {
-  display: block;
-  padding: 6px 8px;
-  margin-left: -8px; // Should be flush left with container
-
-  // avoid jumpiness from focus/hover styles
-  border: 1px solid transparent;
-
-  // focus styles
-  &:focus {
-    @include alt-focus-styles(#fff, #e00);
-  }
-}
-
 @mixin pfe-navigation__logo-wrapper {
   display: flex;
   align-items: center;
@@ -179,7 +166,6 @@ $gutter: pfe-local(gutter);
   padding: 10px 16px 10px 0;
 }
 
-// @todo: determine why the ..__logo-link style block is present twice, remove if duplicate is merge accident
 @mixin pfe-navigation__logo-link {
   position: relative;
   display: block;
@@ -192,7 +178,6 @@ $gutter: pfe-local(gutter);
   border: 1px solid transparent;
 
   // focus styles
-  transition: box-shadow 0.2s;
   &:focus {
     @include focus-styles(#fff, 1px);
   }

--- a/elements/pfe-navigation/src/_variables-mixins.scss
+++ b/elements/pfe-navigation/src/_variables-mixins.scss
@@ -272,26 +272,14 @@ $gutter: pfe-local(gutter);
     }
   }
 
-  &:hover,
-  &:focus {
+  &:focus,
+  &:hover {
     box-shadow: inset 4px 0 0 0 #e00;
     @include breakpoint(#{$menu-name + '-expand'}) {
       box-shadow: inset 0 4px 0 0 #e00;
     }
     @include collapse($menu-name) {
       box-shadow: inset 4px 0 0 0 #e00;
-    }
-  }
-
-  // focus styles
-  &:focus {
-    @include alt-focus-styles(#000, #e00, true);
-
-    @include breakpoint(#{$menu-name + '-expand'}) {
-      @include alt-focus-styles(#fff, #e00);
-    }
-    @include collapse('secondary-nav') {
-      @include alt-focus-styles(#000, #e00, true);
     }
   }
 

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -1,4 +1,4 @@
-<div id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
+<nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
   <!-- @todo: make sure all icons are the updated redesigned versions -->
 
   <button class="pfe-navigation__menu-toggle" id="mobile__button">
@@ -12,11 +12,11 @@
       <!-- Placeholder to move search form at mobile breakpoint to maintain tab order -->
       <div id="pfe-navigation__search-wrapper--xs"></div>
 
-      <nav id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
-      </nav>
+      <div id="pfe-navigation__menu-wrapper" class="pfe-navigation__menu-wrapper">
+      </div>
 
-      <ul class="pfe-navigation__secondary-links-wrapper" id="pfe-navigation__secondary-links-wrapper">
-        <li>
+      <div class="pfe-navigation__secondary-links-wrapper" id="pfe-navigation__secondary-links-wrapper">
+        <div>
           <button class="pfe-navigation__search-toggle" id="secondary-links__button--search">
             <pfe-icon icon="web-search" pfe-size="sm" aria-hidden="true"></pfe-icon>
             Search
@@ -25,8 +25,8 @@
             <slot name="pfe-navigation--search" class="pfe-navigation__search" id="search-slot">
             </slot>
           </div>
-        </li>
-        <li>
+        </div>
+        <div>
           <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat" aria-label="Open All Red Hat menu">
             <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
             All Red Hat
@@ -34,6 +34,7 @@
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
             <div class="pfe-navigation__all-red-hat-toggle--back-wrapper">
               <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Close All Red Hat menu and return to main menu">Back to menu</button>
+              <h2 class="sr-only">All Red Hat menu</h2>
             </div>
 
             <div class="pfe-navigation__all-red-hat-wrapper__inner">
@@ -42,13 +43,11 @@
               </div>
             </div>
           </div>
-        </li>
+        </div>
 
         <slot name="pfe-navigation--custom-links" id="pfe-navigation--custom-links"></slot>
 
-      </ul>
-
-      </ul>
+      </div>
     </div>
   </div>
 
@@ -57,5 +56,5 @@
     Log In
   </a>
 
-</div>
+</nav>
 <div class="pfe-navigation__overlay" hidden></div>

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -27,13 +27,13 @@
           </div>
         </li>
         <li>
-          <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat">
+          <button class="pfe-navigation__all-red-hat-toggle" id="secondary-links__button--all-red-hat" aria-label="Open All Red Hat menu">
             <pfe-icon icon="web-icon-grid-3x3" pfe-size="sm" aria-hidden="true"></pfe-icon>
             All Red Hat
           </button>
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
             <div class="pfe-navigation__all-red-hat-toggle--back-wrapper">
-              <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Close and return to previous menu">Back to menu</button>
+              <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Close All Red Hat menu and return to main menu">Back to menu</button>
             </div>
 
             <div class="pfe-navigation__all-red-hat-wrapper__inner">

--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -33,7 +33,7 @@
           </button>
           <div class="pfe-navigation__all-red-hat-wrapper" id="secondary-links__dropdown--all-red-hat">
             <div class="pfe-navigation__all-red-hat-toggle--back-wrapper">
-              <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Back to main menu">Back to menu</button>
+              <button id="pfe-navigation__all-red-hat-toggle--back" aria-label="Close and return to previous menu">Back to menu</button>
             </div>
 
             <div class="pfe-navigation__all-red-hat-wrapper__inner">

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -105,7 +105,7 @@ class PfeNavigation extends PFElement {
     this._mobileNavSearchSlot = this.shadowRoot.querySelector('slot[name="pfe-navigation--search"]');
     this._siteSwitchLoadingIndicator = this.shadowRoot.querySelector("#site-loading");
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
-    this._pfeNav = this;
+    this._shadowNavWrapper = this.shadowRoot.querySelector(`.${this.tag}__wrapper`);
     this._focusableElements = null;
     this._focusableNavContent = null;
     this._lastFocusableNavElement = null;
@@ -208,10 +208,8 @@ class PfeNavigation extends PFElement {
       });
     }
 
-    // Only run if mobile site switcher is null (md and up breakpoints)
-
     // Get last focusable element for nav
-    this._getLastFocusableElement(this._pfeNav);
+    this._getLastFocusableElement(this._shadowNavWrapper);
     // Tab key listener attached to the last focusable element in the component
     this._lastFocusableNavElement.addEventListener("keydown", this._a11yCloseAllMenus);
 
@@ -234,10 +232,8 @@ class PfeNavigation extends PFElement {
     this._allRedHatToggleBack.removeEventListener("click", this._allRedHatToggleBackClickHandler);
     this.removeEventListener("keydown", this._generalKeyboardListener);
 
-    if (this._siteSwitcherMobileOnly === null) {
-      this._getLastFocusableElement(this._pfeNav);
-      this._lastFocusableNavElement.removeEventListener("keydown", this._a11yCloseAllMenus);
-    }
+    this._getLastFocusableElement(this._shadowNavWrapper);
+    this._lastFocusableNavElement.removeEventListener("keydown", this._a11yCloseAllMenus);
 
     if (this._siteSwitcherMobileOnly !== null) {
       this._siteSwitcherMobileOnly.removeEventListener("keydown", this._siteSwitcherFocusHandler);
@@ -1443,7 +1439,6 @@ class PfeNavigation extends PFElement {
 
     // Get tab key
     if (key === "Tab") {
-      console.log(`${event.key}`);
       // Ignore shift + tab
       if (event.shiftKey) {
         return false;
@@ -1481,19 +1476,14 @@ class PfeNavigation extends PFElement {
         this._lastFocusElementSiteSwitcher = this._siteSwitcherFocusElements[
           this._siteSwitcherFocusElements.length - 1
         ];
-
-        console.log("Site Switcher");
         return this._lastFocusElementSiteSwitcher;
       }
 
       // Check if nav region is the main menu
-    } else if (navRegion === this._pfeNav && this._siteSwitcherMobileOnly === null) {
+    } else if (navRegion === this._shadowNavWrapper) {
       this._focusableNavContent = this.shadowRoot.querySelectorAll(this._focusableElements);
       // Get the last focusable elements of Nav and All Red Hat sub menu
       this._lastFocusableNavElement = this._focusableNavContent[this._focusableNavContent.length - 1];
-
-      console.log("Main Nav");
-      console.log(this._pfeNav);
       return this._lastFocusableNavElement;
     }
   }
@@ -1511,7 +1501,6 @@ class PfeNavigation extends PFElement {
       if (this._siteSwitcherMobileOnly !== null) {
         // Get tab key
         if (key === "Tab") {
-          console.log(`${event.key}`);
           // Ignore shift + tab
           if (event.shiftKey) {
             return;
@@ -1521,7 +1510,6 @@ class PfeNavigation extends PFElement {
               this._lastFocusElementSiteSwitcher.addEventListener("blur", () => {
                 // if this is the mobile menu and the All Red Hat Toggle is clicked set focus to Back to Menu Button inside of All Red Hat Menu
                 this._allRedHatToggleBack.focus();
-                console.log(this._allRedHatToggleBack);
               });
             } else {
               return;
@@ -1625,7 +1613,6 @@ class PfeNavigation extends PFElement {
           // Get last focusable element ONLY if mobile site switcher is NOT null
           if (this._siteSwitcherMobileOnly !== null) {
             this._getLastFocusableElement(this._siteSwitcherMenu);
-            console.log(this._lastFocusElementSiteSwitcher);
           }
         }
       };

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -105,11 +105,15 @@ class PfeNavigation extends PFElement {
     this._mobileNavSearchSlot = this.shadowRoot.querySelector('slot[name="pfe-navigation--search"]');
     this._siteSwitchLoadingIndicator = this.shadowRoot.querySelector("#site-loading");
     this._overlay = this.shadowRoot.querySelector(`.${this.tag}__overlay`);
+    this._menuLg = this.shadowRoot.querySelector(`${this.tag}-wrapper`);
     // Get all focusable elements inside of nav
-    this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-    this._focusableNavContent = this.shadowRoot.querySelectorAll(this._focusableElements);
-    // Get the last focusable elements of Nav and All Red Hat sub menu
-    this._lastFocusableNavElement = this._focusableNavContent[this._focusableNavContent.length - 1];
+    // this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    this._focusableElements = null;
+    // this._focusableNavContent = this.shadowRoot.querySelectorAll(this._focusableElements);
+    this._focusableNavContent = null;
+    // // Get the last focusable elements of Nav and All Red Hat sub menu
+    // this._lastFocusableNavElement = this._focusableNavContent[this._focusableNavContent.length - 1];
+    this._lastFocusableNavElement = null;
 
     // Set default breakpoints to null (falls back to CSS)
     this.menuBreakpoints = {
@@ -153,6 +157,7 @@ class PfeNavigation extends PFElement {
     this._overlayClickHandler = this._overlayClickHandler.bind(this);
     this._tabKeyEventListener = this._tabKeyEventListener.bind(this);
     this._stickyHandler = this._stickyHandler.bind(this);
+    this._getLastFocusableElement = this._getLastFocusableElement.bind(this);
     this._siteSwitcherFocusHandler = this._siteSwitcherFocusHandler.bind(this);
     this._hideMobileMainMenuSr = this._hideMobileMainMenuSr.bind(this);
     this._showMobileMainMenuSr = this._showMobileMainMenuSr.bind(this);
@@ -208,7 +213,9 @@ class PfeNavigation extends PFElement {
       });
     }
 
+    this._getLastFocusableElement(this._menuLg);
     // Tab key listener attached to the last focusable element in the component
+    // @todo (KS): figure out how to pass last focusable nav value to this var from getFocusableElements()
     this._lastFocusableNavElement.addEventListener("keydown", this._tabKeyEventListener);
 
     if (this._siteSwitcherMobileOnly === null) {
@@ -230,14 +237,14 @@ class PfeNavigation extends PFElement {
     this._allRedHatToggle.removeEventListener("click", this._toggleAllRedHat);
     this._allRedHatToggleBack.removeEventListener("click", this._allRedHatToggleBackClickHandler);
     this.removeEventListener("keydown", this._generalKeyboardListener);
-    this._lastFocusableNavElement.removeEventListener("keydown", this._tabKeyEventListener);
+    // this._lastFocusableNavElement.removeEventListener("keydown", this._tabKeyEventListener);
 
-    if (this._siteSwitcherMobileOnly === null) {
-      return;
-    } else {
-      // Key listener attached to the last focusable element in the mobile site switcher menu
-      this._siteSwitcherMobileOnly.removeEventListener("keydown", this._siteSwitcherFocusHandler);
-    }
+    // if (this._siteSwitcherMobileOnly === null) {
+    //   return;
+    // } else {
+    //   // Key listener attached to the last focusable element in the mobile site switcher menu
+    //   this._siteSwitcherMobileOnly.removeEventListener("keydown", this._siteSwitcherFocusHandler);
+    // }
 
     if (this.hasAttribute("pfe-sticky") && this.getAttribute("pfe-sticky") != "false") {
       window.removeEventListener("scroll", () => {
@@ -1284,7 +1291,7 @@ class PfeNavigation extends PFElement {
     this._wasSecondaryLinksSectionCollapsed = isSecondaryLinksSectionCollapsed;
 
     if (this._siteSwitcherMobileOnly === null) {
-      this._showMobileMainMenuSr();
+      // this._showMobileMainMenuSr();
       return;
     } else {
       // Key listener attached to the last focusable element in the mobile site switcher menu
@@ -1299,10 +1306,10 @@ class PfeNavigation extends PFElement {
     if (!this.isOpen("mobile__button")) {
       this._changeNavigationState("mobile__button", "open");
       // Show main menu when All Red Hat menu is closed
-      this._showMobileMainMenuSr();
+      // this._showMobileMainMenuSr();
     } else {
       this._changeNavigationState("mobile__button", "close");
-      this._hideMobileMainMenuSr();
+      // this._hideMobileMainMenuSr();
     }
   }
 
@@ -1316,10 +1323,10 @@ class PfeNavigation extends PFElement {
     this._changeNavigationState("secondary-links__button--all-red-hat");
     if (this.isOpen("mobile__button")) {
       // Hide mobile main menu when All Red Hat menu is open
-      this._hideMobileMainMenuSr();
+      // this._hideMobileMainMenuSr();
       this._allRedHatToggleBack.focus();
     } else {
-      this._showMobileMainMenuSr();
+      // this._showMobileMainMenuSr();
     }
   }
 
@@ -1456,6 +1463,39 @@ class PfeNavigation extends PFElement {
   }
 
   /**
+   * Get Last Focusable Element Handler
+   * Get all focusable elements then find the last focusable element
+   */
+  _getLastFocusableElement(navRegion) {
+    // Store all focusable elements inside variable
+    this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    // Logic switch for Site Switcher nav versus main nav
+    if (navRegion === this._siteSwitcherMenu) {
+      // Site Switcher
+      if (this._siteSwitcherMobileOnly !== null) {
+        // Store all focusable elements inside of site switcher menu inside variable
+        this._siteSwitcherFocusElements = this._siteSwitcherMobileOnly.querySelectorAll(this._focusableElements);
+        // Store the last focusable element for site switcher menu inside variable
+        this._lastFocusElementSiteSwitcher = this._siteSwitcherFocusElements[
+          this._siteSwitcherFocusElements.length - 1
+        ];
+
+        console.log("Site Switcher");
+        console.log(this._lastFocusElementSiteSwitcher);
+        return this._lastFocusElementSiteSwitcher;
+      }
+    } else if (navRegion === this._menuLg && this._siteSwitcherMobileOnly === null) {
+      this._focusableNavContent = this.shadowRoot.querySelectorAll(this._focusableElements);
+      // Get the last focusable elements of Nav and All Red Hat sub menu
+      this._lastFocusableNavElement = this._focusableNavContent[this._focusableNavContent.length - 1];
+
+      console.log("Main Nav");
+      console.log(this._lastFocusableNavElement);
+      return this._lastFocusableNavElement;
+    }
+  }
+
+  /**
    * Mobile site-switcher Focus Handler
    * Get last focusable element of site-switcher menu
    * When last focusable element loses focus send focus to back to menu button
@@ -1470,14 +1510,18 @@ class PfeNavigation extends PFElement {
       if (this._siteSwitcherMenu === null) {
         return;
       } else {
-        // Store all focusable elements inside variable
-        this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-        // Store all focusable elements inside of site switcher menu inside variable
-        this._siteSwitcherFocusElements = this._siteSwitcherMobileOnly.querySelectorAll(this._focusableElements);
-        // Store the last focusable element for site switcher menu inside variable
-        this._lastFocusElementSiteSwitcher = this._siteSwitcherFocusElements[
-          this._siteSwitcherFocusElements.length - 1
-        ];
+        // // Store all focusable elements inside variable
+        // this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+        // // Store all focusable elements inside of site switcher menu inside variable
+        // this._siteSwitcherFocusElements = this._siteSwitcherMobileOnly.querySelectorAll(this._focusableElements);
+        // // Store the last focusable element for site switcher menu inside variable
+        // this._lastFocusElementSiteSwitcher = this._siteSwitcherFocusElements[
+        //   this._siteSwitcherFocusElements.length - 1
+        // ];
+
+        // fire getFocusableElements here
+        // getFocusableElements()
+        // this._getLastFocusableElement(this._siteSwitcherMenu);
 
         // Get tab key
         if (charCode === 9) {
@@ -1500,6 +1544,7 @@ class PfeNavigation extends PFElement {
         }
       }
     }
+    console.log("Last Item Site Switcher Mobile");
   }
 
   /**
@@ -1588,6 +1633,7 @@ class PfeNavigation extends PFElement {
           this._siteSwitcherWrapper.innerHTML = xhr.responseText;
           // Store site switcher content in variable - All Red Hat menu
           this._siteSwitcherMenu = this.shadowRoot.querySelector("#site-switcher");
+          this._getLastFocusableElement(this._siteSwitcherMenu);
         }
       };
 

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -207,17 +207,6 @@ class PfeNavigation extends PFElement {
         });
       });
     }
-
-    // Get last focusable element for nav
-    this._a11yGetLastFocusableElement(this._shadowNavWrapper);
-    // Tab key listener attached to the last focusable element in the component
-    this._lastFocusableNavElement.addEventListener("keydown", this._a11yCloseAllMenus);
-
-    // Only run if mobile site switcher is NOT null (mobile - md breakpoints)
-    if (this._siteSwitcherMobileOnly !== null) {
-      // Key listener attached to the last focusable element in the mobile site switcher menu
-      this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
-    }
   } // end connectedCallback()
 
   disconnectedCallback() {
@@ -1077,6 +1066,22 @@ class PfeNavigation extends PFElement {
       this._observer.observe(this, lightDomObserverConfig);
     }
 
+    /**
+     *  A11y adjustments for screem readers and keyboards
+     **/
+    // Get last focusable element for nav
+    this._a11yGetLastFocusableElement(this._shadowNavWrapper);
+    // Tab key listener attached to the last focusable element in the component
+    this._lastFocusableNavElement.addEventListener("keydown", this._a11yCloseAllMenus);
+    console.log(this._lastFocusableNavElement);
+
+    // Only run if mobile site switcher is NOT null (mobile - md breakpoints)
+    if (this._siteSwitcherMobileOnly !== null) {
+      // Key listener attached to the last focusable element in the mobile site switcher menu
+      this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
+      console.log(this._siteSwitcherMobileOnly);
+    }
+
     // Timeout lets these run a little later
     window.setTimeout(this._addMenuBreakpoints, 0);
 
@@ -1088,7 +1093,7 @@ class PfeNavigation extends PFElement {
     };
 
     window.setTimeout(postProcessLightDom, 10);
-  }
+  } // end _processLightDom()
 
   /**
    * Behavior for main menu breakpoint
@@ -1283,15 +1288,20 @@ class PfeNavigation extends PFElement {
     this._wasMobileMenuButtonVisible = isMobileMenuButtonVisible;
     this._wasSecondaryLinksSectionCollapsed = isSecondaryLinksSectionCollapsed;
 
-    // @todo: (KS) fix this based on PR feedback
-    // if (this._siteSwitcherMobileOnly === null) {
-    //   // this._a11yShowMobileMainMenu();
-    //   return;
-    // } else {
-    //   // Key listener attached to the last focusable element in the mobile site switcher menu
-    //   this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
-    // }
-  }
+    /**
+     *  A11y adjustments for screem readers and keyboards
+     **/
+    // Get last focusable element for nav
+    this._a11yGetLastFocusableElement(this._shadowNavWrapper);
+    // Tab key listener attached to the last focusable element in the component
+    this._lastFocusableNavElement.addEventListener("keydown", this._a11yCloseAllMenus);
+
+    // Only run if mobile site switcher is NOT null (mobile - md breakpoints)
+    if (this._siteSwitcherMobileOnly !== null) {
+      // Key listener attached to the last focusable element in the mobile site switcher menu
+      this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
+    }
+  } // end _postResizeAdjustments()
 
   /**
    * Event listeners for toggles
@@ -1303,8 +1313,9 @@ class PfeNavigation extends PFElement {
       this._a11yShowMobileMainMenu();
     } else {
       this._changeNavigationState("mobile__button", "close");
+      // @todo: (KS) decide if I need this (i do not think so rn)
       // Hide main menu when mobile All Red Hat menu is open
-      this._a11yHideMobileMainMenu();
+      // this._a11yHideMobileMainMenu();
     }
   }
 
@@ -1527,75 +1538,29 @@ class PfeNavigation extends PFElement {
   /**
    * Hide main menu from screen readers and keyboard when mobile All Red Hat menu is open
    */
-  // @todo: (KS) fix this based on PR feedback
   _a11yHideMobileMainMenu() {
-    const shadowMainMenu = this.shadowRoot.getElementById("pfe-navigation__menu");
-    console.log(shadowMainMenu);
+    // Search
+    this._searchSpotXs.setAttribute("hidden", "");
 
-    shadowMainMenu.setAttribute("aria-hidden", "true");
-    shadowMainMenu.setAttribute("tabindex", "-1");
-    shadowMainMenu.setAttribute("hidden", "");
+    // Main menu
+    this._menuDropdownMd.setAttribute("hidden", "");
 
-    // this._searchSpotXs.setAttribute("aria-hidden", "true");
-    // this._menuDropdownMd.setAttribute("aria-hidden", "true");
-    // this._searchToggle.setAttribute("aria-hidden", "true");
-    // this._searchSpotMd.setAttribute("aria-hidden", "true");
-    // this._mobileNavSearchSlot.setAttribute("aria-hidden", "true");
-    // this._allRedHatToggle.setAttribute("aria-hidden", "true");
-    // this._customLinksSlot.setAttribute("aria-hidden", "true");
-
-    // this._searchSpotXs.setAttribute("tabindex", "-1");
-    // this._menuDropdownMd.setAttribute("tabindex", "-1");
-    // this._searchToggle.setAttribute("tabindex", "-1");
-    // this._searchSpotMd.setAttribute("tabindex", "-1");
-    // this._mobileNavSearchSlot.setAttribute("tabindex", "-1");
-    // this._allRedHatToggle.setAttribute("tabindex", "-1");
-    // this._customLinksSlot.setAttribute("tabindex", "-1");
-
-    // this._searchSpotXs.setAttribute("hidden", "");
-    // this._menuDropdownMd.setAttribute("hidden", "");
-    // this._searchToggle.setAttribute("hidden", "");
-    // this._searchSpotMd.setAttribute("hidden", "");
-    // this._mobileNavSearchSlot.setAttribute("hidden", "");
-    // this._allRedHatToggle.setAttribute("hidden", "");
-    // this._customLinksSlot.setAttribute("hidden", "");
+    // All Red Hat Toggle
+    this._allRedHatToggle.setAttribute("hidden", "");
   }
 
   /**
    * Show main menu to screen readers and keyboard users when Back to main menu button is pressed
    */
-  // @todo: (KS) fix this based on PR feedback
   _a11yShowMobileMainMenu() {
-    const shadowMainMenu = this.shadowRoot.getElementById("pfe-navigation__menu");
-    console.log(shadowMainMenu);
+    // Search
+    this._searchSpotXs.removeAttribute("hidden", "");
 
-    shadowMainMenu.removeAttribute("aria-hidden", "true");
-    shadowMainMenu.removeAttribute("tabindex", "-1");
-    shadowMainMenu.removeAttribute("hidden", "");
+    // Main menu
+    this._menuDropdownMd.removeAttribute("hidden", "");
 
-    // this._searchSpotXs.removeAttribute("aria-hidden", "true");
-    // this._menuDropdownMd.removeAttribute("aria-hidden", "true");
-    // this._searchToggle.removeAttribute("aria-hidden", "true");
-    // this._searchSpotMd.removeAttribute("aria-hidden", "true");
-    // this._mobileNavSearchSlot.removeAttribute("aria-hidden", "true");
-    // this._allRedHatToggle.removeAttribute("aria-hidden", "true");
-    // this._customLinksSlot.removeAttribute("aria-hidden", "true");
-
-    // this._searchSpotXs.removeAttribute("tabindex");
-    // this._menuDropdownMd.removeAttribute("tabindex");
-    // this._searchToggle.removeAttribute("tabindex");
-    // this._searchSpotMd.removeAttribute("tabindex");
-    // this._mobileNavSearchSlot.removeAttribute("tabindex");
-    // this._allRedHatToggle.removeAttribute("tabindex");
-    // this._customLinksSlot.removeAttribute("tabindex");
-
-    // this._searchSpotXs.removeAttribute("hidden", "");
-    // this._menuDropdownMd.removeAttribute("hidden", "");
-    // this._searchToggle.removeAttribute("hidden", "");
-    // this._searchSpotMd.removeAttribute("hidden", "");
-    // this._mobileNavSearchSlot.removeAttribute("hidden", "");
-    // this._allRedHatToggle.removeAttribute("hidden", "");
-    // this._customLinksSlot.removeAttribute("hidden", "");
+    // All Red Hat Toggle
+    this._allRedHatToggle.removeAttribute("hidden", "");
   }
 
   /**

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -153,6 +153,7 @@ class PfeNavigation extends PFElement {
     this._tabKeyEventListener = this._tabKeyEventListener.bind(this);
     this._stickyHandler = this._stickyHandler.bind(this);
     this._siteSwitcherFocusHandler = this._siteSwitcherFocusHandler.bind(this);
+    this._hideMobileMainMenu = this._hideMobileMainMenu.bind(this);
 
     // Handle updates to slotted search content
     this._searchSlot.addEventListener("slotchange", this._processSearchSlotChange);
@@ -229,6 +230,7 @@ class PfeNavigation extends PFElement {
     this._allRedHatToggleBack.removeEventListener("click", this._allRedHatToggleBackClickHandler);
     this.removeEventListener("keydown", this._generalKeyboardListener);
     this._lastFocusableNavElement.removeEventListener("keydown", this._tabKeyEventListener);
+    this._allRedHatToggle.removeEventListener("click", this._hideMobileMainMenu);
 
     if (this._siteSwitcherMobileOnly === null) {
       return;
@@ -1294,6 +1296,9 @@ class PfeNavigation extends PFElement {
       // if this is the mobile menu and the All Red Hat Toggle is clicked set focus to Back to Menu Button inside of All Red Hat Menu
       this._allRedHatToggleBack.focus();
     }
+
+    // Hide mobile main menu when All Red Hat menu is open
+    this._hideMobileMainMenu();
   }
 
   _dropdownItemToggle(event) {
@@ -1353,10 +1358,14 @@ class PfeNavigation extends PFElement {
   /**
    * Back to Menu Event Handler
    * close All Red Hat Menu and go back to Main Mobile Menu and set focus back to All Red Hat Toggle
+   * Show main menu
    */
   _allRedHatToggleBackClickHandler() {
     this._changeNavigationState("mobile__button", "open");
     this._allRedHatToggle.focus();
+
+    // Call _showMainMenu
+    // Show main menu when All Red Hat menu is closed
   }
 
   /**
@@ -1471,6 +1480,18 @@ class PfeNavigation extends PFElement {
         }
       }
     }
+  }
+
+  /**
+   * Hide main menu when mobile All Red Hat menu is open
+   */
+
+  _hideMobileMainMenu() {
+    this._searchSpotXs.setAttribute("hidden", "");
+    // figure out how to stop hidden settings from being overwritten by display flex
+    this._menuDropdownMd.setAttribute("hidden", "");
+    this._searchToggle.setAttribute("hidden", "");
+    this._searchSpotMd.setAttribute("hidden", "");
   }
 
   /**

--- a/elements/pfe-navigation/src/pfe-navigation.js
+++ b/elements/pfe-navigation/src/pfe-navigation.js
@@ -152,10 +152,10 @@ class PfeNavigation extends PFElement {
     this._overlayClickHandler = this._overlayClickHandler.bind(this);
     this._a11yCloseAllMenus = this._a11yCloseAllMenus.bind(this);
     this._stickyHandler = this._stickyHandler.bind(this);
-    this._getLastFocusableElement = this._getLastFocusableElement.bind(this);
-    this._siteSwitcherFocusHandler = this._siteSwitcherFocusHandler.bind(this);
-    this._hideMobileMainMenuSr = this._hideMobileMainMenuSr.bind(this);
-    this._showMobileMainMenuSr = this._showMobileMainMenuSr.bind(this);
+    this._a11yGetLastFocusableElement = this._a11yGetLastFocusableElement.bind(this);
+    this._a11ySiteSwitcherFocusHandler = this._a11ySiteSwitcherFocusHandler.bind(this);
+    this._a11yHideMobileMainMenu = this._a11yHideMobileMainMenu.bind(this);
+    this._a11yShowMobileMainMenu = this._a11yShowMobileMainMenu.bind(this);
 
     // Handle updates to slotted search content
     this._searchSlot.addEventListener("slotchange", this._processSearchSlotChange);
@@ -209,14 +209,14 @@ class PfeNavigation extends PFElement {
     }
 
     // Get last focusable element for nav
-    this._getLastFocusableElement(this._shadowNavWrapper);
+    this._a11yGetLastFocusableElement(this._shadowNavWrapper);
     // Tab key listener attached to the last focusable element in the component
     this._lastFocusableNavElement.addEventListener("keydown", this._a11yCloseAllMenus);
 
     // Only run if mobile site switcher is NOT null (mobile - md breakpoints)
     if (this._siteSwitcherMobileOnly !== null) {
       // Key listener attached to the last focusable element in the mobile site switcher menu
-      this._siteSwitcherMobileOnly.addEventListener("keydown", this._siteSwitcherFocusHandler);
+      this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
     }
   } // end connectedCallback()
 
@@ -232,11 +232,11 @@ class PfeNavigation extends PFElement {
     this._allRedHatToggleBack.removeEventListener("click", this._allRedHatToggleBackClickHandler);
     this.removeEventListener("keydown", this._generalKeyboardListener);
 
-    this._getLastFocusableElement(this._shadowNavWrapper);
+    this._a11yGetLastFocusableElement(this._shadowNavWrapper);
     this._lastFocusableNavElement.removeEventListener("keydown", this._a11yCloseAllMenus);
 
     if (this._siteSwitcherMobileOnly !== null) {
-      this._siteSwitcherMobileOnly.removeEventListener("keydown", this._siteSwitcherFocusHandler);
+      this._siteSwitcherMobileOnly.removeEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
     }
 
     if (this.hasAttribute("pfe-sticky") && this.getAttribute("pfe-sticky") != "false") {
@@ -1285,11 +1285,11 @@ class PfeNavigation extends PFElement {
 
     // @todo: (KS) fix this based on PR feedback
     // if (this._siteSwitcherMobileOnly === null) {
-    //   // this._showMobileMainMenuSr();
+    //   // this._a11yShowMobileMainMenu();
     //   return;
     // } else {
     //   // Key listener attached to the last focusable element in the mobile site switcher menu
-    //   this._siteSwitcherMobileOnly.addEventListener("keydown", this._siteSwitcherFocusHandler);
+    //   this._siteSwitcherMobileOnly.addEventListener("keydown", this._a11ySiteSwitcherFocusHandler);
     // }
   }
 
@@ -1299,28 +1299,30 @@ class PfeNavigation extends PFElement {
   _toggleMobileMenu(event) {
     if (!this.isOpen("mobile__button")) {
       this._changeNavigationState("mobile__button", "open");
-      // Show main menu when All Red Hat menu is closed
-      // this._showMobileMainMenuSr();
+      // Show main menu when mobile All Red Hat menu is closed
+      this._a11yShowMobileMainMenu();
     } else {
       this._changeNavigationState("mobile__button", "close");
-      // this._hideMobileMainMenuSr();
+      // Hide main menu when mobile All Red Hat menu is open
+      this._a11yHideMobileMainMenu();
     }
   }
 
   _toggleSearch(event) {
     this._changeNavigationState("secondary-links__button--search");
     // Move focus to search field when Desktop search button is activated
-    this._searchFieldFocusHandler();
+    this._a11ySearchFieldFocusHandler();
   }
 
   _toggleAllRedHat(event) {
     this._changeNavigationState("secondary-links__button--all-red-hat");
     if (this.isOpen("mobile__button")) {
-      // Hide mobile main menu when All Red Hat menu is open
-      // this._hideMobileMainMenuSr();
+      // Hide main menu when mobile All Red Hat menu is open
+      this._a11yHideMobileMainMenu();
       this._allRedHatToggleBack.focus();
     } else {
-      // this._showMobileMainMenuSr();
+      // Show main menu when mobile All Red Hat menu is closed
+      this._a11yShowMobileMainMenu();
     }
   }
 
@@ -1385,7 +1387,7 @@ class PfeNavigation extends PFElement {
   _allRedHatToggleBackClickHandler() {
     this._changeNavigationState("mobile__button", "open");
     // Show main menu when All Red Hat menu is closed
-    this._showMobileMainMenuSr();
+    this._a11yShowMobileMainMenu();
     this._allRedHatToggle.focus();
   }
 
@@ -1461,7 +1463,7 @@ class PfeNavigation extends PFElement {
    * Get all focusable elements then find the last focusable element for specified nav
    * @param {string} navRegion Define which nav to get last focusable element from
    */
-  _getLastFocusableElement(navRegion) {
+  _a11yGetLastFocusableElement(navRegion) {
     // Store all focusable elements inside variable
     this._focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
     // Logic switch for Site Switcher nav versus main nav
@@ -1494,7 +1496,7 @@ class PfeNavigation extends PFElement {
    * When last focusable element loses focus send focus to back to menu button
    * @param {object} event for keydown listener
    */
-  _siteSwitcherFocusHandler(event) {
+  _a11ySiteSwitcherFocusHandler(event) {
     const key = event.key;
 
     if (this._siteSwitcherMenu !== null) {
@@ -1526,69 +1528,91 @@ class PfeNavigation extends PFElement {
    * Hide main menu from screen readers and keyboard when mobile All Red Hat menu is open
    */
   // @todo: (KS) fix this based on PR feedback
-  _hideMobileMainMenuSr() {
-    this._searchSpotXs.setAttribute("aria-hidden", "true");
-    this._menuDropdownMd.setAttribute("aria-hidden", "true");
-    this._searchToggle.setAttribute("aria-hidden", "true");
-    this._searchSpotMd.setAttribute("aria-hidden", "true");
-    this._mobileNavSearchSlot.setAttribute("aria-hidden", "true");
-    this._allRedHatToggle.setAttribute("aria-hidden", "true");
-    this._customLinksSlot.setAttribute("aria-hidden", "true");
+  _a11yHideMobileMainMenu() {
+    const shadowMainMenu = this.shadowRoot.getElementById("pfe-navigation__menu");
+    console.log(shadowMainMenu);
 
-    this._searchSpotXs.setAttribute("tabindex", "-1");
-    this._menuDropdownMd.setAttribute("tabindex", "-1");
-    this._searchToggle.setAttribute("tabindex", "-1");
-    this._searchSpotMd.setAttribute("tabindex", "-1");
-    this._mobileNavSearchSlot.setAttribute("tabindex", "-1");
-    this._allRedHatToggle.setAttribute("tabindex", "-1");
-    this._customLinksSlot.setAttribute("tabindex", "-1");
+    shadowMainMenu.setAttribute("aria-hidden", "true");
+    shadowMainMenu.setAttribute("tabindex", "-1");
+    shadowMainMenu.setAttribute("hidden", "");
 
-    this._searchSpotXs.setAttribute("hidden", "");
-    this._menuDropdownMd.setAttribute("hidden", "");
-    this._searchToggle.setAttribute("hidden", "");
-    this._searchSpotMd.setAttribute("hidden", "");
-    this._mobileNavSearchSlot.setAttribute("hidden", "");
-    this._allRedHatToggle.setAttribute("hidden", "");
-    this._customLinksSlot.setAttribute("hidden", "");
+    // this._searchSpotXs.setAttribute("aria-hidden", "true");
+    // this._menuDropdownMd.setAttribute("aria-hidden", "true");
+    // this._searchToggle.setAttribute("aria-hidden", "true");
+    // this._searchSpotMd.setAttribute("aria-hidden", "true");
+    // this._mobileNavSearchSlot.setAttribute("aria-hidden", "true");
+    // this._allRedHatToggle.setAttribute("aria-hidden", "true");
+    // this._customLinksSlot.setAttribute("aria-hidden", "true");
+
+    // this._searchSpotXs.setAttribute("tabindex", "-1");
+    // this._menuDropdownMd.setAttribute("tabindex", "-1");
+    // this._searchToggle.setAttribute("tabindex", "-1");
+    // this._searchSpotMd.setAttribute("tabindex", "-1");
+    // this._mobileNavSearchSlot.setAttribute("tabindex", "-1");
+    // this._allRedHatToggle.setAttribute("tabindex", "-1");
+    // this._customLinksSlot.setAttribute("tabindex", "-1");
+
+    // this._searchSpotXs.setAttribute("hidden", "");
+    // this._menuDropdownMd.setAttribute("hidden", "");
+    // this._searchToggle.setAttribute("hidden", "");
+    // this._searchSpotMd.setAttribute("hidden", "");
+    // this._mobileNavSearchSlot.setAttribute("hidden", "");
+    // this._allRedHatToggle.setAttribute("hidden", "");
+    // this._customLinksSlot.setAttribute("hidden", "");
   }
 
   /**
    * Show main menu to screen readers and keyboard users when Back to main menu button is pressed
    */
   // @todo: (KS) fix this based on PR feedback
-  _showMobileMainMenuSr() {
-    this._searchSpotXs.removeAttribute("aria-hidden", "true");
-    this._menuDropdownMd.removeAttribute("aria-hidden", "true");
-    this._searchToggle.removeAttribute("aria-hidden", "true");
-    this._searchSpotMd.removeAttribute("aria-hidden", "true");
-    this._mobileNavSearchSlot.removeAttribute("aria-hidden", "true");
-    this._allRedHatToggle.removeAttribute("aria-hidden", "true");
-    this._customLinksSlot.removeAttribute("aria-hidden", "true");
+  _a11yShowMobileMainMenu() {
+    const shadowMainMenu = this.shadowRoot.getElementById("pfe-navigation__menu");
+    console.log(shadowMainMenu);
 
-    this._searchSpotXs.removeAttribute("tabindex");
-    this._menuDropdownMd.removeAttribute("tabindex");
-    this._searchToggle.removeAttribute("tabindex");
-    this._searchSpotMd.removeAttribute("tabindex");
-    this._mobileNavSearchSlot.removeAttribute("tabindex");
-    this._allRedHatToggle.removeAttribute("tabindex");
-    this._customLinksSlot.removeAttribute("tabindex");
+    shadowMainMenu.removeAttribute("aria-hidden", "true");
+    shadowMainMenu.removeAttribute("tabindex", "-1");
+    shadowMainMenu.removeAttribute("hidden", "");
 
-    this._searchSpotXs.removeAttribute("hidden", "");
-    this._menuDropdownMd.removeAttribute("hidden", "");
-    this._searchToggle.removeAttribute("hidden", "");
-    this._searchSpotMd.removeAttribute("hidden", "");
-    this._mobileNavSearchSlot.removeAttribute("hidden", "");
-    this._allRedHatToggle.removeAttribute("hidden", "");
-    this._customLinksSlot.removeAttribute("hidden", "");
+    // this._searchSpotXs.removeAttribute("aria-hidden", "true");
+    // this._menuDropdownMd.removeAttribute("aria-hidden", "true");
+    // this._searchToggle.removeAttribute("aria-hidden", "true");
+    // this._searchSpotMd.removeAttribute("aria-hidden", "true");
+    // this._mobileNavSearchSlot.removeAttribute("aria-hidden", "true");
+    // this._allRedHatToggle.removeAttribute("aria-hidden", "true");
+    // this._customLinksSlot.removeAttribute("aria-hidden", "true");
+
+    // this._searchSpotXs.removeAttribute("tabindex");
+    // this._menuDropdownMd.removeAttribute("tabindex");
+    // this._searchToggle.removeAttribute("tabindex");
+    // this._searchSpotMd.removeAttribute("tabindex");
+    // this._mobileNavSearchSlot.removeAttribute("tabindex");
+    // this._allRedHatToggle.removeAttribute("tabindex");
+    // this._customLinksSlot.removeAttribute("tabindex");
+
+    // this._searchSpotXs.removeAttribute("hidden", "");
+    // this._menuDropdownMd.removeAttribute("hidden", "");
+    // this._searchToggle.removeAttribute("hidden", "");
+    // this._searchSpotMd.removeAttribute("hidden", "");
+    // this._mobileNavSearchSlot.removeAttribute("hidden", "");
+    // this._allRedHatToggle.removeAttribute("hidden", "");
+    // this._customLinksSlot.removeAttribute("hidden", "");
   }
 
   /**
    * Set focus to search field when search button is pressed on Desktop
-   * set to the light dom search input field so focus is in the correct place for screen readers and keyboards
+   * if search input exists set to the light dom search input field (either type=text or type=search) so focus is in the correct place for screen readers and keyboards
    */
-  _searchFieldFocusHandler() {
-    const searchInput = document.querySelector(".pfe-navigation__search  input");
-    searchInput.focus();
+  _a11ySearchFieldFocusHandler() {
+    const searchInputTypeText = document.querySelector(".pfe-navigation__search  input[type='text']");
+    const searchInputTypeSearch = document.querySelector(".pfe-navigation__search  input[type='search']");
+
+    if (searchInputTypeText) {
+      searchInputTypeText.focus();
+    }
+
+    if (searchInputTypeSearch) {
+      searchInputTypeSearch.focus();
+    }
   }
 
   /**
@@ -1612,7 +1636,7 @@ class PfeNavigation extends PFElement {
           this._siteSwitcherMenu = this.shadowRoot.querySelector("#site-switcher");
           // Get last focusable element ONLY if mobile site switcher is NOT null
           if (this._siteSwitcherMobileOnly !== null) {
-            this._getLastFocusableElement(this._siteSwitcherMenu);
+            this._a11yGetLastFocusableElement(this._siteSwitcherMenu);
           }
         }
       };

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -483,7 +483,7 @@ See mixin blocks before selectors that contain the selector name and the three l
 // Back to menu icon
 @mixin pfe-navigation__back__before--mobile {
   position: absolute;
-  top: 27px;
+  top: 27px; // Aligns the CSS left caret icon to the vertical center of the button text
   left: 35px;
   right: auto;
   display: block;

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -481,7 +481,7 @@ See mixin blocks before selectors that contain the selector name and the three l
 // Back to menu icon
 @mixin pfe-navigation__back__before--mobile {
   position: absolute;
-  top: 24px;
+  top: 27px;
   left: 35px;
   right: auto;
   display: block;

--- a/elements/pfe-navigation/src/pfe-navigation.scss
+++ b/elements/pfe-navigation/src/pfe-navigation.scss
@@ -37,9 +37,11 @@ See mixin blocks before selectors that contain the selector name and the three l
   z-index: pfe-zindex(navigation);
 }
 
-:host([hidden]) {
-  display: none;
-}
+:host([hidden]),
+[hidden] {
+  // Set to !important to ensure that the display none setting when the hidden attribute is added is not overwritten
+  display: none !important;
+ }
 
 :host(.pfe-sticky) {
   position: fixed;
@@ -1092,7 +1094,7 @@ See mixin blocks before selectors that contain the selector name and the three l
     margin-left: 0;
   }
 
-  > li {
+  > div {
     @include secondary-links-li;
   }
 


### PR DESCRIPTION
---
name: Cpfed 3851 keyboard trap all redhat menu
labels: "ready for review"
---

## pfe-navigation

- Add functions to hide mobile menu from keyboard and screen reader when the all red hat mobile menu is open
- Add show mobile menu sr function to postResize
- Add function to send the focus to the search input field when the desktop search toggle is pressed
- Removed some console logs
- Add tab index -1 to places where aria hidden is set to true
- Remove tab index attribute when aria-hidden is set to false (aria hidden needs to be used with tab index -1 to fully work)
- Removed focus styles I added to test with
- Restructured nav so that all the elements were contained in the main nav tag for better screen reader experience
- Removed li items from around the mobile buttons for search and all red hat to improve the screen reader experience
- Added more specificity for hidden attr styles to keep other display settings from overriding them
- Changed li styles to div styles to go along with pfe-nav shadow dom template restructure

## Testing 
- Navigate the desktop and mobile menu with your keyboard using the tab key
- Navigate the desktop and mobile menu with your prefered screen reader using the tab key
- Focus on the All Red Hat menu for mobile and the search toggle for desktop

### Expected behavior: 
- You cannot navigate to the All Red Hat menu without activating the mobile All Red Hat button and you cannot navigate back to the main menu without activating the back to menu button. 
- When tabbing out of the menu it should close all open dropdowns. 
- When activating the search toggle on desktop it should move focus to the search field.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.
