### PR TITLE
feat: Add nav-label functionality to pfe-jump-links

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -1,4 +1,11 @@
-## Prerelease 56 ( TBD )
+## Prerelease 59 ( 2021-04-21 )
+- [1549](https://github.com/patternfly/patternfly-elements/pull/1549) feat: Add nav-label to pfe-jump-links to support customized autobuild text in the pfe-jump-links-nav
+
+## Prerelease 58 ( 2021-02-22 )
+
+- [1391](https://github.com/patternfly/patternfly-elements/pull/1391) fix: Update pfe-jump-links to remove has_slot
+
+## Prerelease 56 ( 2020-08-27 )
 
 - [06a9b94](https://github.com/patternfly/patternfly-elements/commit/06a9b94505d1471d899f1db9704727c5a249a489) fix: move visual regression testing to merge script
 - [7aad6b](https://github.com/patternfly/patternfly-elements/commit/7aad6b463920cad87de2697ee5fdf99b46eb628e) feat: Remove build from postinstall

--- a/elements/pfe-jump-links/README.md
+++ b/elements/pfe-jump-links/README.md
@@ -78,6 +78,8 @@ No extra roles or aria labels are required because we're using standard html tag
 
 - `pfe-c-autobuild`: Flips the switch on the component to create its own markup for the navigation. You can add `pfe-jump-links-panel__section` to each section that should show in the nav. If you want to use sub-sections add `has-sub-section` to the parent section that should always show and the `sub-section` class to the children of that section. If you use this attribute, keep in mind that non-JavaScript environments (some search engines, browsers with JS disabled) will not see the proper markup.
 
+  - `nav-label`: This attribute can be added to headings with the `pfe-jump-links-panel__section` class in order to inform the navigation text to be used in the pfe-jump-links-nav (only works when autobuild is set for the navigation element).
+
 - `sr-text`: This attribute is read when the component upgrades to provide the innerText of the heading. If there is no `sr-text` attribute then the component defaults to "JUMP TO SECTION". This attribute is to enable translations and internationalization.
 
 - `pfe-c-offset`: This attribute determines the distance from the top of the browser window to trigger a switch from one link being active to the next. For instance `pfe-c-offset="600"` would mean that threshold flips at 600px from the top. The default is set at 200, and if you desire 200px then you can leave this attribute off. The `pfe-c-offset` attribute should be placed on `pfe-jump-links-panel`. There is a css solution to control the offset, however the attribute value takes precedence over css. To read more about a css solution see below.

--- a/elements/pfe-jump-links/demo/index.html
+++ b/elements/pfe-jump-links/demo/index.html
@@ -104,7 +104,7 @@
     <div class="pfe-l-grid__item pfe-m-12-col pfe-m-9-col-on-lg">
       <pfe-jump-links-panel class="special" pfe-c-scrolltarget="jumplinks1">
         <div>
-          <h1 class="pfe-jump-links-panel__section" id="section1">Section 1</h1>
+          <h1 class="pfe-jump-links-panel__section" id="section1" nav-label="First section">Section 1</h1>
           <p>Lorem ipsum dolor amet umami vaporware actually church-key keytar, hell of roof party unicorn helvetica
             lomo pop-up fam taxidermy food truck dolore. Crucifix quinoa af eiusmod try-hard velit aesthetic freegan
             seitan readymade vinyl snackwave four dollar toast neutra. In ipsum blog tbh. Authentic la croix bespoke

--- a/elements/pfe-jump-links/demo/index.html
+++ b/elements/pfe-jump-links/demo/index.html
@@ -104,7 +104,7 @@
     <div class="pfe-l-grid__item pfe-m-12-col pfe-m-9-col-on-lg">
       <pfe-jump-links-panel class="special" pfe-c-scrolltarget="jumplinks1">
         <div>
-          <h1 class="pfe-jump-links-panel__section" id="section1" nav-label="First section">Section 1</h1>
+          <h1 class="pfe-jump-links-panel__section" id="section1">Section 1</h1>
           <p>Lorem ipsum dolor amet umami vaporware actually church-key keytar, hell of roof party unicorn helvetica
             lomo pop-up fam taxidermy food truck dolore. Crucifix quinoa af eiusmod try-hard velit aesthetic freegan
             seitan readymade vinyl snackwave four dollar toast neutra. In ipsum blog tbh. Authentic la croix bespoke
@@ -577,7 +577,7 @@
     <div class="pfe-l-grid__item pfe-m-12-col pfe-m-9-col-on-lg">
       <pfe-jump-links-panel pfe-c-scrolltarget="jumplinks8">
         <div>
-          <h1 class="pfe-jump-links-panel__section" id="section6">Section 6</h1>
+          <h1 class="pfe-jump-links-panel__section" id="section6" nav-label="First section">Section 6</h1>
           <p>Lorem ipsum dolor amet umami vaporware actually church-key keytar, hell of roof party unicorn helvetica
             lomo pop-up fam taxidermy food truck dolore. Crucifix quinoa af eiusmod try-hard velit aesthetic freegan
             seitan readymade vinyl snackwave four dollar toast neutra. In ipsum blog tbh. Authentic la croix bespoke
@@ -611,7 +611,7 @@
             gentrify brooklyn fingerstache hoodie wolf. DIY veniam elit bushwick pok pok. Esse voluptate cillum, cred
             skateboard ethical forage aliqua master cleanse 90's cornhole. Id ut raclette swag ad keytar polaroid synth
             sunt williamsburg butcher woke lorem whatever squid. </p>
-          <h1 class="pfe-jump-links-panel__section" id="section7">Section 7</h1>
+          <h1 class="pfe-jump-links-panel__section" id="section7" nav-label="Next section">Section 7</h1>
           <p>Lorem ipsum dolor amet umami vaporware actually church-key keytar, hell of roof party unicorn helvetica
             lomo pop-up fam taxidermy food truck dolore. Crucifix quinoa af eiusmod try-hard velit aesthetic freegan
             seitan readymade vinyl snackwave four dollar toast neutra. In ipsum blog tbh. Authentic la croix bespoke

--- a/elements/pfe-jump-links/src/pfe-jump-links.js
+++ b/elements/pfe-jump-links/src/pfe-jump-links.js
@@ -168,26 +168,32 @@ class PfeJumpLinksNav extends PFElement {
 
       for (let i = 0; i < panelSections.length; i++) {
         let arr = [...panelSections];
-        if (arr[i].classList.contains("has-sub-section")) {
+        let section = arr[i];
+        let text = section.innerHTML;
+        // If a custom label was provided, use that instead
+        if (section.hasAttribute("nav-label")) {
+          text = section.getAttribute("nav-label");
+        }
+        if (section.classList.contains("has-sub-section")) {
           let linkListItem = `
           <li class="pfe-jump-links-nav__item">
             <a
               class="pfe-jump-links-nav__link has-sub-section"
-              href="#${arr[i].id}"
-              data-target="${arr[i].id}">
-                ${arr[i].innerHTML}
+              href="#${section.id}"
+              data-target="${section.id}">
+                ${text}
             </a>
             <ul class="sub-nav">
         `;
           linkList += linkListItem;
-        } else if (arr[i].classList.contains("sub-section")) {
+        } else if (section.classList.contains("sub-section")) {
           let linkSubItem = `
         <li class="pfe-jump-links-nav__item">
             <a
               class="pfe-jump-links-nav__link sub-section"
-              href="#${arr[i].id}"
-              data-target="${arr[i].id}">
-                ${arr[i].innerHTML}
+              href="#${section.id}"
+              data-target="${section.id}">
+                ${text}
             </a>
         </li>`;
           if (!arr[i + 1].classList.contains("sub-section")) {
@@ -199,9 +205,9 @@ class PfeJumpLinksNav extends PFElement {
           <li class="pfe-jump-links-nav__item">
             <a
               class="pfe-jump-links-nav__link"
-              href="#${arr[i].id}"
-              data-target="${arr[i].id}">
-                ${arr[i].innerHTML}
+              href="#${section.id}"
+              data-target="${section.id}">
+                ${text}
             </a>
           </li>
         `;

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,6 +58,7 @@
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-dropdown/demo">pfe-dropdown</a></pfe-cta>
+				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-foo/demo">pfe-foo</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-health-index/demo">pfe-health-index</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta>

--- a/examples/index.html
+++ b/examples/index.html
@@ -58,7 +58,6 @@
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-cta/demo">pfe-cta</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-datetime/demo">pfe-datetime</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-dropdown/demo">pfe-dropdown</a></pfe-cta>
-				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-foo/demo">pfe-foo</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-health-index/demo">pfe-health-index</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon/demo">pfe-icon</a></pfe-cta>
 				<pfe-cta pfe-priority="secondary" pfe-variant="wind"><a href="../elements/pfe-icon-panel/demo">pfe-icon-panel</a></pfe-cta>


### PR DESCRIPTION
**DO NOT MERGE.  THIS PR IS PURELY FOR CODE REVIEW AND WILL BE ROLLED AS v1.0.0-prerelease.59**

## Add nav-label functionality

- Added support for a `nav-label` attribute to be used in autobuild pfe-jump-links-nav elements


### Preview

Link(s) to demo page(s) where this element can be viewed:
- [Autobuild example with nav-label](http://localhost:8000/elements/pfe-jump-links/demo/#section6) (localhost)

### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- [x] *nav-label*
  1. Add a nav-label attribute with string value to any of the headings in the pfe-jump-links-panel that pairs with a pfe-jump-links-nav containing an autobuild attribute. :)
  2. The rendered nav should use the nav-label rather than the heading text.


#### Browser requirements

Your component should work in all of the following environments:

- [x] Latest 2 versions of Edge
- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Firefox 78 (or latest version for Red Hat Enterprise Linux distribution)
- [x] Latest 2 versions of Safari


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Browser testing passed.
- [x] Changelog updated.
- [x] Documentation (README.md, WHY.md, etc.) updated or added.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

