### PR TITLE
fix: Update pfelement logging so arrays and objects get printed (#1573)

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,5 @@
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Updating PFElement.log (aka this.log) so it logs arrays and objects, instead of converting them to strings
+
 # 1.6.0 (2021-04-23)
 
 - [0a549f8](https://github.com/patternfly/patternfly-elements/commit/0a549f8c54037e01006063800e729d633b515f66) feat: JSDoc preview added for PFElement

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,5 @@
+# 1.6.1 (2021)
+
 - [](https://github.com/patternfly/patternfly-elements/commit/) fix: Updating PFElement.log (aka this.log) so it logs arrays and objects, instead of converting them to strings
 
 # 1.6.0 (2021-04-23)

--- a/elements/pfelement/src/pfelement.js
+++ b/elements/pfelement/src/pfelement.js
@@ -58,7 +58,7 @@ class PFElement extends HTMLElement {
    * @example this.log("Hello");
    */
   log(...msgs) {
-    PFElement.log(`[${this.tag}${this.id ? `#${this.id}` : ""}]: ${msgs.join(", ")}`);
+    PFElement.log(`[${this.tag}${this.id ? `#${this.id}` : ""}]`, ...msgs);
   }
 
   /**


### PR DESCRIPTION
Code actually written by @mwcz, despite being committed by @wesruv

<!-- Labels: feature, needs: AT updates, needs: changelog, ready: branch testing, ready: browser testing, ready: code review, priority: low -->

## Updating PFElement.log (aka this.log) so it logs arrays and objects, instead of converting them to strings

### Related issues

- (#1573)

### Testing instructions

1. Add `PFElement._debugLog = true;` to `constructor()` of a component
2. Add `this.log(['foo', 'bar', 'baz'])` after `debugLog` somewhere
3. Verify that logged message prints the array so you can inspect it's values, and not as a flattened string (e.g. `[array]`)

### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable. -->

- [ ] Tests have been updated to cover these changes.
- [x] Changelog updated.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

