### PR TITLE
chore: Add a tool to open an issue if the build on master breaks

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -27,7 +27,8 @@ jobs:
           column_name: Needs prioritization
       - name: Move to backlog
         uses: takanabe/github-actions-automate-projects@v0.0.1
-        if: contains(github.event.*.labels.*.name, 'needs: dev discovery')
+        if: |
+          contains(github.event.*.labels.*.name, 'needs: dev discovery')
         env:
           GITHUB_PROJECT_COLUMN_NAME: Needs prioritization
       - name: Move to hold

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,9 +5,9 @@ name: Update cards on project board
 
 on:
   issues:
-    types: [labeled, unlabeled]
-  pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, labeled]
+  # pull_request:
+  #   types: [labeled, unlabeled]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -19,11 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.*.state, 'open')
     steps:
+      - name: Assign new issues to project board
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: github.event.action == 'opened'
+        with:
+          project: 'https://github.com/patternfly/patternfly-elements/projects/2'
+          column_name: Needs prioritization
       - name: Move to backlog
         uses: takanabe/github-actions-automate-projects@v0.0.1
-        if: contains(github.event.*.labels.*.name, 'discovery')
+        if: contains(github.event.*.labels.*.name, 'needs: dev discovery')
         env:
-          GITHUB_PROJECT_COLUMN_NAME: Backlog
+          GITHUB_PROJECT_COLUMN_NAME: Needs prioritization
       - name: Move to hold
         uses: takanabe/github-actions-automate-projects@v0.0.1
         if: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,10 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'skip ci')
       ) ||
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action'
+      (
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/chore-add-broken-build-action'
+      )
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -121,7 +124,7 @@ jobs:
     name: Run test suite (Web Component Tester)
     needs: build
     runs-on: ubuntu-latest
-    if: needs.build.result == success()
+    if: needs.build.result == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -167,7 +170,7 @@ jobs:
     name: Run test suite (Web Test Runner)
     needs: build
     runs-on: ubuntu-latest
-    if: needs.build.result == success()
+    if: needs.build.result == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -218,7 +221,7 @@ jobs:
   e2e:
     name: Visual regression testing
     needs: build
-    if: needs.build.result == success() && (
+    if: needs.build.result == 'success' && (
         contains(github.event.pull_request.labels.*.name, 'ready to merge') ||
         contains(github.event.pull_request.labels.*.name, 'run e2e') ||
         contains(github.event.pull_request.user.login, 'dependabot')
@@ -301,20 +304,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action' # && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
-      - name: Test action
-        if: needs.test.result == failure() || needs.test-wtr.result == failure() || needs.e2e.result == failure()
-        uses: imjohnbo/issue-bot@v3
-        with:
-          assignees: "castastrophe"
-          labels: "fix, priority: high"
-          pinned: false
-          project: 2  # The project-number from organization project https://github.com/orgs/org/projects/project-number
-          column: Prioritized
-          close-previous: true
-          title: "[URGENT] ❌ Build is failing on master"
-          body: "{{ assignees }}, the master build is currently failing. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/{{ github.run_id }}) for more details."
       - name: Open issue if build breaks
-        if: needs.test == failure() || needs.test-wtr == failure() || needs.e2e == failure()
+        if: needs.test.result == 'failure' || needs.test-wtr.result == 'failure' || needs.e2e.result == 'failure'
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "castastrophe"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,15 @@ env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
   # Turn this on to debug an action
-  # GITHUB_CONTEXT: ${{ toJson(github) }}
+  GITHUB_CONTEXT: toJson(github)
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - name: debugging context
+        run: echo ${{ env.GITHUB_CONTEXT }}
   build:
     name: Compile project
     outputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
     #   - "*.md"
   # Build when PRs are merged into master/main
   push:
-    branches: [master, main, chore-add-broken-build-action]
+    branches: [master, main]
   # Manual run, no inputs necessary
   workflow_dispatch:
 
@@ -313,5 +313,5 @@ jobs:
           project: 2  # The project-number from organization project https://github.com/orgs/org/projects/project-number
           column: Prioritized
           close-previous: true
-          title: "[URGENT] ❌ Build is failing on master"
+          title: "❌ Build is failing on master"
           body: "It looks like the build is currently failing on the master branch. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/${{ github.run_id }}) for more details."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -288,12 +288,12 @@ jobs:
           local-testing: stop
   validate:
     name: Validate successful build on master
-    needs: [test, e2e]
+    needs: [test, test-wtr, e2e]
     if: github.event_name == 'push' && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Open issue if build breaks
-        if: needs.test == failure() || needs.e2e == failure()
+        if: needs.test == failure() || needs.test-wtr == failure() || needs.e2e == failure()
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "castastrophe"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,7 +298,7 @@ jobs:
   validate:
     name: Validate successful build on master
     needs: [test, test-wtr, e2e]
-    if: github.event_name == 'push' && github.ref == 'chore-add-broken-build-action' # && github.ref == 'master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action' # && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Test action

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,13 +304,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Open issue if build breaks
-        if: needs.test.result == 'failure' || needs.test-wtr.result == 'failure' || needs.e2e.result == 'failure'
+        if: |
+          needs.test.result == 'failure' ||
+          needs.test-wtr.result == 'failure' ||
+          needs.e2e.result == 'failure'
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "castastrophe"
           labels: "fix, priority: high"
-          pinned: false
-          project: 2  # The project-number from organization project https://github.com/orgs/org/projects/project-number
+          pinned: true
+          project: 2  # The project-number from organization project
           column: Prioritized
           close-previous: true
           title: "❌ Build is failing on master"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -301,7 +301,11 @@ jobs:
   validate:
     name: Validate successful build on master
     needs: [test, test-wtr, e2e]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action' # && github.ref == 'master'
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/chore-add-broken-build-action'
+    # && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - run: echo "{{ needs.test.result }} || {{ needs.test-wtr.result }} || {{ needs.e2e.result }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,6 +299,8 @@ jobs:
           assignees: "castastrophe"
           labels: "fix, priority: high"
           pinned: false
-          close-previous: false
-          title: "[URGENT] Build is failing on master"
-          body: "{{ assignees }}, the master build is currently failing."
+          project: 2  # The project-number from organization project https://github.com/orgs/org/projects/project-number
+          column: Prioritized
+          close-previous: true
+          title: "[URGENT] ❌ Build is failing on master"
+          body: "{{ assignees }}, the master build is currently failing. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/{{ github.run_id }}) for more details."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,6 +304,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action' # && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
+      - run: echo "{{ needs.test.result }} || {{ needs.test-wtr.result }} || {{ needs.e2e.result }}"
       - name: Open issue if build breaks
         if: needs.test.result == 'failure' || needs.test-wtr.result == 'failure' || needs.e2e.result == 'failure'
         uses: imjohnbo/issue-bot@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,12 +43,12 @@ env:
 
 jobs:
   # Turn this on to debug an action
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debugging context variables
-        run: echo "$GITHUB_CONTEXT"
+  # debug:
+  #   name: Debug
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Debugging context variables
+  #       run: echo "$GITHUB_CONTEXT"
   build:
     name: Compile project
     outputs:
@@ -72,10 +72,7 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'skip ci')
       ) ||
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/chore-add-broken-build-action'
-      )
+      github.event_name == 'push'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -303,12 +300,9 @@ jobs:
     needs: [test, test-wtr, e2e]
     if: |
       always() &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/chore-add-broken-build-action'
