### PR TITLE
fix: issue-1781  Mobile typography variable names

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1,3 +1,7 @@
+# TBD
+
+- [](https://github.com/patternfly/patternfly-elements/commit/) fix: mobile-typography demo page now has correct CSS variables
+
 # 1.11.1 (2021-09-03)
 
 - [5393d18](https://github.com/patternfly/patternfly-elements/commit/5393d185fec3b62e78037a9835470fc15adae2b3) fix: Pfe-Primary-Detail - Fixing animation jank when expanding a section in compact mode

--- a/elements/pfe-styles/demo/typography-mobile.html
+++ b/elements/pfe-styles/demo/typography-mobile.html
@@ -66,20 +66,20 @@
     @media screen and (max-width: 767px) {
     :root {
       border: orange 5px solid;
-      --pf-c--content--h1--FontSize: 1.444rem;
-      --pf-c--content--h2--FontSize: 1.333rem;
-      --pf-c--content--h3--FontSize: 1.111rem;
-      --pf-c--content--h4--FontSize: 1rem;
-      --pf-c--content--h5--FontSize: 0.889rem;
-      --pf-c--content--h6--FontSize: 0.778rem;
-      --pf-c--title--m-6xl--FontSize: 1.944rem;
-      --pf-c--title--m-5xl--FontSize: 1.611rem;
-      --pf-c--title--m-4xl--FontSize: 1.444rem;
-      --pf-c--title--m-3xl--FontSize: 1.333rem;
-      --pf-c--title--m-2xl--FontSize: 1.111rem;
-      --pf-c--title--m-xl--FontSize: 1rem;
-      --pf-c--title--m-lg--FontSize: 0.889rem;
-      --pf-c--title--m-md--FontSize: 0.778rem; } }
+      --pf-c-content--h1--FontSize: 1.444rem;
+      --pf-c-content--h2--FontSize: 1.333rem;
+      --pf-c-content--h3--FontSize: 1.111rem;
+      --pf-c-content--h4--FontSize: 1rem;
+      --pf-c-content--h5--FontSize: 0.889rem;
+      --pf-c-content--h6--FontSize: 0.778rem;
+      --pf-c-title--m-6xl--FontSize: 1.944rem;
+      --pf-c-title--m-5xl--FontSize: 1.611rem;
+      --pf-c-title--m-4xl--FontSize: 1.444rem;
+      --pf-c-title--m-3xl--FontSize: 1.333rem;
+      --pf-c-title--m-2xl--FontSize: 1.111rem;
+      --pf-c-title--m-xl--FontSize: 1rem;
+      --pf-c-title--m-lg--FontSize: 0.889rem;
+      --pf-c-title--m-md--FontSize: 0.778rem; } }
  
   </style>
 </head>


### PR DESCRIPTION
## Pull request description

Fixes names of CSS variables in demo page

### Related issues

 - Fixes https://github.com/patternfly/patternfly-elements/issues/1781


### Preview

https://deploy-preview-1782--patternfly-elements.netlify.app/elements/pfe-styles/demo/typography-mobile.html

http://localhost:8080/elements/pfe-styles/demo/typography-mobile.html


### What has changed and why

CSS variables had too many dashes, so they weren't working. Now you can see the demo of responsive typography in action.


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- [x] *Test case*  
  1. Go here  https://deploy-preview-1782--patternfly-elements.netlify.app//elements/pfe-styles/demo/typography-mobile.html
  2. Squish the window size down until the blue border turns orange. You should see the typography sizing on all headings and text change. 

 
### Merging

Please **squash** when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

**Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!**

