### PR TITLE
fix: [pfe-tooltip] forced reflow performance isssues

### DIFF
--- a/elements/pfe-absolute-position/CHANGELOG.md
+++ b/elements/pfe-absolute-position/CHANGELOG.md
@@ -1,5 +1,3 @@
-## 1.3.0 ( TBD )
+# 1.x.x-beta
 
-Tag: [1.3.0](https://github.com/patternfly/patternfly-elements/releases/tag/1.3.0)
-
-- [code](url) Description
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: forced reflow performance isssues

--- a/elements/pfe-absolute-position/package.json
+++ b/elements/pfe-absolute-position/package.json
@@ -11,7 +11,7 @@
     },
     "assets": []
   },
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "keywords": [
     "web-components",
     "html"

--- a/elements/pfe-absolute-position/src/pfe-absolute-position.js
+++ b/elements/pfe-absolute-position/src/pfe-absolute-position.js
@@ -217,7 +217,7 @@ class PfeAbsolutePosition extends PFElement {
       this._updatingPosition = true;
       // ask the manager to update our position over the target element.
       this.__manager.positionElement(this);
-      // we are only going to debounce this for one second.
+      // we are only going to debounce this for 100ms.
       // not doing this will result in a reflow request loop and crash the browser :(
       setTimeout(() => {
         this._updatingPosition = false;

--- a/elements/pfe-absolute-position/src/pfe-absolute-position.js
+++ b/elements/pfe-absolute-position/src/pfe-absolute-position.js
@@ -210,10 +210,21 @@ class PfeAbsolutePosition extends PFElement {
    * @returns {void}
    */
   updatePosition() {
+    // waiting until the position manager sets this._updatingPostion to
+    if (this._updatingPosition) return;
     if (this.__observe === true) {
+      // set the internal state to updating
+      this._updatingPosition = true;
+      // ask the manager to update our position over the target element
       this.__manager.positionElement(this);
+      // we are only going to debounce this for one second.
+      // not doing this will result in a reflow request loop and crash the browser :(
+      setTimeout(() => {
+        this._updatingPosition = false;
+      }, 100);
     }
   }
+
   /**
    * life cycle, element is removed from DOM
    * @returns {void}

--- a/elements/pfe-absolute-position/src/pfe-absolute-position.js
+++ b/elements/pfe-absolute-position/src/pfe-absolute-position.js
@@ -210,12 +210,14 @@ class PfeAbsolutePosition extends PFElement {
    * @returns {void}
    */
   updatePosition() {
-    // waiting until the position manager sets this._updatingPostion to
+    // waiting until the position manager sets this._updatingPosition to
+    // "true" which means that we can update the position again if we wish
+    // without cause forced reflow issues.
     if (this._updatingPosition) return;
     if (this.__observe === true) {
-      // set the internal state to updating
+      // set the internal state to updating.
       this._updatingPosition = true;
-      // ask the manager to update our position over the target element
+      // ask the manager to update our position over the target element.
       this.__manager.positionElement(this);
       // we are only going to debounce this for one second.
       // not doing this will result in a reflow request loop and crash the browser :(

--- a/elements/pfe-absolute-position/src/pfe-absolute-position.js
+++ b/elements/pfe-absolute-position/src/pfe-absolute-position.js
@@ -210,9 +210,7 @@ class PfeAbsolutePosition extends PFElement {
    * @returns {void}
    */
   updatePosition() {
-    // waiting until the position manager sets this._updatingPosition to
-    // "true" which means that we can update the position again if we wish
-    // without cause forced reflow issues.
+    // if we are currently updating the position then ignore this request
     if (this._updatingPosition) return;
     if (this.__observe === true) {
       // set the internal state to updating.

--- a/elements/pfe-popover/package.json
+++ b/elements/pfe-popover/package.json
@@ -11,7 +11,7 @@
     },
     "assets": []
   },
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "keywords": [
     "web-components",
     "html"
@@ -54,7 +54,7 @@
   "dependencies": {
     "@patternfly/pfelement": "^1.6.0",
     "@patternfly/pfe-icon": "^1.6.0",
-    "@rhdc-fed/pfe-absolute-position": "^1.0.0-alpha.1",
+    "@rhdc-fed/pfe-absolute-position": "^1.0.0-alpha.2",
     "gh-pages": "^2.2.0"
   },
   "devDependencies": {

--- a/elements/pfe-tooltip/package.json
+++ b/elements/pfe-tooltip/package.json
@@ -11,7 +11,7 @@
     },
     "assets": []
   },
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "keywords": [
     "web-components",
     "html"
@@ -53,7 +53,7 @@
   "license": "MIT",
   "dependencies": {
     "@patternfly/pfelement": "^1.6.0",
-    "@rhdc-fed/pfe-absolute-position": "^1.0.0-alpha.1",
+    "@rhdc-fed/pfe-absolute-position": "^1.0.0-alpha.2",
     "gh-pages": "^2.2.0"
   }
 }


### PR DESCRIPTION
## Description

When a use hovers over a tooltip very quickly and repetitively it was causing warnings for `forced reflow`.  This is caused when javascript is trying to calculate styles at the same time it's applying them.  This would cause sever performance issues.

The cause is that we are trying to update the position of the tooltip when the it was about to activate.  This would allow the target to potentially move around the screen and the tooltip would always follow it.

## Replicate Issue

- Go here: https://deploy-preview-1406--patternfly-elements.netlify.app/elements/pfe-tooltip/demo/
- Open dev console
- Quickly hover over the different tooltips in quick succession
- You should see a `forced reflow` warning in your console

![Screen Shot 2021-07-07 at 1 41 45 PM](https://user-images.githubusercontent.com/3428964/124805232-3de4f380-df29-11eb-8863-00cb57f2ae23.png)
  

## Tests
- [ ] Verify it prevents force reflow errors
 - Go here: https://deploy-preview-1702--patternfly-elements.netlify.app/elements/pfe-tooltip/demo/
 - Open dev console
 - Quickly hover over the different tooltips in quick succession
 - There should be no slowdown in how the tooltip renders