### PR TITLE
CI: color flag for command line in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_COLOR: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # For webdriver script

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,6 @@ jobs:
       ) ||
       github.event_name == 'workflow_dispatch'
     steps:
-      - run: export FORCE_COLOR=true
       # Turn this on to debug an action
       # - run: echo "$GITHUB_CONTEXT"
 
@@ -115,8 +114,6 @@ jobs:
       matrix:
         node: [10]
     steps:
-      - run: export FORCE_COLOR=true
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -171,8 +168,6 @@ jobs:
       matrix:
         node: [10]
     steps:
-      - run: export FORCE_COLOR=true
-
       - name: BrowserStack environment setup
         uses: "browserstack/github-actions/setup-env@master"
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,7 @@ jobs:
       ) ||
       github.event_name == 'workflow_dispatch'
     steps:
+      - run: export FORCE_COLOR=true
       # Turn this on to debug an action
       # - run: echo "$GITHUB_CONTEXT"
 
@@ -114,6 +115,8 @@ jobs:
       matrix:
         node: [10]
     steps:
+      - run: export FORCE_COLOR=true
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -168,6 +171,8 @@ jobs:
       matrix:
         node: [10]
     steps:
+      - run: export FORCE_COLOR=true
+
       - name: BrowserStack environment setup
         uses: "browserstack/github-actions/setup-env@master"
         with:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies --colors"
+CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
 
 for el in "$@"; do
   [[ "$el" != "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies"
+CMD="npm run lerna -- run build --parallel --no-bail --include-dependencies --colors"
 
 for el in "$@"; do
   [[ "$el" != "pfe-sass" ]] && CMD="$CMD --scope \"*/$el\""

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 CMD=""
 

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 CMD="npm run build $@ && npm-run-all --parallel \"watch $@\" \"start $@\""
 

--- a/scripts/hugo-check.sh
+++ b/scripts/hugo-check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 HUGO_BIN=${HUGO_BIN:="hugo"}
 

--- a/scripts/leftover-check.sh
+++ b/scripts/leftover-check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 DIRS=""
 DIRS_COUNT=""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 #######################################################################
 #                     PUBLISH PFELEMENTS TO NPM!                      #

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash	
 
-CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json --colors"	
+CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json"	
 
 for el in "$@"; do	
   if [[ $el == -* ]]; then	

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash	
 
-CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json"	
+CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json --colors"	
 
 for el in "$@"; do	
   if [[ $el == -* ]]; then	

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash	
+export FORCE_COLOR=true
 
 CMD="npm run build $@; ./node_modules/.bin/wct --configFile wct.conf.json"	
 

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export FORCE_COLOR=true
 
 CMD="npm run lerna -- run watch --parallel --no-bail --include-dependencies"
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -12,6 +12,7 @@ exports.config = {
   logLevel: "error",
   framework: "mocha",
   mochaOpts: {
+    colors: true,
     timeout: 90000
   },
   user: process.env.BROWSERSTACK_USER,


### PR DESCRIPTION
## What has changed and why

When a bash script is run in a GitHub Action, it opens a sub-shell which which isn't reading at tty.  Adding `export FORCE_COLOR=true` to the top of bash scripts forces the color support on in these shells.  
Voilà!  Color!

- It works!!! https://github.com/patternfly/patternfly-elements/runs/1826170121?check_suite_focus=true

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

