### PR TITLE
feat: removing default slot

### DIFF
--- a/elements/pfe-clipboard/README.md
+++ b/elements/pfe-clipboard/README.md
@@ -16,22 +16,28 @@ A button to copy the current URL to the system clipboard.
 
 ### Override the link text
 ```html
-<pfe-clipboard role="button" tabindex="0">hey you, copy this url!</pfe-clipboard>
+<pfe-clipboard role="button" tabindex="0">
+    <span slot="text">hey you, copy this url!</span>
+</pfe-clipboard>
 ```
 
 ### Override the copied notification text
 ```html
-<pfe-clipboard role="button" tabindex="0"><span slot="text--success">URL Copied to clipboard</span></pfe-clipboard>
+<pfe-clipboard role="button" tabindex="0">
+    <span slot="text--success">URL Copied to clipboard</span>
+</pfe-clipboard>
 ```
 ### Override the icon
 ```html
-<pfe-clipboard role="button" tabindex="0"><pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon></pfe-clipboard>
+<pfe-clipboard role="button" tabindex="0">
+    <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
+</pfe-clipboard>
 ```
 
 ## Override all slots
 ```html
 <pfe-clipboard role="button" tabindex="0">
-    Copy this article URL
+    <span slot="text">Copy this article URL</span>
     <span slot="text--success">URL Copied to clipboard</span>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
 </pfe-clipboard>
@@ -46,13 +52,13 @@ A button to copy the current URL to the system clipboard.
 
 `<pfe-clipboard>` implements many features of a standard button to provide an accessible
 experience for all users. By default, `role="button"` and `tabindex="0"` are added to
-inform assistive technology that `<pfe-clipboard>` should be treated as a button.  It listens for 
-mouse clicks as well as enter and space key presses per the recommendation of 
+inform assistive technology that `<pfe-clipboard>` should be treated as a button.  It listens for
+mouse clicks as well as enter and space key presses per the recommendation of
 [w3.org](https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html).
 
 ## Slots
 
-- **Default slot**: Optionally override the text of the button.
+- `text`: Optionally override the text of the button.
 
 - `icon`: Optionally override the default link svg icon. You can inline svg `<svg slot="icon"></svg>` or use pfe-icon `<pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>`.
 

--- a/elements/pfe-clipboard/demo/index.html
+++ b/elements/pfe-clipboard/demo/index.html
@@ -70,7 +70,7 @@
 
     <h2>Clipboard: w/ custom text</h2>
     <pfe-clipboard role="button" tabindex="0">
-      You can totally click to copy url
+      <span slot="text">You can totally click to copy url</span>
       <span slot="text--success">Making some copies!</span>
     </pfe-clipboard>
 
@@ -94,7 +94,7 @@
 
     <h2>Clipboard: w/ custom text</h2>
     <pfe-clipboard role="button" tabindex="0">
-      You can totally click to copy url
+      <span slot="text">You can totally click to copy url</span>
       <span slot="text--success">Making some copies!</span>
     </pfe-clipboard>
 

--- a/elements/pfe-clipboard/src/pfe-clipboard.html
+++ b/elements/pfe-clipboard/src/pfe-clipboard.html
@@ -12,5 +12,3 @@ ${!this.noIcon ? `
 <div class="pfe-clipboard__text--success" role="alert">
     <slot name="text--success" id="text--success">Copied</slot>
 </div>
-<!-- hidden default slot to transpose to text slot -->
-<slot hidden data-slot="text"></slot>

