### PR TITLE
[pfe-progress-steps] removing erroneous count property

### DIFF
--- a/elements/pfe-progress-steps/demo/pfe-progress-steps.html
+++ b/elements/pfe-progress-steps/demo/pfe-progress-steps.html
@@ -237,7 +237,7 @@
       </pfe-progress-steps-item>
     </pfe-progress-steps>
 
-    <pfe-progress-steps vertical variant="count">
+    <pfe-progress-steps vertical>
       <pfe-progress-steps-item state="active" current>
         <div slot="title">Current</div>
         <a slot="link" href="#">View current step</a>

--- a/elements/pfe-progress-steps/pfe-progress-steps-item.scss
+++ b/elements/pfe-progress-steps/pfe-progress-steps-item.scss
@@ -85,20 +85,6 @@
     margin: calc((#{pfe-local(size--active, $region: circle)} - #{pfe-local(size, $region: circle)}) / 2) auto; // top/bottom: (32px - 20px) / 2
     transform: translateX(#{pfe-var(ui--border-width--md)});
 
-    :host([variant="count"]) &::before {
-      content: attr(count);
-      text-align: center;
-      line-height: calc(#{pfe-local(size--active, $region: circle)} * .8);
-      font-size: pfe-var(FontSize--xs);
-      font-weight: 600;
-
-      position: absolute;
-      top: -.2em;
-      left: -.2em;
-      width: 20px;
-      height: 20px;
-    }
-
     :host([state="active"]) & {
       border-color: pfe-local(color--active, $region: circle);
       background-color: pfe-local(color--active, $region: circle);

--- a/elements/pfe-progress-steps/pfe-progress-steps.ts
+++ b/elements/pfe-progress-steps/pfe-progress-steps.ts
@@ -22,9 +22,6 @@ export class PfeProgressSteps extends LitElement {
   @cascades('pfe-progress-steps-item')
   @property({ type: Boolean, reflect: true }) vertical = false
 
-  @cascades('pfe-progress-steps-item')
-  @property({ reflect: true }) variant?: 'count';
-
   private _resizeObserver = new ResizeObserver(this._build);
 
   private get stepItems() {
@@ -75,9 +72,6 @@ export class PfeProgressSteps extends LitElement {
 
     for (let index = 0; index < items.length; index++) {
       const item = items[index];
-
-      // Set the count on the children
-      if (this.variant === 'count') item.setAttribute('count', `${index + 1}`);
 
       if (!this.vertical) {
         Promise.all([customElements.whenDefined(item.tagName.toLowerCase())]).then(() => {


### PR DESCRIPTION
## Description

This PR removes some code that was supposed to enable progress steps to have a `count` connotation.  I think this is erroneous code that snuck passed code review.  Not only doesn't it work, we don't have design specs for it.
