### PR TITLE
fix: Fix content set ID copy to shadow dom

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,7 @@
+# 1.9.2 (2021-05-27)
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-content-set, bring back IE copy from parent to nested item
+
 # 1.9.1 (2021-05-27)
 
 - [21bee7a](https://github.com/patternfly/patternfly-elements/commit/21bee7afb03d9736870ec597f4b29ceb18862276) fix: pfe-content-set, Safari 14.1.1 / WebKitGTK 2.32.0 bug fix (IE11 update: only renders as accordion)

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,6 +1,6 @@
 # 1.9.2 (2021-05-27)
 
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-content-set, bring back IE copy from parent to nested item
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: pfe-content-set, bring back ID copy from parent to nested item
 
 # 1.9.1 (2021-05-27)
 

--- a/elements/pfe-content-set/src/pfe-content-set.js
+++ b/elements/pfe-content-set/src/pfe-content-set.js
@@ -467,6 +467,8 @@ class PfeContentSet extends PFElement {
       Promise.all([customElements.whenDefined(this.expectedTag)]).then(() => {
         const template = this.expectedTag === "pfe-tabs" ? PfeTabs.contentTemplate : PfeAccordion.contentTemplate;
         const sets = this._buildSets(addedNodes, template);
+        sets.id = this.id || this.randomId;
+        
         const container = this.shadowRoot.querySelector("#container");
 
         if (sets && container) {


### PR DESCRIPTION
In the rewrite required to fix the Safari 14.1.1 issue, the ID copy from parent to nested shadow DOM component was missed.  This brings that back.

- [Link](https://deploy-preview-1653--patternfly-elements.netlify.app/elements/pfe-content-set/demo)


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- [x] Open the [demo page](https://deploy-preview-1653--patternfly-elements.netlify.app/elements/pfe-content-set/demo/?my-content-set=header-2#mycontent-set), should show the 2nd tab as active
- [x] Open the [demo page](https://deploy-preview-1653--patternfly-elements.netlify.app/elements/pfe-content-set/demo/#mycontent-set), click around in the tabs and validate that the URL updates


### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Changelog updated.

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