--- a/elements/pfe-clipboard/src/pfe-clipboard.js
+++ b/elements/pfe-clipboard/src/pfe-clipboard.js
@@ -91,56 +91,6 @@ class PfeClipboard extends PFElement {
     // the copy functionality
     this.addEventListener("click", this._clickHandler.bind(this));
     this.addEventListener("keydown", this._keydownHandler.bind(this));
-
-    // Monitor the default slot for changes so we can map them to the text slot
-    this.shadowRoot.addEventListener("slotchange", this._slotchangeHandler.bind(this));
-  }
-
-  // Monitor the default slot for changes so we can map them to the text slot
-  _slotchangeHandler(event) {
-    // Target just the default slot
-    if (!event.target.hasAttribute("name")) {
-      // Transpose the default slot content
-      this._transposeSlot(event);
-    }
-  }
-
-  /**
-   * Transpose content from one slot to another. Accounts
-   * for empty default content and filters it.
-   * @todo Provide hook to allow users to add their own filtering logic.
-   * @todo Convert from slotchange to MutationObserver to observe children.
-   * @example
-   * // Decorate the source slot with a `hidden` attribute and a `data-slot`
-   * // attribute where the destination slot name is provided.
-   * // <slot hidden data-slot="text"></slot>
-   * _slotchangeHandler(event) { this._transposeSlot(event) }
-   *
-   * @param {event} SlotchangeEvent
-   * @return void
-   */
-  _transposeSlot(event) {
-    const source = event.target;
-    const slot = source.dataset.slot;
-    const target = this.shadowRoot.querySelector(`slot[name="${slot}"]`);
-    const fallbackContentVariable = `_transposeSlot${slot}`;
-    // Store the default content of the target for later use.
-    if (typeof this[fallbackContentVariable] === "undefined") {
-      this[fallbackContentVariable] = target.innerHTML;
-    }
-    // Get all children for the source slot. We need to include flatten to make sure we get the content.
-    const childNodes = [...source.assignedNodes({ flatten: true })];
-    // Trim the content nodes for whitespace and combine it into one string for evaluation.
-    const childContent = childNodes.map(child => child.textContent.trim()).join("");
-    // Find out if there is any non whitespace content
-    if (childContent !== "") {
-      // Transpose the content to the target slot
-      target.innerHTML = childContent;
-    }
-    // If there isn't any content then we are going to place the target slot's default content back in.
-    else {
-      target.innerHTML = this[fallbackContentVariable];
-    }
   }
 
   disconnectedCallback() {

--- a/elements/pfe-clipboard/test/pfe-clipboard_test.js
+++ b/elements/pfe-clipboard/test/pfe-clipboard_test.js
@@ -56,7 +56,7 @@ suite("<pfe-clipboard>", () => {
 
     test("it should render slot overrides", done => {
         // The default slot override will be handled by transposeSlot
-        const defaultSlot = `You can totally click to copy url`;
+        const defaultSlot = `<span slot="text">You can totally click to copy url</span>`;
         const textSuccessSlot = `<span slot="text--success">Making some copies!</span>`;
         const iconSlot = `<pfe-icon slot="icon" icon="web-icon-globe" color="darker"></pfe-icon>`;
         clipboard.innerHTML = `
@@ -66,26 +66,10 @@ suite("<pfe-clipboard>", () => {
         `;
         flush(() => {
             // transposeSlot should have sent it to the text named slot
-            assert.equal(clipboard.shadowRoot.querySelector(`#text`).assignedNodes({ flatten: true }).map(i => i.textContent.trim()).join(""), defaultSlot);
+            assert.equal(clipboard.shadowRoot.querySelector(`#text`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join(""), defaultSlot);
             // The text--success and icon slots should be working as expected also
             assert.equal(clipboard.shadowRoot.querySelector(`#text--success`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join(""), textSuccessSlot);
             assert.equal(clipboard.shadowRoot.querySelector(`#icon`).assignedNodes({ flatten: true }).map(i => i.outerHTML.trim()).join(""), iconSlot);
-            done();
-        });
-    });
-
-    test("it should handle transposeSlot fallback content correctly", done => {
-        // Has the correct default content
-        assert.equal(clipboardTransposeTest.shadowRoot.querySelector(`#text`).textContent, slots.text.defaultContent);
-        // Then we dynamically update the default content
-        clipboardTransposeTest.innerHTML = `
-            You can totally click to copy url
-        `;
-        // And immediatly remove the innerHTML dynamamically
-        clipboardTransposeTest.innerHTML = ``;
-        flush(() => {
-            // transposeSlot should have sent it to the text named slot
-            assert.equal(clipboardTransposeTest.shadowRoot.querySelector(`#text`).assignedNodes({ flatten: true }).map(i => i.textContent.trim()).join(""), slots.text.defaultContent);
             done();
         });
     });
@@ -100,7 +84,6 @@ suite("<pfe-clipboard>", () => {
         });
     });
 
-    // @todo: this should eventually use the normal test-fixture
     test(`it should have the correct text color settings for both copied and non-copied states`, done => {
         // Default text should be set the link variable
         assert.equal(getComputedStyle(clipboardStylesTest.shadowRoot.querySelector(`.pfe-clipboard__text`), null)["color"], `rgb(${hexToRgb("#0066cc").join(', ')})`);
@@ -136,7 +119,6 @@ suite("<pfe-clipboard>", () => {
         assert.equal(clipboardA11yTest.getAttribute("tabindex"), 0);
     });
 
-    // @todo: this should eventually use the normal test-fixture
     test(`it should display the text--success state for 3 seconds`, done => {
         clipboardStylesTest.click();
         flush(() => {


### PR DESCRIPTION
Fixes the IE11 issue with not supporting transposeSlot functionality.  

- IE11 doesn't support slotchange
- mutation observer implementation wasn't a 1:1 alternative of slotchange

The two issues that we would need to address with default slots in the future are:

- Default slots get wiped out with whitespaces
- Eliminates the power of a web component "gobbling up lightdom".  The technique were you put fallback content inside the web component knowing that it's going to get cleared out when the web component sets up.

## Proposal

For now, let's just remove the default slot until we come up with a bulletproof way of having named slots and default slots.