### PR TITLE
fix: [pfe-styles] adjust weight of text modifier classes to be lighter

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -6,8 +6,8 @@
 - [9fab144](https://github.com/patternfly/patternfly-elements/commit/9fab1440da7bc26e3dd5f92224f03e964ea9eda2) feat: pfe-primary-detail
 - [03899cc](https://github.com/patternfly/patternfly-elements/commit/03899ccf7a4421186a7316926955b3a3bd1068f7) fix: Typography: mixins & extends
 - [57b5dd2](https://github.com/patternfly/patternfly-elements/commit/57b5dd2adf1c0fd0e00a6c9112d3ad5fb66a5a11) feat: Update Firefox support to 78 (latest version for RHEL CSB)
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-clipboard docs; add font-size
-
+- [5d661cb](https://github.com/patternfly/patternfly-elements/commit/5d661cb7e85921ed72f324a0b635873c23bc69e9) fix: pfe-clipboard docs; add font-size 
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: update font-weight on pfe text modifier classes
 ## 1.1.1 ( 2021-01-18 )
 
 - [f876664](https://github.com/patternfly/patternfly-elements/commit/f876664655894cbd29d610c20b3bdbde31aaed7a) fix: Sass maps missing from compiled assets

--- a/elements/pfe-sass/mixins/_copy-mixins.scss
+++ b/elements/pfe-sass/mixins/_copy-mixins.scss
@@ -193,7 +193,7 @@
         $font-family: pfe-var(font-family);
         $font-size: pfe-var(text--m-#{$sizing}--FontSize);
         $line-height: pfe-var(line-height);
-        $font-weight: pfe-var(font-weight--normal);
+        $font-weight: pfe-var(font-weight--light);
         $margin-bottom: pfe-var(content-spacer--body--sm);
         @if $use-local and $light-dom-heading {
             --pf-c--FontSize: #{pfe-local(FontSize)};


### PR DESCRIPTION
## Component name

- pfe-styles


### Related issue

- https://github.com/patternfly/patternfly-elements/issues/1337


### Preview

https://deploy-preview-1338--happy-galileo-ea79c4.netlify.app/elements/pfe-styles/demo/
 


### What has changed and why

- fix font-weight for pfe-text modifier classes within mixin

### Testing instructions

1.  Check the pfe-styles demo page, the text modifiers at the bottom should look like this: 
![image](https://user-images.githubusercontent.com/456863/107424683-f5491b80-6aeb-11eb-9289-2f3da486eb9b.png)

 

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Tests have been updated to cover these changes.
- [x] Browser testing passed.
- [ ] Repository compiles and tests pass.
- [ ] Changelog updated (not needed for documentation updates).
- [x] Documentation (README.md, WHY.md, etc.) updated or added.
- [x] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**
