### PR TITLE
fix: IE11 bug for jump links 

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,7 @@
+# 1.10.2 (2021)
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: Jump links parseInt for IE11
+
 # 1.10.1 (2021-07-12)
 
 - [b717636](https://github.com/patternfly/patternfly-elements/commit/b717636782ebce33b4549ba9f68ffff09c036889) fix: pfelement - only resetContext on a nested child element during contextUpdate if resetContext is available on the child

--- a/elements/pfe-jump-links/src/pfe-jump-links-nav.js
+++ b/elements/pfe-jump-links/src/pfe-jump-links-nav.js
@@ -140,7 +140,7 @@ class PfeJumpLinksNav extends PFElement {
     if (data.length < 1) return "991px";
 
     // Subtract one because PFElement breakpoints uses mobile-first numbering
-    return window.matchMedia(`(max-width: ${Number.parseInt(data[1], 10) - 1}${data[2]})`).matches;
+    return window.matchMedia(`(max-width: ${parseInt(data[1], 10) - 1}${data[2]})`).matches;
   }
 
   /**
@@ -310,7 +310,7 @@ class PfeJumpLinksNav extends PFElement {
         {
           type: Number,
         },
-        Number.parseInt(offsetVariable, 10)
+        parseInt(offsetVariable, 10)
       );
       if (offsetVariable && offsetVariable >= 0) return offsetVariable;
     }
@@ -326,7 +326,7 @@ class PfeJumpLinksNav extends PFElement {
         {
           type: Number,
         },
-        Number.parseInt(navHeightVariable, 10)
+        parseInt(navHeightVariable, 10)
       );
       if (navHeightVariable && navHeightVariable > 0) height = navHeightVariable;
     }
@@ -341,7 +341,7 @@ class PfeJumpLinksNav extends PFElement {
         {
           type: Number,
         },
-        Number.parseInt(stickyJumpLinks, 10)
+        parseInt(stickyJumpLinks, 10)
       );
       if (stickyJumpLinks && stickyJumpLinks > 0) height = height + stickyJumpLinks;
     }
@@ -770,7 +770,7 @@ class PfeJumpLinksNav extends PFElement {
 
     // Check if we need to update the variable:
     const currentHeight = this.cssVariable(`pfe-jump-links--Height--actual`, null, document.body);
-    if (!currentHeight || Number.parseInt(currentHeight, 10) !== height) {
+    if (!currentHeight || parseInt(currentHeight, 10) !== height) {
       // If there are no other sticky jump links, set the height on the body
       // Note: we set it on the body to be consistent with pfe-navigation
       this.cssVariable(`pfe-jump-links--Height--actual`, `${height}px`, document.body);
@@ -943,7 +943,7 @@ class PfeJumpLinksNav extends PFElement {
         {
           type: Number,
         },
-        Number.parseInt(section.getAttribute("offset"), 10)
+        parseInt(section.getAttribute("offset"), 10)
       );
       if (sectionOffsetProp) itemOffset = sectionOffsetProp;
     } else if (this.panel && this.panel.offset) {


### PR DESCRIPTION
<!-- Labels: feature, ready: branch testing, ready: browser testing, ready: code review, priority: low -->

- [parseInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt) Number.parseInt doesn't work in IE11, only the globally scoped parseInt does


#### Browser requirements

Your component should work in all of the following environments:

- [x] Internet Explorer 11 (should be useable, not pixel perfect)
- [x] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Browser testing passed.
- [x] Changelog updated (required for fix and feat changes).


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

