### PR TITLE
feat: set aggressive threshold on IntersectionObserver, sort active i…

### DIFF
--- a/elements/pfe-jump-links/src/pfe-jump-links-panel.js
+++ b/elements/pfe-jump-links/src/pfe-jump-links-panel.js
@@ -319,21 +319,13 @@ class PfeJumpLinksPanel extends PFElement {
       // We want only sections that are visible
       .filter(section => section.isVisible)
       // Sort the items by largest intersectionRatio which will be the item
-      // that is the most visible on the sceen.
+      // that is the most visible on the screen.
       // @todo we could take into account other variables like how big the section is on the page
       .sort((a, b) => a.intersectionRatio - b.intersectionRatio)
       .reverse()
       // Now that they are sorted, all we need is the section id
       .map(item => item.id);
 
-    // @todo REMOVE
-    ids.forEach(i => {
-      console.log({
-        id: i,
-        percentVisible: this.sectionRefs[i].intersectionRatio,
-        isVisible: this.sectionRefs[i].isVisible
-      });
-    });
 
     this.emitEvent(PfeJumpLinksPanel.events.activeNavItem, {
       detail: {

--- a/elements/pfe-jump-links/src/pfe-jump-links-panel.js
+++ b/elements/pfe-jump-links/src/pfe-jump-links-panel.js
@@ -82,7 +82,11 @@ class PfeJumpLinksPanel extends PFElement {
     this._intersectionObserver = new IntersectionObserver(this._intersectionCallback, {
       root: null,
       rootMargin: `${this.offsetValue}px 0px 0px 0px`,
-      threshold: 1.0 // @TODO Should this be 0.8?
+      // Threshold is an array of intervals that fire intersection observer event
+      // @todo This could be a dynamic property
+      threshold: Array(100)
+        .fill()
+        .map((_, i) => i / 100 || 0) // [0, 0.01, 0.02, 0.03, 0.04, ...]
     });
   }
 
@@ -307,12 +311,29 @@ class PfeJumpLinksPanel extends PFElement {
       if (section.id) {
         let ref = this.sectionRefs[section.id];
         if (ref) ref.isVisible = entry.isIntersecting;
+        if (ref) ref.intersectionRatio = entry.intersectionRatio;
       }
     });
 
     const ids = Object.values(this.sectionRefs)
+      // We want only sections that are visible
       .filter(section => section.isVisible)
+      // Sort the items by largest intersectionRatio which will be the item
+      // that is the most visible on the sceen.
+      // @todo we could take into account other variables like how big the section is on the page
+      .sort((a, b) => a.intersectionRatio - b.intersectionRatio)
+      .reverse()
+      // Now that they are sorted, all we need is the section id
       .map(item => item.id);
+
+    // @todo REMOVE
+    ids.forEach(i => {
+      console.log({
+        id: i,
+        percentVisible: this.sectionRefs[i].intersectionRatio,
+        isVisible: this.sectionRefs[i].isVisible
+      });
+    });
 
     this.emitEvent(PfeJumpLinksPanel.events.activeNavItem, {
       detail: {


### PR DESCRIPTION
## Component name

pfe-jump-links


## Description of changes

The threshold for Intersection Observer can take an array of increments that determine when the Observer should fire a new update.  I set the threshold to fire on increments of 1 percent change.

Then I'm sorting the active items by the intersection observers value of how much of the element is visible.