### PR TITLE
fix: Adding better details to accordion events

### DIFF
--- a/elements/pfe-accordion/src/pfe-accordion-header.js
+++ b/elements/pfe-accordion/src/pfe-accordion-header.js
@@ -161,10 +161,11 @@ class PfeAccordionHeader extends PFElement {
     }
   }
 
-  _clickHandler() {
+  _clickHandler(event) {
     this.emitEvent(PfeAccordionHeader.events.change, {
       detail: {
         expanded: !this.expanded,
+        toggle: event.target,
       },
     });
   }

--- a/elements/pfe-accordion/src/pfe-accordion.js
+++ b/elements/pfe-accordion/src/pfe-accordion.js
@@ -178,7 +178,12 @@ class PfeAccordion extends PFElement {
 
     header.focus();
 
-    this.emitEvent(PfeAccordion.events.expand);
+    this.emitEvent(PfeAccordion.events.expand, {
+      detail: {
+        toggle: header,
+        panel: panel,
+      },
+    });
   }
 
   /**
@@ -207,7 +212,12 @@ class PfeAccordion extends PFElement {
     this._collapseHeader(header);
     this._collapsePanel(panel);
 
-    this.emitEvent(PfeAccordion.events.collapse);
+    this.emitEvent(PfeAccordion.events.collapse, {
+      detail: {
+        toggle: header,
+        panel: panel,
+      },
+    });
   }
 
   /**

--- a/elements/pfe-accordion/test/pfe-accordion.spec.js
+++ b/elements/pfe-accordion/test/pfe-accordion.spec.js
@@ -179,14 +179,14 @@ describe("<pfe-accordion>", () => {
     const pfeAccordion = await createFixture(testElement);
     const header = pfeAccordion.querySelector('pfe-accordion-header');
     // const panel = pfeAccordion.querySelector('pfe-accordion-panel');
-    
+
     setTimeout(() => header.click(), 100);
 
     const { detail } = await oneEvent(pfeAccordion, "pfe-accordion:change");
 
     assert.deepEqual(detail, {
       expanded: true,
-      // toggle: header,
+      toggle: header,
       // panel: panel
     });
   });
@@ -215,12 +215,12 @@ describe("<pfe-accordion>", () => {
 
     // Wait until the animation is complete
     await oneEvent(pfeAccordion, "transitionend");
-    
+
     [2,3].forEach(idx => {
       const header = headers[idx - 1];
       assert.isTrue(header.expanded);
       assert.isTrue(header.hasAttribute("expanded"));
-  
+
       const panel = pfeAccordion._panelForHeader(header);
       assert.isTrue(panel.expanded);
       assert.isTrue(panel.hasAttribute("expanded"));
@@ -244,7 +244,7 @@ describe("<pfe-accordion>", () => {
 
     assert.equal(headers.length, 1);
     assert.equal(panels.length, 1);
-    
+
     await elementUpdated(pfeAccordion);
 
     assert.equal(headers[0].getAttribute('disclosure'), 'true');
@@ -274,7 +274,7 @@ describe("<pfe-accordion>", () => {
   it("should switch from an accordion to a disclosure if the disclosure attribute switches from false to true", async () => {
     const pfeAccordion = await createFixture(testElement);
     pfeAccordion.setAttribute("disclosure", "false");
-    
+
     const header = pfeAccordion.querySelector("pfe-accordion-header");
     const panel = pfeAccordion.querySelector("pfe-accordion-panel");
 


### PR DESCRIPTION
## Description of the issue

When an accordion is clicked in pfe-content-set there isn't enough information to tell what has been expanded/collapsed, making analytics based on interaction impossible.

### Impacted component(s)

- pfe-accordion
- pfe-content-set


### Related issues

- (#1764 )


### Preview

<!-- Suggest linking to Netlify or a public sandbox; not a resource behind a log-in or VPN -->
Link(s) to demo page(s) where this element can be viewed:
- [Link](https://deploy-preview-<pr_number>--happy-galileo-ea79c4.netlify.app/examples/) 


### What has changed and why

<!-- Summarize files edited as part of this MR along with a brief description of what was changed/why. -->

- Added extra keys to details on accordion events to give analytics quick access to what element has opened/closed.


### Testing instructions

1. Go to https://www.redhat.com/en/contact
2. In the console, add:
  ```js
  document.addEventListener('pfe-accordion:expand', function(event) {
    debugger;
  });
  ```
3. Click on an accordion to expand
4. `event.details` Should have a reference to the toggle and pane that have updated

#### Browser requirements

Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 78 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)


### Ready-for-merge Checklist

<!-- Check off items as they are completed.  Feel free to delete items if they are not applicable. -->

- [ ] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [ ] Tests have been updated to cover these changes.
- [ ] Browser testing passed.
- [ ] Changelog updated.
- [ ] Documentation (README.md, WHY.md, etc.) updated or added.
- [ ] Link to the demo recording: []()
- [ ] Approved by designer.


### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

