### PR TITLE
CPFED-4211: change aria text for main nav to Main

### DIFF
--- a/elements/pfe-navigation/src/pfe-navigation.html
+++ b/elements/pfe-navigation/src/pfe-navigation.html
@@ -1,4 +1,4 @@
-<nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main Navigation">
+<nav id="pfe-navigation__wrapper" class="pfe-navigation__wrapper" aria-label="Main">
   <!-- @todo: make sure all icons are the updated redesigned versions -->
   <button class="pfe-navigation__menu-toggle" id="mobile__button">
     <div class="pfe-navigation__burger-icon"></div>


### PR DESCRIPTION
Changed aria-text of pfe-nav from "Main navigation" to "Main" to remove redundancy for screen readers.

