### PR TITLE
pfe-primary-detail: Simplifying back button text and removing unused functions

### DIFF
--- a/elements/pfe-primary-detail/demo/pfe-primary-detail.html
+++ b/elements/pfe-primary-detail/demo/pfe-primary-detail.html
@@ -14,7 +14,7 @@
   </h3>
   <h3 slot="details-nav">Infrastructure and Management</h3>
   <div slot="details">
-    <p>Infrastructure and Management:</p>
+    <p>This is Infrastructure and Management.</p>
     <ul>
       <li><a href="#nowhere">Lorum ipsum dolor sit amet</a></li>
       <li><a href="#nowhere">Aliquam tincidunt mauris eu risus</a></li>
@@ -26,7 +26,7 @@
 
   <h3 slot="details-nav">Cloud Computing</h3>
   <div slot="details">
-    <p>Cloud Computing:</p>
+    <p>This is Cloud Computing.</p>
     <ul>
       <li><a href="#nowhere">Morbi in sem quis dui placerat ornare</a></li>
       <li><a href="#nowhere">Praesent dapibus, neque id cursus faucibus</a></li>
@@ -46,7 +46,7 @@
 
   <h3 slot="details-nav">Storage</h3>
   <div slot="details">
-    <p>Storage:</p>
+    <p>This is Storage.</p>
     <ul>
       <li><a href="#nowhere">Morbi in sem quis dui placerat ornare</a></li>
       <li><a href="#nowhere">Praesent dapibus, neque id cursus faucibus</a></li>
@@ -56,7 +56,7 @@
 
   <h3 slot="details-nav">Runtimes</h3>
   <div slot="details">
-    <p>Runtimes:</p>
+    <p>This is Runtimes.</p>
     <ul>
       <li><a href="#nowhere">Pellentesque fermentum dolor</a></li>
       <li><a href="#nowhere">Morbi in sem quis dui placerat ornare</a></li>

--- a/elements/pfe-primary-detail/pfe-primary-detail.ts
+++ b/elements/pfe-primary-detail/pfe-primary-detail.ts
@@ -93,6 +93,9 @@ export class PfePrimaryDetail extends LitElement {
   /** Read only: Displays what breakpoint is currently being used */
   @property({ type: String, reflect: true }) breakpoint?: 'compact'|'desktop';
 
+  /** Used to set text of back button **/
+  @property({ type: String }) expandedSectionTitle?: string;
+
   @state() private pristine = true;
   @state() private controlsId?: string;
   @state() private nextToggle: HTMLElement|null = null;
@@ -159,7 +162,7 @@ export class PfePrimaryDetail extends LitElement {
                 aria-controls="${ifDefined(this.controlsId)}"
                 aria-expanded="${ifDefined(detailsBackButtonExpanded)}"
                 @click="${this.closeAll}">
-              ${this._renderDetailsWrapperHeading()}
+              ${this.expandedSectionTitle}
             </button>
           </div>
           <slot name="details"></slot>
@@ -423,24 +426,17 @@ export class PfePrimaryDetail extends LitElement {
   }
 
   private _renderDetailsWrapperHeading(): TemplateResult {
-    const desktop = (this.breakpoint === 'desktop') || undefined;
-    const notDesktop = (this.breakpoint !== 'desktop') || undefined;
-
-    if (!this.nextToggle) {
-      return html`
-        <div id="details-wrapper__heading"
-            aria-selected="${ifDefined(desktop && 'true')}"
-            aria-expanded="${ifDefined(notDesktop && 'true')}"
-        ></div> `;
+    if (!this.expandedSectionTitle) {
+      return html`<strong id="details-wrapper__heading"></strong>`;
     } else {
-      const { wasTag } = this.nextToggle.dataset;
+      const { wasTag } = this.nextToggle?.dataset ?? {};
+      // If wasTag isn't a headline, use strong
       const tag = unsafeStatic(wasTag?.match(/^H/i) ? wasTag : 'strong');
+
       return statichtml`
-        <${tag} id="details-wrapper__heading"
-            aria-selected="${ifDefined(desktop && 'true')}"
-            aria-expanded="${ifDefined(notDesktop && 'true')}"
-        >${this.nextToggle.innerText}</${tag}>
-      `;
+        <${tag} id="details-wrapper__heading">
+          ${this.expandedSectionTitle}
+        </${tag}>`;
     }
   }
 
@@ -485,6 +481,9 @@ export class PfePrimaryDetail extends LitElement {
 
     // Make sure the aria-controls attribute is set to the details wrapper
     this.controlsId = nextDetails?.id;
+
+    // Set the back button text
+    this.expandedSectionTitle = this.nextToggle.innerText;
 
     // Shut previously active detail
     if (currentToggle) {
@@ -545,26 +544,6 @@ export class PfePrimaryDetail extends LitElement {
   }
 
   /**
-   * Check if active element is a tab panel
-   */
-  private _isPanel(element: EventTarget|null): element is HTMLElement {
-    return element instanceof HTMLElement && element.getAttribute('slot') === 'details';
-  }
-
-  /**
-   * Get the corresponding active tab panel for the active tab toggle
-   */
-  private _getFocusedPanel(): HTMLElement|null {
-    const toggles = this.slots.getSlotted('nav', 'details-nav');
-    const newIndex = toggles?.findIndex(toggle => toggle === document.activeElement);
-
-    if (newIndex == null) {
-      return null;
-    }
-    return toggles[newIndex % toggles.length].nextElementSibling as HTMLElement;
-  }
-
-  /**
    * Get previous toggle in relation to the active toggle
    * @return  DOM Element for toggle before the active one
    */
@@ -573,14 +552,6 @@ export class PfePrimaryDetail extends LitElement {
     const newIndex = (toggles?.findIndex(toggle => toggle === document.activeElement) ?? -1) - 1;
 
     return toggles?.[(newIndex + toggles.length) % toggles.length] ?? null;
-  }
-
-  /**
-   * Get currently active toggle
-   * @return {object} DOM Element for active toggle
-   */
-  private _getFocusedToggle(): HTMLElement|null {
-    return this.root?.getElementById(this.active ?? '') ?? null;
   }
 
   /**


### PR DESCRIPTION
```
Removed aria attributes from element surrounding text, only need htose on the button wrapper
Set back button text to property so we aren't reading the DOM during render (? seems like the that's recommended)
Removed unused functions made during original development, but are now unused
Updated Demo HTML, thought text in 'details' was a bug in functionality, but was content in the slot. Hopefully the slight adjustment makes that more clear.
```

This update isn't as necessary as I thought; the 'bug' I was chasing was content in `slot=details` on the first example, not duplicate content added by the component code 🤦🏼‍♂️ 
Was confused myself about how this thing is supposed to work... so that's not a great sign.

_I think_ that having the back button text be a property is probably simpler? Seems like we're accessing the DOM during render if we don't which was listed as one the 'uncool' things in the Lit render docs.

Whether or not we use this update to the code, I think pfe-primary-details is good to go. So after you decide what you want to do with this we can check it off the list.