### PR TITLE
fix: Updating demo custom styles

### DIFF
--- a/elements/pfe-accordion/demo/demo.css
+++ b/elements/pfe-accordion/demo/demo.css
@@ -52,6 +52,23 @@ h2 {
     --pfe-theme--color--ui-accent: #ad41ad;
 }
 
+.custom-styles pfe-accordion-header[expanded] {
+    --pfe-accordion--accent: #ad41ad;
+}
+
+.custom-styles pfe-accordion pfe-accordion {
+    --pfe-accordion--accent: initial;
+    --pfe-theme--color--ui-accent: initial;
+    --pfe-broadcasted--text: initial;
+    --pfe-broadcasted--link: initial;
+    --pfe-broadcasted--link--hover: initial;
+    --pfe-broadcasted--link--focus: initial;
+}
+
+.custom-styles pfe-accordion pfe-accordion-header[expanded] {
+    --pfe-accordion--accent: initial;
+}
+
 .custom-styles h2 {
     margin-top: 0;
 }

--- a/elements/pfe-accordion/demo/index.html
+++ b/elements/pfe-accordion/demo/index.html
@@ -405,7 +405,7 @@
 
   <section class="custom-styles">
     <h2>&lt;pfe-accordion&gt; custom styles</h2><br />
-    <pfe-accordion>
+    <pfe-accordion id="#custom">
       <pfe-accordion-header>
         <h3>Why do wizards need money if they could just create it?</h3>
       </pfe-accordion-header>

--- a/elements/pfe-accordion/demo/index.html
+++ b/elements/pfe-accordion/demo/index.html
@@ -405,7 +405,7 @@
 
   <section class="custom-styles">
     <h2>&lt;pfe-accordion&gt; custom styles</h2><br />
-    <pfe-accordion id="#custom">
+    <pfe-accordion id="custom">
       <pfe-accordion-header>
         <h3>Why do wizards need money if they could just create it?</h3>
       </pfe-accordion-header>


### PR DESCRIPTION
Updating the accordion custom styles.

From:
<img width="1542" alt="Screen Shot 2021-05-06 at 3 59 22 PM" src="https://user-images.githubusercontent.com/1840295/117358360-1075be00-ae84-11eb-8436-c8fae868cf8a.png">

To:
<img width="1546" alt="Screen Shot 2021-05-06 at 4 01 07 PM" src="https://user-images.githubusercontent.com/1840295/117358583-5599f000-ae84-11eb-8216-11aa824fe697.png">

### Preview

[Preview](https://deploy-preview-1589--patternfly-elements.netlify.app/elements/pfe-accordion/demo/)

### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Documentation updates are clear and concise.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.  Documentation updates do not require a CHANGELOG entry.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**