### PR TITLE
chore: update package dependencies for primary detail

### DIFF
--- a/elements/pfe-primary-detail/package.json
+++ b/elements/pfe-primary-detail/package.json
@@ -55,7 +55,9 @@
     "@patternfly/pfelement": "1.0.0"
   },
   "devDependencies": {
-    "@patternfly/pfe-sass": "^1.3.0"
+    "@patternfly/pfe-cta": "^1.3.0",
+    "@patternfly/pfe-sass": "^1.3.0",
+    "@patternfly/pfe-styles": "^1.3.0"
   },
   "bugs": {
     "url": "https://github.com/patternfly/patternfly-elements/issues"

--- a/elements/pfe-primary-detail/package.json
+++ b/elements/pfe-primary-detail/package.json
@@ -21,6 +21,15 @@
     "url": "github:patternfly/patternfly-elements",
     "directory": "elements/pfe-primary-detail"
   },
+  "engines": {
+    "node": ">=10 <13"
+  },
+  "browserslist": [
+    "last 2 versions",
+    "Firefox >= 78",
+    "iOS >= 8",
+    "ie 11"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -43,7 +52,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfelement": "1.0.0",
-    "gh-pages": "^2.2.0"
+    "@patternfly/pfelement": "1.0.0"
+  },
+  "devDependencies": {
+    "@patternfly/pfe-sass": "^1.3.0"
+  },
+  "bugs": {
+    "url": "https://github.com/patternfly/patternfly-elements/issues"
   }
 }


### PR DESCRIPTION
Updates package.json to include devDependencies:

- pfe-sass: Used in compiling the CSS assets
- pfe-styles: Used on the demo page
- pfe-cta: Used on the demo page

This update is urgent because without pfe-sass as a dependency, lerna is not handling the timing of compilation correctly and it's running without the compiled assets available and throwing Sass errors.

### Ready-for-merge Checklist

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

