### PR TITLE
chore: Update automerge & needs/ready labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 name: Default template
 about: Generic template
-labels: "feature, needs: AT updates, needs: changelog, needs: branch testing, priority: low"
+labels: "feature, needs: AT updates, needs: changelog, ready: branch testing, priority: low"
 ---
 
 ## Component name

--- a/.github/PULL_REQUEST_TEMPLATE/new_component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_component.md
@@ -1,4 +1,4 @@
-<!-- Labels: feature, needs: branch testing, needs: browser testing, needs: code review, priority: low -->
+<!-- Labels: feature, ready: branch testing, ready: browser testing, needs: code review, priority: low -->
 
 <!-- Thank you for submitting a pull request! -->
 ## New component: <component-name>

--- a/.github/PULL_REQUEST_TEMPLATE/update_component.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update_component.md
@@ -1,4 +1,4 @@
-<!-- Labels: feature, needs: branch testing, needs: browser testing, needs: code review, priority: low -->
+<!-- Labels: feature, ready: branch testing, ready: browser testing, needs: code review, priority: low -->
 
 <!-- Thank you for submitting a pull request! -->
 ## Component updates: <component-name>

--- a/.github/PULL_REQUEST_TEMPLATE/update_infrastructure.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update_infrastructure.md
@@ -1,4 +1,4 @@
-<!-- Labels: tools, needs: branch testing, needs: code review, priority: low -->
+<!-- Labels: tools, ready: branch testing, needs: code review, priority: low -->
 
 <!-- Thank you for submitting a pull request! -->
 ## Infrastructure updates

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,10 +6,6 @@ on:
   pull_request_review:
     types:
       - submitted
-  workflow_run:
-    workflows: ["Build & test"]
-    types:
-      - completed
 
 jobs:
   try_to_merge:
@@ -20,7 +16,7 @@ jobs:
         uses: pascalgn/automerge-action@v0.12.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "!work in progress!,!on hold,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: branch testing,!ready: browser testing"
+          MERGE_LABELS: "!work in progress!,!on hold,!blocked,!needs: code updates,!needs: additional info,!needs: AT updates,!needs: changelog,!ready: code review,!ready: design review,!ready: branch testing,!ready: browser testing"
           MERGE_REMOVE_LABELS: "ready to merge"
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: "pull-request-title"

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Move to testing
         uses: takanabe/github-actions-automate-projects@v0.0.1
         if: |
-          contains(github.event.*.labels.*.name, 'needs: browser testing') ||
-          contains(github.event.*.labels.*.name, 'needs: branch testing')
+          contains(github.event.*.labels.*.name, 'ready: browser testing') ||
+          contains(github.event.*.labels.*.name, 'ready: branch testing')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Testing
       - name: Ready to merge


### PR DESCRIPTION
- Updating `needs: code review`, `needs: branch testing`, and `needs: browser testing` to `ready:` prefix.
- The workflow_run event is not valid for automerge; throwing errors so this PR removes that event

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

