### PR TITLE
tools: fix sass compile timing

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,8 +11,7 @@ done
 
 CMD="$CMD && npm run build-storybook"
 
-# eval $CMD
-echo $CMD
+eval $CMD
 
 rm -rf examples/node_modules
 mkdir examples/node_modules

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,14 +2,14 @@
 
 CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
 
+[[ -n "$*" ]] &&  CMD="$CMD --scope \"*/pfe-sass\""
+
 for el in "$@"; do
   [[ "$el" != "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""
 done
 
-# If pfe-sass was the only provided input, compile it
-[[ "$@" == "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""
-
-CMD="$CMD && npm run build-storybook"
+# Only build storybook when every component is being built
+[[ -z "$*" ]] && CMD="$CMD && npm run build-storybook"
 
 eval $CMD
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,14 +2,15 @@
 
 CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
 
-[[ -n "$*" ]] &&  CMD="$CMD --scope \"*/pfe-sass\""
-
 for el in "$@"; do
   [[ "$el" != "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""
 done
 
-# Only build storybook when every component is being built
-[[ -z "$*" ]] && CMD="$CMD && npm run build-storybook"
+# If all components are being built (thus $* is empty), ignore pfe-sass (it gets built by components as a dependency)
+# Only add the storybook build when every component is being built
+if [[ -z "$*" ]]; then
+  CMD="$CMD --ignore \"*/pfe-sass\" && npm run build-storybook";
+fi
 
 eval $CMD
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,12 +3,16 @@
 CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
 
 for el in "$@"; do
-  CMD="$CMD --scope \"*/$el\""
+  [[ "$el" != "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""
 done
+
+# If pfe-sass was the only provided input, compile it
+[[ "$@" == "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""
 
 CMD="$CMD && npm run build-storybook"
 
-eval $CMD
+# eval $CMD
+echo $CMD
 
 rm -rf examples/node_modules
 mkdir examples/node_modules


### PR DESCRIPTION
## Infrastructure updates

Currently pfe-sass is passed to the build command as if it's a component, but since components all build concurrently, this can occasionally lead to issues where pfe-sass is in the process of rebuilding and components are requesting assets from it.  By removing pfe-sass from the build (unless it is the only input provided), we are allowing lerna to pre-build pfe-sass when it is a dependency of a component.  This is partly because pfe-sass is a `devDependency` so lerna isn't bootstrapping it for us.

### Testing instructions

1. `npm run build` -> builds pfe-sass FIRST then all other components
2. `npm run build pfe-accordion` -> builds pfe-sass then pfe-accordion
3. `npm run build pfe-sass` -> builds pfe-sass only
4. `npm run build pfe-accordion pfe-band pfe-sass` -> builds pfe-sass FIRST, then pfe-accordion and pfe-band


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

