### PR TITLE
chore: Update pfe-sass references

### DIFF
--- a/elements/pfe-navigation/package.json
+++ b/elements/pfe-navigation/package.json
@@ -61,11 +61,9 @@
   "license": "MIT",
   "dependencies": {
     "@patternfly/pfe-icon": "^1.3.2",
-    "@patternfly/pfelement": "^1.3.2"
-  },
-  "devDependencies": {
     "@patternfly/pfe-sass": "^1.3.2",
-    "@patternfly/pfe-styles": "^1.3.2"
+    "@patternfly/pfe-styles": "^1.3.2",
+    "@patternfly/pfelement": "^1.3.2"
   },
   "generator-pfelement-version": "1.1.0"
 }

--- a/elements/pfe-primary-detail/package.json
+++ b/elements/pfe-primary-detail/package.json
@@ -52,12 +52,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfelement": "1.0.0"
-  },
-  "devDependencies": {
-    "@patternfly/pfe-cta": "^1.3.2",
     "@patternfly/pfe-sass": "^1.3.2",
-    "@patternfly/pfe-styles": "^1.3.2"
+    "@patternfly/pfelement": "1.0.0"
   },
   "bugs": {
     "url": "https://github.com/patternfly/patternfly-elements/issues"

--- a/elements/pfe-styles/package.json
+++ b/elements/pfe-styles/package.json
@@ -59,7 +59,7 @@
     }
   ],
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@patternfly/pfe-sass": "^1.3.2"
   },
   "bugs": {

--- a/elements/pfelement/package.json
+++ b/elements/pfelement/package.json
@@ -60,7 +60,7 @@
     }
   ],
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@patternfly/pfe-sass": "^1.3.2"
   },
   "generator-pfelement-version": "0.3.4",

--- a/generators/element/templates/package.json
+++ b/generators/element/templates/package.json
@@ -57,13 +57,13 @@
   }<% } %>],
   "license": "MIT",
   "dependencies": {
-    <% if (isPfelement) { %>"@patternfly/pfelement": "<%= pfelementVersion %>"<% } %><% if (Object.entries( dependencies ).length > 0) { %>,<% } %><% for (const [package, version] of Object.entries( dependencies )) { %>
-    "<%= package %>": "<%= version %>"<% if ( _.findLastKey( dependencies ) !== package ) { %>,<% } } %>
+    <% if (isPfelement) { %>"@patternfly/pfelement": "<%= pfelementVersion %>"<% } %><% if (sassLibraryPkg) { if (isPfelement) { %>,<% } %>
+    "<%= sassLibraryPkg %>": "<%= pfeSassVersion %>"<% } %><% if (Object.entries( dependencies ).length > 0) { %><% if (isPfelement || sassLibraryPkg) { %>,<% } %><% for (const [package, version] of Object.entries( dependencies )) { %>
+    "<%= package %>": "<%= version %>"<% if ( _.findLastKey( dependencies ) !== package ) { %>,<% } } } %>
   }<% if (!isPfelement) { %>,
-  "devDependencies": {<% for (const [package, version] of Object.entries( devDependencies )) { %>
-    "<%= package %>": "<%= version %>"<% if ( _.findLastKey( devDependencies ) !== package ) { %>,<% } } %><% if (sassLibraryPkg) { if (devDependencies.length > 0) { %>,<% } %>
-    "<%= sassLibraryPkg %>": "<%= pfeSassVersion %>"<% } %>
-  },
+  <% if (Object.entries( devDependencies ).length > 0) { %>"devDependencies": {<% for (const [package, version] of Object.entries( devDependencies )) { %>
+    "<%= package %>": "<%= version %>"<% if ( _.findLastKey( devDependencies ) !== package ) { %>,<% } } %>
+  },<% } %>
   "bugs": {
     "url" : "https://github.com/patternfly/patternfly-elements/issues?q=is%3Aissue+is%3Aopen+<%= elementName %>"
   }<% } %>


### PR DESCRIPTION
Sometimes Netlify doesn't let the pfe-sass dependency finish building before it kicks off the build for components that have it listed as a dependency

All components should list pfe-sass as a dependency.


### Related issues

- (#1458)[https://github.com/patternfly/patternfly-elements/issues/1458] Issue with sass:globbing timing


### Preview

<!-- Suggest linking to Netlify or a public sandbox; not a resource behind a log-in or VPN -->
Link(s) to demo page(s) where this element can be viewed:
- [Link](https://deploy-preview-<pr_number>--happy-galileo-ea79c4.netlify.app//examples/) 


### What has changed and why

- pfe-navigation: moved pfe-styles and pfe-sass to dependencies
- pfe-primary-detail: removed pfe-cta and pfe-styles dependency (not invoked in the component, only used on demo page); moved pfe-sass to dependency
- pfe-styles: move pfe-sass to dependency
- pfelement: move pfe-sass to dependency
- Update generator


### Testing instructions

- [ ] Run the full build a couple of times and watch for `Error: File to import not found or unreadable: _variables.`


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

