### PR TITLE
fix: moved public focus method to private.

### DIFF
--- a/elements/pfe-dropdown/pfe-dropdown.ts
+++ b/elements/pfe-dropdown/pfe-dropdown.ts
@@ -191,7 +191,7 @@ export class PfeDropdown extends LitElement {
       case 'Escape':
         event.preventDefault();
         event.stopPropagation();
-        this.focus();
+        this._focus();
         await this.updateComplete;
         this.close();
         break;
@@ -341,7 +341,7 @@ export class PfeDropdown extends LitElement {
       // return focus back to button
       this.close();
       await this.updateComplete;
-      this.focus();
+      this._focus();
     } else {
       item.click();
     }
@@ -350,6 +350,11 @@ export class PfeDropdown extends LitElement {
   private _itemContainer(item: PfeDropdownItem): HTMLElement|null {
     // used to apply the focus state to the item's container
     return item.shadowRoot?.querySelector(`.pfe-dropdown-item__container`) ?? null;
+  }
+
+  // move focus to the button
+  private _focus():void {
+    this.shadowRoot?.querySelector<HTMLButtonElement>('#pfe-dropdown-toggle')?.focus();
   }
 
   /**

--- a/elements/pfe-dropdown/test/pfe-dropdown.spec.ts
+++ b/elements/pfe-dropdown/test/pfe-dropdown.spec.ts
@@ -170,7 +170,7 @@ describe('<pfe-dropdown>', function() {
       let menu: HTMLElement | null | undefined;
       beforeEach(async function() {
         menu = element.shadowRoot?.querySelector('#pfe-dropdown-menu');
-        element.focus();
+        await sendKeys({ press: 'Tab' });
         await element.updateComplete;
       });
 
@@ -218,7 +218,7 @@ describe('<pfe-dropdown>', function() {
           await element.updateComplete;
         });
 
-        it(`Enter should exit open dialog and move to the dropdown.`, async function() {
+        it(`Enter should exit open dialog and move focus to the dropdown.`, async function() {
           await sendKeys({ press: 'ArrowUp' });
           await sendKeys({ press: 'Enter' });
           await element.updateComplete;


### PR DESCRIPTION
Removing the public `focus()` method causes an error in the following test: 
`Enter should exit open dialog and move focus to the dropdown.`.  Meaning that when you're focused on the list item and you click `Enter` on an action item it needs to programatically move the focus to `pfe-dropdown`.  Knowing that, I added a private `_focus()` method to programmatically move the focus to the button.

```
<pfe-dropdown>
  #shadowRoot
    <button>
```