### PR TITLE
test: updating pfe-datetime Spanish locale test

### DIFF
--- a/elements/pfe-datetime/test/old-test/pfe-datetime_test.js
+++ b/elements/pfe-datetime/test/old-test/pfe-datetime_test.js
@@ -39,7 +39,7 @@ suite('<pfe-datetime>', () => {
     const element = document.getElementById('esLocale');
     const text = element.shadowRoot.querySelector('span').textContent;
 
-    assert.equal(text, 'lunes, 02 de ene. de 2006', "should show a (locally) formatted date with time");
+    assert.equal(text, 'lunes, 02 de ene de 2006', "should show a (locally) formatted date with time");
   });
 
   test("it should show formatted date for a specified time zone", () => {

--- a/elements/pfe-datetime/test/pfe-datetime_test.js
+++ b/elements/pfe-datetime/test/pfe-datetime_test.js
@@ -47,7 +47,7 @@ suite("<pfe-datetime>", () => {
     const element = document.getElementById("esLocale");
     const text = element.shadowRoot.querySelector("span").textContent;
 
-    assert.equal(text, "lunes, 02 de ene. de 2006", "should show a (locally) formatted date with time");
+    assert.equal(text, "lunes, 02 de ene de 2006", "should show a (locally) formatted date with time");
   });
 
   test("it should show formatted date for a specified time zone", () => {


### PR DESCRIPTION
Fixes #1320

## pfe-datetime

pfe-datetime tests are currently failing 


### Related issue
(#1320)


### Preview
No preview. The tests should just pass.


### What has changed and why
Something has changed with how Chrome is doing localization for the Spanish locale. I had to remove the period in "lunes, 02 de ene de 2006" (was previously lunes, 02 de ene. de 2006) to get the tests to pass.


### Testing instructions
1. Run the tests

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