-    # && github.ref == 'master'
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "{{ needs.test.result }} || {{ needs.test-wtr.result }} || {{ needs.e2e.result }}"
       - name: Open issue if build breaks
         if: needs.test.result == 'failure' || needs.test-wtr.result == 'failure' || needs.e2e.result == 'failure'
         uses: imjohnbo/issue-bot@v3
@@ -320,4 +314,4 @@ jobs:
           column: Prioritized
           close-previous: true
           title: "[URGENT] ❌ Build is failing on master"
-          body: "{{ assignees }}, the master build is currently failing. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/{{ github.run_id }}) for more details."
+          body: "It looks like the build is currently failing on the master branch. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/${{ github.run_id }}) for more details."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ env:
   # https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
   ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
-  GITHUB_CONTEXT: toJson(github)
+  GITHUB_CONTEXT: ${{ toJson(github) }}
 
 jobs:
   # Turn this on to debug an action

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,15 +40,15 @@ env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
   # Turn this on to debug an action
-  GITHUB_CONTEXT: toJson(github)
+  # GITHUB_CONTEXT: toJson(github)
 
 jobs:
   debug:
     name: Debug
     runs-on: ubuntu-latest
     steps:
-      - name: debugging context
-        run: echo ${{ env.GITHUB_CONTEXT }}
+      - name: Debugging context variables
+        run: echo ${{ toJson(github) }}
   build:
     name: Compile project
     outputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
     #   - "*.md"
   # Build when PRs are merged into master/main
   push:
-    branches: [master, main]
+    branches: [master, main, chore-add-broken-build-action]
   # Manual run, no inputs necessary
   workflow_dispatch:
 
@@ -289,9 +289,21 @@ jobs:
   validate:
     name: Validate successful build on master
     needs: [test, test-wtr, e2e]
-    if: github.event_name == 'push' && github.ref == 'master'
+    if: github.event_name == 'push' && github.ref == 'chore-add-broken-build-action' # && github.ref == 'master'
     runs-on: ubuntu-latest
     steps:
+      - name: Test action
+        if: needs.test == failure() || needs.test-wtr == failure() || needs.e2e == failure()
+        uses: imjohnbo/issue-bot@v3
+        with:
+          assignees: "castastrophe"
+          labels: "fix, priority: high"
+          pinned: false
+          project: 2  # The project-number from organization project https://github.com/orgs/org/projects/project-number
+          column: Prioritized
+          close-previous: true
+          title: "[URGENT] ❌ Build is failing on master"
+          body: "{{ assignees }}, the master build is currently failing. See failed [action results](https://github.com/patternfly/patternfly-elements/actions/runs/{{ github.run_id }}) for more details."
       - name: Open issue if build breaks
         if: needs.test == failure() || needs.test-wtr == failure() || needs.e2e == failure()
         uses: imjohnbo/issue-bot@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,16 +39,16 @@ env:
   # https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
   ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
