### PR TITLE
chore: Fix watch task failure 

### DIFF
--- a/elements/pfe-sass/gulpfile.js
+++ b/elements/pfe-sass/gulpfile.js
@@ -32,7 +32,7 @@ task("build:sassdoc", () => src(["{extends,functions,maps,mixins,variables}/_*.s
 
 task("build", series("clean", "build:sassdoc"));
 
-task("watch", async () => {
+task("watch",  () => {
   watch(["{extends,functions,maps,mixins,variables}/_*.scss", "pfe-sass.scss"], {
     cwd: paths.compiled
   }, series("build:sassdoc"));

--- a/generators/element/templates/scripts/gulpfile.factory.js
+++ b/generators/element/templates/scripts/gulpfile.factory.js
@@ -319,7 +319,7 @@ ${fs
     )
   );
 
-  task("watch", async () => {
+  task("watch",  () => {
     watch(path.join(paths.source, "*"), series("build"));
   });
 

--- a/scripts/gulpfile.factory.js
+++ b/scripts/gulpfile.factory.js
@@ -336,7 +336,7 @@ ${fs
     )
   );
 
-  task("watch", async () => {
+  task("watch", () => {
     watch(path.join(paths.source, "*"), series("build"));
   });
 
@@ -350,7 +350,7 @@ ${fs
     series("clean", "compile:styles", "minify:styles", "copy:src", "copy:compiled", ...prebundle, "clean:post")
   );
 
-  task("watch:nojs", async () => {
+  task("watch:nojs", () => {
     watch(path.join(paths.source, "*"), series("build:nojs"));
   });
 


### PR DESCRIPTION
By setting the watch functions to async, we were telling the task to complete after firing but really we want the task to hang out until the command is cancelled.

### What has changed and why

- Removed async from the watch functions

### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- [x] `npm run dev pfe-cta`
- [x] `npm run dev`


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

