### PR TITLE
feat: Update fetch mixin to support region input (#1328) 

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,6 +1,7 @@
 # 1.8.0 (2021)
 
-- [](https://github.com/patternfly/patternfly-elements/commit/) feat: pfe-icon now supports setting default icon sets
+- [f1c1176](https://github.com/patternfly/patternfly-elements/commit/f1c1176d9278d6e5b8066b42fc040ea01d98ecb2) feat: pfe-icon now supports setting default icon sets
+- [](https://github.com/patternfly/patternfly-elements/commit/) feat: Update fetch mixin to support region input (#1328)
 - [56eb55e](https://github.com/patternfly/patternfly-elements/commit/56eb55ec8b4b62aee7d36950d158229cbf50ddef) fix: pfe-accordion IE11 regression; background context should always be white with black text
 
 # 1.7.0 (2021-05-10)

--- a/elements/pfe-sass/functions/_custom-properties.scss
+++ b/elements/pfe-sass/functions/_custom-properties.scss
@@ -134,12 +134,15 @@
 ///   .my-element {
 ///     background-color: pfe-fetch( ui-base );
 ///   }
-@function pfe-fetch($name) {
+@function pfe-fetch($name, $region: '') {
     $var-name: to-string($name, "--");
-    @if map-get($LOCAL-VARIABLES, $var-name) != null {
+    @if $region != '' and map-deep-get($LOCAL-VARIABLES, $region, $var-name) != null {
+        @return map-deep-get($LOCAL-VARIABLES, $region, $var-name);
+    }
+    @else if $region == '' and map-get($LOCAL-VARIABLES, $var-name) != null {
         @return map-get($LOCAL-VARIABLES, $var-name);
     }
-    @if map-get($pfe-vars, $var-name) != null {
+    @else if map-get($pfe-vars, $var-name) != null {
         @return map-get($pfe-vars, $var-name);
     }
     @else if map-get($pfe-colors, $var-name) != null {

--- a/elements/pfe-sass/functions/_custom-properties.scss
+++ b/elements/pfe-sass/functions/_custom-properties.scss
@@ -127,6 +127,7 @@
 /// Returns the value (only) of a property from the respective maps
 /// Similar to pfe-var, but does not include css variable in the compiled CSS
 /// @param {String} $name - Name of the key for the map
+/// @param {String} $region - Identifies the region or slot to which this is assigned
 /// @see $pfe-vars
 /// @see $pfe-colors
 /// @see $pfe-broadcasted
@@ -134,12 +135,12 @@
 ///   .my-element {
 ///     background-color: pfe-fetch( ui-base );
 ///   }
-@function pfe-fetch($name, $region: '') {
+@function pfe-fetch($name, $region: null) {
     $var-name: to-string($name, "--");
-    @if $region != '' and map-deep-get($LOCAL-VARIABLES, $region, $var-name) != null {
+    @if $region != null and map-deep-get($LOCAL-VARIABLES, $region, $var-name) != null {
         @return map-deep-get($LOCAL-VARIABLES, $region, $var-name);
     }
-    @else if $region == '' and map-get($LOCAL-VARIABLES, $var-name) != null {
+    @else if $region == null and map-get($LOCAL-VARIABLES, $var-name) != null {
         @return map-get($LOCAL-VARIABLES, $var-name);
     }
     @else if map-get($pfe-vars, $var-name) != null {


### PR DESCRIPTION
<!-- Labels: feature, ready: branch testing, ready: browser testing, needs: code review, priority: low -->

<!-- Thank you for submitting a pull request! -->
## Component updates: <component-name>

Currently, pfe-fetch can query the $LOCAL-VARIABLES map but it does not accept an optional $region variable so it cannot capture values from the map inside nested region maps.

This PR fixes that issue.


### Related issues

- (#1328) [feat] pfe-sass | pfe-fetch accept $region variable


### What has changed and why

<!-- Summarize files edited as part of this MR along with a brief description of what was changed/why. -->

- Allow pfe-fetch to receive an optional region value which it can then use to deep search $LOCAL-VARIABLES maps


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

1. In the pfe-cta.scss file, try: `pfe-fetch(Display, $region: arrow)` --> should output: `inline` in the _temp/pfe-cta.css file. 


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Changelog updated.
- [x] Documentation (README.md, WHY.md, etc.) updated or added.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