-  # Turn this on to debug an action
-  # GITHUB_CONTEXT: toJson(github)
+  GITHUB_CONTEXT: toJson(github)
 
 jobs:
+  # Turn this on to debug an action
   debug:
     name: Debug
     runs-on: ubuntu-latest
     steps:
       - name: Debugging context variables
-        run: echo ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   build:
     name: Compile project
     outputs:
@@ -70,11 +70,8 @@ jobs:
         github.event.pull_request.draft == false
       ) ||
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' && github.ref == 'chore-add-broken-build-action'
+      github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action'
     steps:
-      # Turn this on to debug an action
-      # - run: echo "$GITHUB_CONTEXT"
-
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,9 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.event.action != 'labeled' &&
-        github.event.pull_request.draft == false
+        github.event.pull_request.draft == false &&
+        !contains(github.event.pull_request.labels.*.name, 'blocked') &&
+        !contains(github.event.pull_request.labels.*.name, 'skip ci')
       ) ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' && github.ref == 'refs/heads/chore-add-broken-build-action'
@@ -119,6 +121,7 @@ jobs:
     name: Run test suite (Web Component Tester)
     needs: build
     runs-on: ubuntu-latest
+    if: needs.build.result == success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -164,7 +167,7 @@ jobs:
     name: Run test suite (Web Test Runner)
     needs: build
     runs-on: ubuntu-latest
-
+    if: needs.build.result == success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -215,11 +218,11 @@ jobs:
   e2e:
     name: Visual regression testing
     needs: build
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'ready to merge') ||
-      contains(github.event.pull_request.labels.*.name, 'run e2e') ||
-      contains(github.event.pull_request.user.login, 'dependabot') ||
-      contains(github.event.pull_request.user.login, 'dependabot-preview')
+    if: needs.build.result == success() && (
+        contains(github.event.pull_request.labels.*.name, 'ready to merge') ||
+        contains(github.event.pull_request.labels.*.name, 'run e2e') ||
+        contains(github.event.pull_request.user.login, 'dependabot')
+      ) && !contains(github.event.pull_request.labels.*.name, 'skip vrt')
     runs-on: ubuntu-latest
     steps:
       - name: BrowserStack environment setup
@@ -290,6 +293,8 @@ jobs:
         uses: browserstack/github-actions/setup-local@master
         with:
           local-testing: stop
+
+  # Validate the build to master was successful; open an issue if not
   validate:
     name: Validate successful build on master
     needs: [test, test-wtr, e2e]
@@ -297,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Test action
-        if: needs.test == failure() || needs.test-wtr == failure() || needs.e2e == failure()
+        if: needs.test.result == failure() || needs.test-wtr.result == failure() || needs.e2e.result == failure()
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "castastrophe"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,3 +286,19 @@ jobs:
         uses: browserstack/github-actions/setup-local@master
         with:
           local-testing: stop
+  validate:
+    name: Validate successful build on master
+    needs: [test, e2e]
+    if: github.event_name == 'push' && github.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue if build breaks
+        if: needs.test == failure() || needs.e2e == failure()
+        uses: imjohnbo/issue-bot@v3
+        with:
+          assignees: "castastrophe"
+          labels: "fix, priority: high"
+          pinned: false
+          close-previous: false
+          title: "[URGENT] Build is failing on master"
+          body: "{{ assignees }}, the master build is currently failing."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,8 @@ jobs:
         github.event.action != 'labeled' &&
         github.event.pull_request.draft == false
       ) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' && github.ref == 'chore-add-broken-build-action'
     steps:
       # Turn this on to debug an action
       # - run: echo "$GITHUB_CONTEXT"

--- a/elements/pfe-accordion/test/pfe-accordion_test.js
+++ b/elements/pfe-accordion/test/pfe-accordion_test.js
@@ -1,5 +1,6 @@
 suite('<pfe-accordion>', () => {
   test('it should upgrade pfe-accordion', () => {
+    assert.equal("foo", "bar");
     assert.instanceOf(document.querySelector('pfe-accordion'), customElements.get("pfe-accordion"), 'pfe-accordion should be an instance of PfeAccordion');
   });
 

--- a/elements/pfe-accordion/test/pfe-accordion_test.js
+++ b/elements/pfe-accordion/test/pfe-accordion_test.js
@@ -1,6 +1,5 @@
 suite('<pfe-accordion>', () => {
   test('it should upgrade pfe-accordion', () => {
-    assert.equal("foo", "bar");
     assert.instanceOf(document.querySelector('pfe-accordion'), customElements.get("pfe-accordion"), 'pfe-accordion should be an instance of PfeAccordion');
   });
 


### PR DESCRIPTION
This action validates the build on master and if it failed, it opens a new issue.