### PR TITLE
fix: types for trackPerformance function

### DIFF
--- a/core/pfe-core/core.ts
+++ b/core/pfe-core/core.ts
@@ -28,7 +28,7 @@ function getMeta(name: string): string|undefined {
  * For use in a JS file or script tag; can also be added in the constructor of a component during development.
  * @example trackPerformance(true);
  */
-export function trackPerformance(preference = noPref) {
+export function trackPerformance(preference: Boolean | Symbol | undefined = noPref) {
   if (preference !== noPref) {
     window.PfeConfig.trackPerformance = !!preference;
   }


### PR DESCRIPTION
I ran into a typescript issue when trying to use `trackPerformance` from `@patternfly/pfe-core`.

<img width="1337" alt="Screen Shot 2022-01-26 at 10 31 54 PM" src="https://user-images.githubusercontent.com/3428964/151287192-958d4001-cee5-485a-ad0f-d1ad85ae4ac9.png">

Here is the example project showing how I was using the `trackPrerformance`.
https://github.com/heyMP/pfe-2.0-demos/blob/master/src/track-performance.ts

