### PR TITLE
fix(deps): add ^ to pfe-nav's pfe deps to avoid duplication

### DIFF
--- a/elements/pfe-navigation/package.json
+++ b/elements/pfe-navigation/package.json
@@ -46,13 +46,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@patternfly/pfe-icon": "1.9.2",
-    "@patternfly/pfe-avatar": "1.9.2",
-    "@patternfly/pfelement": "1.9.2"
+    "@patternfly/pfe-icon": "^1.9.2",
+    "@patternfly/pfe-avatar": "^1.9.2",
+    "@patternfly/pfelement": "^1.9.2"
   },
   "devDependencies": {
     "@cpelements/rh-account-dropdown": "^1.0.37",
-    "@patternfly/pfe-sass": "1.9.2"
+    "@patternfly/pfe-sass": "^1.9.2"
   },
   "generator-pfelement-version": "1.1.0"
 }


### PR DESCRIPTION
This adds a `^` to each PFE dependency of pfe-navigation.  The reason for removing the fixed version dependency is that when pfe-navigation is included in another project (Primer in this case), an extra copy of each fixed-version dependency is pulled in.

Example:

 - Primer has `pfe-icon@^1.0.0` which resolves to `1.11.2`
   - pfe-icon depends on `pfelement@^1.9.3` which resolves to `1.11.2`
 - Primer has `pfe-navigation@1.0.0` which resolves to `1.0.83`
   - pfe-navigation depends on `pfelement@1.9.3` which resolves to `1.9.3`

As a result, Primer winds up bundling both PFElement  `1.11.2` and `1.9.3`.