### PR TITLE
fix: set hidden attribute to empty string

### DIFF
--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -133,7 +133,7 @@ class PfeContentSet extends PFElement {
     super.connectedCallback();
 
     if (this.hasLightDOM()) {
-      this.setAttribute("hidden");
+      this.setAttribute("hidden", "");
 
       // If the tab does not exist in the light DOM, add it
       if (!this.tabs) {


### PR DESCRIPTION
## <Pull request description>

Fixed small bug with setting hidden attribute to the pfe-content-set element.
