### PR TITLE
fix: IE11 regression; background should be set to white to prevent context errors

### DIFF
--- a/elements/pfe-accordion/src/pfe-accordion-header.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-header.scss
@@ -24,6 +24,8 @@
 
     @include browser-query(ie11) {
       padding: 16px 24px;
+      background-color: pfe-fetch(surface--lightest) !important;
+      color: pfe-fetch(text) !important;
       &:hover {
         border-left-color: pfe-fetch(ui-accent);
       }

--- a/elements/pfe-accordion/src/pfe-accordion-panel.scss
+++ b/elements/pfe-accordion/src/pfe-accordion-panel.scss
@@ -9,6 +9,10 @@
    @include pfe-accordion-props;
    @include pfe-box-sizing;
    box-sizing: border-box;
+   @include browser-query(ie11) {
+    background-color: pfe-fetch(surface--lightest) !important;
+    color: pfe-fetch(text) !important;
+   }
 }
 
 :host(.animating) {


### PR DESCRIPTION
<!-- Labels: tools, ready: branch testing, needs: code review, priority: low -->

<!-- Thank you for submitting a pull request! -->
## Infrastructure updates

IE11 for pfe-accordion should show background-color white and text black in all contexts to prevent inaccessible content.


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

1. Open the pfe-accordion demo in IE11
2. All accordions should have a white background with black text


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable to your PR. -->

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Repository compiles and tests pass.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

