### PR TITLE
fix: Issue with slotted content rendering in pfe-accordion-header

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,9 +1,10 @@
 # 1.11.0 (2021)
 
 - [d3ea7fa](https://github.com/patternfly/patternfly-elements/commit/d3ea7facb0c36b7f3e20e2568bdc4bf2e5a5a852) feat: Graceful failure for component registry
-- [](https://github.com/patternfly/patternfly-elements/commit/) fix: container sass placeholder using incorrect variable for spacing (#1522)
 - [099dc3e](https://github.com/patternfly/patternfly-elements/commit/099dc3e2d3ce732a32ecde0644f5c03ec1e8dd9c) fix: Accordion alignment with latest design kit
 - [5f88c39](https://github.com/patternfly/patternfly-elements/commit/5f88c3963f8a6c13a9aeba6e9f664678453d46ce) fix: Jump links parseInt for IE11
+- [43a904e](https://github.com/patternfly/patternfly-elements/commit/43a904e2ce4f2ef7182f803bf35ade463e7c2f1d) fix: container sass placeholder using incorrect variable for spacing (#1522)
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: accordion rendering slotted content in the header
 
 # 1.10.1 (2021-07-12)
 

--- a/elements/pfe-accordion/src/pfe-accordion-header.js
+++ b/elements/pfe-accordion/src/pfe-accordion-header.js
@@ -196,8 +196,10 @@ class PfeAccordionHeader extends PFElement {
         // Capture it's assigned nodes for validation
         let slotted = node.assignedNodes();
         // If slotted elements were found, add it to the nodeList
-        if (slotted && slotted.length > 0) nodes[idx] = slotted;
-        else {
+        if (slotted && slotted.length > 0) {
+          // Remove the slot from the set, add the slotted content
+          nodes.splice(idx, 1, ...slotted);
+        } else {
           // If no content exists in the slot, check for default content in the slot template
           const defaults = node.children;
           if (defaults && defaults.length > 0) nodes[idx] = defaults[0];


### PR DESCRIPTION
<!-- Labels: feature, ready: branch testing, ready: browser testing, ready: code review, priority: low -->

<!-- Thank you for submitting a pull request! -->
## Component updates: pfe-accordion

Regression in pfe-accordion rendering slotted content in the header region.

<img width="626" alt="Screen Shot 2021-08-03 at 5 10 11 PM" src="https://user-images.githubusercontent.com/1840295/128086639-0a8a0502-66b4-429b-9ae0-96d81a56ef60.png">

URL: https://patternflyelements.org/components/content-set/


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- [x] *Visit [demo](https://deploy-preview-1742--patternfly-elements.netlify.app/elements/pfe-content-set/demo/)*
  1. Validate that all accordion headers render with their text and not "undefined"
- [x] *Visit [demo](https://deploy-preview-1742--patternfly-elements.netlify.app/elements/pfe-content-set/demo/)*
  1. Resize one of the panels rendering as a tabset
  2. Validate that all accordion headers it uses now render with their text and not "undefined"


#### Browser requirements

Your component should work in all of the following environments:

- [x] Latest Firefox (on Mac OS)
- [x] Latest Chrome (on Mac OS)
- [x] Latest Safari

### Ready-for-merge Checklist

Check off items as they are completed.  Feel free to delete items if they are not applicable.

- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [x] Browser testing passed.
- [x] Changelog updated (required for fix and feat changes).

### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

