### PR TITLE
fix: added build debounce, added observer opt-out attribute for dynam…

### DIFF
--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -38,6 +38,18 @@
       "../../pfe-band/dist/pfe-band.umd.js"
     ])
 
+    class XCounter extends HTMLElement {
+      constructor() {
+        super();
+        this.intervals = 0;
+        setInterval(() => {
+          this.intervals++;
+          this.innerHTML = this.intervals;
+        }, 1000)
+      }
+    }
+    window.customElements.define("x-counter", XCounter);
+
   </script>
 
   <link href="demo.css" rel="stylesheet" />
@@ -102,6 +114,7 @@
         porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Maecenas faucibus
         mollis interdum.</p>
         <p class="custom-styles">Custom styles to validate that they still work!</p>
+        <p>We can also ignore changes from dynamic components: <x-counter pfe-content-set--ignore-changes></x-counter></p>
       </div>
       <h4 pfe-content-set--header>Heading 3</h4>
       <div pfe-content-set--panel>Content for heading 3. Donec ullamcorper nulla non metus auctor fringilla. Donec

--- a/elements/pfe-content-set/demo/index.html
+++ b/elements/pfe-content-set/demo/index.html
@@ -546,6 +546,51 @@
       </pfe-tabs>
     </pfe-content-set>
   </section>
+  <section class="faux-container" style="max-width: 800px">
+    <h4 class="label">pfe-content-set with a nested content set</h4>
+    <pfe-content-set id="tabs" selected-index="1">
+      <h4 pfe-content-set--header>Heading 1</h4>
+      <div pfe-content-set--panel>
+        <p>Content for heading 1. Maecenas faucibus mollis interdum. Maecenas sed diam eget risus varius blandit sit
+          amet non magna. Maecenas sed diam eget risus varius blandit sit amet non magna. Maecenas sed diam eget risus
+          varius blandit sit amet non magna. Etiam porta sem malesuada magna mollis euismod.</p>
+        <pfe-content-set id="tabs" selected-index="1">
+          <h4 pfe-content-set--header>Heading 1</h4>
+          <div pfe-content-set--panel>
+            <p>Content for heading 1. Maecenas faucibus mollis interdum. Maecenas sed diam eget risus varius blandit sit
+              amet non magna. Maecenas sed diam eget risus varius blandit sit amet non magna. Maecenas sed diam eget risus
+              varius blandit sit amet non magna. Etiam porta sem malesuada magna mollis euismod.</p>
+          </div>
+          <h4 pfe-content-set--header>Heading 2</h4>
+          <div pfe-content-set--panel>
+            <p>Content for heading 2. Sed posuere consectetur est at lobortis. Donec id elit non mi
+            porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Maecenas faucibus
+            mollis interdum.</p>
+            <p class="custom-styles">Custom styles to validate that they still work!</p>
+            <p>We can also ignore changes from dynamic components: <x-counter pfe-content-set--ignore-changes></x-counter></p>
+          </div>
+          <h4 pfe-content-set--header>Heading 3</h4>
+          <div pfe-content-set--panel>Content for heading 3. Donec ullamcorper nulla non metus auctor fringilla. Donec
+            ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper. Aenean eu leo
+            quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras mattis consectetur purus sit amet
+            fermentum.</div>
+        </pfe-content-set>
+      </div>
+      <h4 pfe-content-set--header>Heading 2</h4>
+      <div pfe-content-set--panel>
+        <p>Content for heading 2. Sed posuere consectetur est at lobortis. Donec id elit non mi
+        porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Maecenas faucibus
+        mollis interdum.</p>
+        <p class="custom-styles">Custom styles to validate that they still work!</p>
+        <p>We can also ignore changes from dynamic components: <x-counter pfe-content-set--ignore-changes></x-counter></p>
+      </div>
+      <h4 pfe-content-set--header>Heading 3</h4>
+      <div pfe-content-set--panel>Content for heading 3. Donec ullamcorper nulla non metus auctor fringilla. Donec
+        ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper. Aenean eu leo
+        quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras mattis consectetur purus sit amet
+        fermentum.</div>
+    </pfe-content-set>
+  </section>
 
   <script>
     var btn = document.querySelector("#addHeaderAndPanelBtn");

--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -10,6 +10,7 @@ const CONTENT_MUTATION_CONFIG = {
   childList: true,
   subtree: true
 };
+
 class PfeContentSet extends PFElement {
   static get tag() {
     return "pfe-content-set";
@@ -33,6 +34,14 @@ class PfeContentSet extends PFElement {
 
   static get pfeType() {
     return PFElement.pfeType.combo;
+  }
+
+  /**
+   * Define the list of elements that will be added by our internal build function. These
+   * elements will be ignored by internal mutation observers.
+   */
+  static get protectedChildren() {
+    return ["PFE-TABS", "PFE-ACCORDION"];
   }
 
   /**
@@ -296,13 +305,16 @@ class PfeContentSet extends PFElement {
   _mutationHandler(mutationsList) {
     if (!this.isIE11 && mutationsList) {
       for (let mutation of mutationsList) {
-        // The first thing we do is to see if the mutation target has
-        // an opt-out attribute
-        // @todo add this to the API docs
         if (typeof mutation.target !== "undefined") {
+          // The first thing we do is to see if the mutation target has
+          // an opt-out attribute
+          // @todo Add this to the API docs
+          // @todo Concider solving this algorithmically or with slots
           if (typeof mutation.target.hasAttribute !== "undefined") {
             if (mutation.target.closest("[pfe-content-set--ignore-changes]")) return;
           }
+          // Then we need to check if it's one of our protected child elements
+          if (PfeContentSet.protectedChildren.includes(mutation.target.tagName)) return;
         }
         switch (mutation.type) {
           case "childList":


### PR DESCRIPTION
I added a small debouncer to the build function to prevent it from re-rendering way too often.  I'm not sure that's going to be enough to prevent some dynamic components from rebuilding out of control so I added an attribute that will prevent the re-renders if it contains dynamic content.  Just add `pfe-content-set--ignore-changes` attribute to an element and it will ignore any changes to that element and it's children.