### PR TITLE
fix: add all commits together

### DIFF
--- a/.changeset/breezy-bikes-smell.md
+++ b/.changeset/breezy-bikes-smell.md
@@ -1,0 +1,37 @@
+---
+"@patternfly/pfe-clipboard": major
+---
+
+Update pfe-clipboard to function with mouse, keyboard, and screen reader and meet WCAG 2.1 A - AA Guidelines ✨♿
+
+BREAKING CHANGE:
+`role="button"` and `tabindex=0` attributes must *no longer* be applied to `<pfe-clipboard>`, make sure all instances 
+on your page are updated
+
+```diff
+- <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
++ <pfe-clipboard></pfe-clipboard>
+```
+
+`pfe-clipboard.spec.ts`
+ - Updated tests based on a11y changes
+
+`README.md`
+ - Updated readme based on a11y updates
+
+`pfe-clipboard.ts`
+ - Added new state property for aria-disabled to added aria features
+ - Added comments for changes
+ - Updated the HTML in render() to add aria features
+ - Cleaned up some comment typos
+
+`pfe-clipboard.scss`
+ - Added sr-only class to utilize with pfe-clipboard to improve the success message output for screen readers
+ - Adjusted the padding and changes some ids to be classes to go with new HTML structure
+
+`pfe-clipboard.html`
+ - Removed role button and tabindex from pfe-clipboard tags because that is being set within the shadowDom now
+pfe-clipboard.js
+ - Removed role button and tabindex from pfe-clipboard tags because that is being set within the shadowDom now
+
+See [docs](https://patternflyelements.org/components/clipboard/) for more info

--- a/elements/pfe-clipboard/README.md
+++ b/elements/pfe-clipboard/README.md
@@ -28,7 +28,7 @@ import '@patternfly/pfe-clipboard';
 
 ### Default
 ```html
-<pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+<pfe-clipboard></pfe-clipboard>
 ```
 
 ### Copy text from an element on the page
@@ -38,10 +38,10 @@ Add a valid HTML selector to the target attribute, component will use `document.
 We recommend using ID's.
 
 ```html
-<pfe-clipboard role="button" tabindex="0" copy-from="#copy-me"></pfe-clipboard>
+<pfe-clipboard copy-from="#copy-me"></pfe-clipboard>
 <div id="copy-me">This text will get copied</div>
 
-<pfe-clipboard role="button" tabindex="0" copy-from="body .copy-me"></pfe-clipboard>
+<pfe-clipboard copy-from="body .copy-me"></pfe-clipboard>
 <div class="copy-me">This text will get copied</div>
 ```
 
@@ -49,7 +49,7 @@ We recommend using ID's.
 Set the attribute `copy-from="property"` and set the property `contentToCopy` on the component with what should be copied.
 ```html
 <!-- Markup on the page -->
-<pfe-clipboard role="button" tabindex="0" copy-from="property" id="copyButton"></pfe-clipboard>
+<pfe-clipboard copy-from="property" id="copyButton"></pfe-clipboard>
 ```
 ```js
 document.getElementById('copyButton').contentToCopy('Wakka wakka!');
@@ -57,32 +57,32 @@ document.getElementById('copyButton').contentToCopy('Wakka wakka!');
 
 ### Optionally hide the icon
 ```html
-<pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+<pfe-clipboard no-icon></pfe-clipboard>
 ```
 
 ### Override the link text
 ```html
-<pfe-clipboard role="button" tabindex="0">
+<pfe-clipboard>
   <span slot="label">hey you, copy this url!</span>
 </pfe-clipboard>
 ```
 
 ### Override the copied notification text
 ```html
-<pfe-clipboard role="button" tabindex="0">
+<pfe-clipboard>
     <span slot="success">URL Copied to clipboard</span>
 </pfe-clipboard>
 ```
 ### Override the icon
 ```html
-<pfe-clipboard role="button" tabindex="0">
+<pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
 </pfe-clipboard>
 ```
 
 ## Override all slots
 ```html
-<pfe-clipboard role="button" tabindex="0">
+<pfe-clipboard>
   <span slot="label">Copy this article URL</span>
   <span slot="success">URL Copied to clipboard</span>
   <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
@@ -91,7 +91,7 @@ document.getElementById('copyButton').contentToCopy('Wakka wakka!');
 
 ## Specify the amount of seconds the copy success text should be visible
 ```html
-<pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+<pfe-clipboard copied-duration="5"></pfe-clipboard>
 ```
 
 ### Accessibility

--- a/elements/pfe-clipboard/demo/pfe-clipboard.html
+++ b/elements/pfe-clipboard/demo/pfe-clipboard.html
@@ -16,96 +16,104 @@
   <p>This element embeds a copy url button on your site.</p>
 
   <h2>Clipboard</h2>
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
 
   <h2>Clipboard with no icon</h2>
-  <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard no-icon></pfe-clipboard>
 
   <h2>Clipboard: with custom icon</h2>
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
 
   <h2>Clipboard: with custom text & copying text from element</h2>
-  <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">
+  <pfe-clipboard copy-from="#textToCopy">
     <span slot="label">This will copy the text in the text field below!</span>
     <span slot="success">Making some copies!</span>
   </pfe-clipboard>
-  <input type="text" id="textToCopy" aria-label="This text will be copied" value="This text will be copied!!11"></input>
+  <input type="text" id="textToCopy" aria-label="This text will be copied." value="This text will be copied!!"></input>
 
   <h2>Clipboard: Copying text from property</h2>
-  <pfe-clipboard role="button" tabindex="0" copy-from="property" id="propertyCopy">
+  <pfe-clipboard copy-from="property" id="propertyCopy">
   </pfe-clipboard>
 
   <h2>Clipboard: with custom success text duration.</h2>
-  <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  <pfe-clipboard copied-duration="5"></pfe-clipboard>
+
+  <h2>Clipboard: with invalid success text duration.</h2>
+  <p>Defaults to 4 seconds.</p>
+  <pfe-clipboard copied-duration="-1"></pfe-clipboard>
+
+  <h2>Clipboard: with invalid success text duration, lower than 4 seconds</h2>
+  <p>Defaults to 4 seconds.</p>
+  <pfe-clipboard copied-duration="1"></pfe-clipboard>
 </pfe-band>
 
 <pfe-band color="darkest">
   <p>This element embeds a copy url button on your site.</p>
 
   <h2>Clipboard</h2>
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
 
   <h2>Clipboard with no icon</h2>
-  <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard no-icon></pfe-clipboard>
 
   <h2>Clipboard: with custom icon</h2>
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
 
   <h2>Clipboard: with custom text</h2>
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">You can totally click to copy url</span>
     <span slot="success">Making some copies!</span>
   </pfe-clipboard>
 
   <h2>Clipboard: with custom success text duration.</h2>
-  <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  <pfe-clipboard copied-duration="5"></pfe-clipboard>
 </pfe-band>
 
 <pfe-band color="accent">
   <p>This element embeds a copy url button on your site.</p>
 
   <h2>Clipboard</h2>
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
 
   <h2>Clipboard with no icon</h2>
-  <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard no-icon></pfe-clipboard>
 
   <h2>Clipboard: with custom icon</h2>
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
 
   <h2>Clipboard: with custom text</h2>
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">You can totally click to copy url</span>
     <span slot="success">Making some copies!</span>
   </pfe-clipboard>
 
   <h2>Clipboard: with custom success text duration.</h2>
-  <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  <pfe-clipboard copied-duration="5"></pfe-clipboard>
 </pfe-band>
 
 <pfe-band color="lightest">
   <h2>Error cases</h2>
 
   <h3>Set to copy "property", but Property doesn't exist</h3>
-  <pfe-clipboard role="button" tabindex="0" copy-from="property">
+  <pfe-clipboard copy-from="property">
     <span slot="label">Oops, I didn't set the property to be copied</span>
   </pfe-clipboard>
 
   <h3>Set to copy a non-existent selector</h3>
-  <pfe-clipboard role="button" tabindex="0" copy-from="#wakka-wakka">
+  <pfe-clipboard copy-from="#wakka-wakka">
     <span slot="label">Oops, I didn't set a valid selector to be copied</span>
   </pfe-clipboard>
 
 </pfe-band>
 
 <pfe-band color="darkest">
-  <pfe-clipboard role="button" tabindex="0" copy-from="property">
+  <pfe-clipboard copy-from="property">
     <span slot="label">Oops, I didn't set the property to be copied</span>
   </pfe-clipboard>
 </pfe-band>

--- a/elements/pfe-clipboard/demo/pfe-clipboard.js
+++ b/elements/pfe-clipboard/demo/pfe-clipboard.js
@@ -6,9 +6,9 @@ const root = document.querySelector('[data-demo="pfe-clipboard"]')?.shadowRoot ?
 
 root.getElementById('propertyCopy').contentToCopy = `
   <h2>Clipboard: with custom text & copying text from element</h2>
-  <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">
+  <pfe-clipboard copy-from="#textToCopy">
     <span slot="text">This will copy the text in the text field below!</span>
     <span slot="success">Making some copies!</span>
   </pfe-clipboard>
-  <input type="text" id="textToCopy" value="This text will be copied!!11"></input>
+  <input type="text" id="textToCopy" value="This text will be copied!!"></input>
 `;

--- a/elements/pfe-clipboard/docs/index.md
+++ b/elements/pfe-clipboard/docs/index.md
@@ -1,94 +1,94 @@
 {% renderOverview %}
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
 {% endrenderOverview %}
 
 {% band header="Usage" %}
   ### Default
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
   ```html
-  <pfe-clipboard role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard></pfe-clipboard>
   ```
 
   ### Optionally hide the icon
-  <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard no-icon></pfe-clipboard>
   ```html
-  <pfe-clipboard no-icon role="button" tabindex="0"></pfe-clipboard>
+  <pfe-clipboard no-icon></pfe-clipboard>
   ```
 
   ### Override the link text
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">You can copy this url</span>
   </pfe-clipboard>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">You can copy this url</span>
   </pfe-clipboard>
   ```
 
   ### Copying text from element with custom button text
-  <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">
+  <pfe-clipboard copy-from="#textToCopy">
     <span slot="label">This will copy the text in the text field below!</span>
   </pfe-clipboard>
   <input type="text" id="textToCopy" value="This text will be copied!"></input>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">
+  <pfe-clipboard copy-from="#textToCopy">
     <span slot="label">This will copy the text in the text field below!</span>
   </pfe-clipboard>
   <input type="text" id="textToCopy" value="This text will be copied!"></input>
   ```
 
   ### Copying text from property
-  <pfe-clipboard role="button" tabindex="0" copy-from="property" id="propertyCopy">
+  <pfe-clipboard copy-from="property" id="propertyCopy">
   </pfe-clipboard>
   <script>
     window.addEventListener('load', function() {
-      document.getElementById('propertyCopy').contentToCopy = '    <h2>Clipboard: with custom text & copying text from element</h2>\n    <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">\n      <span slot="label">This will copy the text in the text field below!</span>\n      <span slot="success">Making some copies!</span>\n    </pfe-clipboard>\n    <input type="text" id="textToCopy" value="This text will be copied!!11"></input>';
+      document.getElementById('propertyCopy').contentToCopy = '    <h2>Clipboard: with custom text & copying text from element</h2>\n    <pfe-clipboard copy-from="#textToCopy">\n      <span slot="label">This will copy the text in the text field below!</span>\n      <span slot="success">Making some copies!</span>\n    </pfe-clipboard>\n    <input type="text" id="textToCopy" value="This text will be copied!!"></input>';
     })
   </script>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0" copy-from="property" id="propertyCopy">
+  <pfe-clipboard copy-from="property" id="propertyCopy">
   </pfe-clipboard>
   <script>
     window.addEventListener('load', function() {
-      document.getElementById('propertyCopy').contentToCopy = '    <h2>Clipboard: with custom text & copying text from element</h2>\n    <pfe-clipboard role="button" tabindex="0" copy-from="#textToCopy">\n      <span slot="label">This will copy the text in the text field below!</span>\n      <span slot="success">Making some copies!</span>\n    </pfe-clipboard>\n    <input type="text" id="textToCopy" value="This text will be copied!!11"></input>';
+      document.getElementById('propertyCopy').contentToCopy = '    <h2>Clipboard: with custom text & copying text from element</h2>\n    <pfe-clipboard copy-from="#textToCopy">\n      <span slot="label">This will copy the text in the text field below!</span>\n      <span slot="success">Making some copies!</span>\n    </pfe-clipboard>\n    <input type="text" id="textToCopy" value="This text will be copied!!"></input>';
     })
   </script>
   ```
 
   ### Override the copied notification text
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="success">URL Copied to clipboard</span>
   </pfe-clipboard>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="success">URL Copied to clipboard</span>
   </pfe-clipboard>
   ```
 
   ### Override the icon
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
   ```
 
   ### Override all slots
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">Copy this article URL</span>
     <span slot="success">URL Copied to clipboard</span>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
   </pfe-clipboard>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0">
+  <pfe-clipboard>
     <span slot="label">Copy this article URL</span>
     <span slot="success">URL Copied to clipboard</span>
     <pfe-icon slot="icon" icon="web-icon-globe"></pfe-icon>
@@ -96,10 +96,10 @@
   ```
 
   ### Specify the amount of seconds the copy success text should be visible
-  <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  <pfe-clipboard copied-duration="5"></pfe-clipboard>
 
   ```html
-  <pfe-clipboard role="button" tabindex="0" copied-duration="5"></pfe-clipboard>
+  <pfe-clipboard copied-duration="5"></pfe-clipboard>
   ```
 {% endband %}
 

--- a/elements/pfe-clipboard/pfe-clipboard.scss
+++ b/elements/pfe-clipboard/pfe-clipboard.scss
@@ -29,13 +29,24 @@
   max-width: fit-content;
   color: pfe-local(Color) !important;
   cursor: pointer;
-  padding: pfe-local(Padding);
   font-weight: pfe-local(FontWeight);
   @include pfe-c-typography($type: text, $sizing: md);
 }
 
 :host([hidden]) {
-  display: none;
+  display: none !important;
+}
+
+// Screen reader only text
+.sr-only {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }
 
 //-- Custom styles applied to slot's shadow element
@@ -67,6 +78,19 @@
 
   &__text--success {
     color: pfe-local(text--success--Color) !important;
+  }
+
+  &__text,
+  &__text--success {
+    display: flex;
+    align-items: center;
+    padding: pfe-local(Padding);
+  }
+  &__button {
+    background-color: transparent;
+    border: 0;
+    font-size: inherit;
+    cursor: pointer;
   }
 }
 
@@ -107,7 +131,7 @@
   --pfe-icon--size: #{pfe-local(icon--Width)};
 }
 
-#icon--url {
+.icon--url {
   display: none;
 
   :host([copy-from="url"]) & {
@@ -115,7 +139,7 @@
   }
 }
 
-#icon--copy {
+.icon--copy {
   :host([copy-from="url"]) & {
     display: none;
   }

--- a/elements/pfe-clipboard/pfe-clipboard.ts
+++ b/elements/pfe-clipboard/pfe-clipboard.ts
@@ -84,7 +84,12 @@ export class PfeClipboard extends LitElement {
   /**
    * Specify the amount of time in seconds the copy success text should be visible.
    */
-  @property({ type: Number, reflect: true, attribute: 'copied-duration' }) copiedDuration = 3;
+  @property({ type: Number, reflect: true, attribute: 'copied-duration' }) copiedDuration = 4;
+
+  /**
+   * Specify when the button slot needs to be aria-disabled or not, coincides with button disabled * states.
+   */
+  @state() private _ariaDisabled = false;
 
   /**
    * Defaults to `url`, decides what should be copied. Possible values are:
@@ -122,12 +127,8 @@ export class PfeClipboard extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('role', 'button');
-    this.setAttribute('tabindex', '0');
 
-    // Since this element as the role of button we are going to listen
-    // for click and as well as 'enter' and 'space' commands to trigger
-    // the copy functionality
+    // the copy functionality for mouse and keyboard
     this.addEventListener('click', this._clickHandler.bind(this));
     this.addEventListener('keydown', this._keydownHandler.bind(this));
 
@@ -143,43 +144,69 @@ export class PfeClipboard extends LitElement {
     }
   }
 
+  // All DOM changes go inside the render function
   render() {
     // TODO: Remove deprecated `text--success` slot and associated logic in 3.0
     const useNewSuccessSlot = this.slots.hasSlotted('success') || !this.slots.hasSlotted('text--success');
     // TODO: Remove deprecated `text` slot and associated logic in 3.0
     const useNewLabelSlot = this.slots.hasSlotted('label') || !this.slots.hasSlotted('text');
     return html`
-      <!-- icon slot -->
-      ${this.noIcon ? '' : html`
-      <div class="pfe-clipboard__icon">
-        <slot name="icon" id="icon">
-          <svg id="icon--url" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 15.277 16">
-            <g transform="translate(-2.077 -1.807)">
-              <path class="a" d="M15.34,2.879a3.86,3.86,0,0,0-5.339,0L6.347,6.545a3.769,3.769,0,0,0,0,5.339.81.81,0,0,0,1.132,0,.823.823,0,0,0,0-1.145A2.144,2.144,0,0,1,7.5,7.677l3.641-3.654a2.161,2.161,0,1,1,3.049,3.062l-.8.8a.811.811,0,1,0,1.145,1.132l.8-.8a3.769,3.769,0,0,0,0-5.339Z" transform="translate(0.906 0)"/>
-              <path class="a" d="M10.482,6.822a.823.823,0,0,0,0,1.145,2.161,2.161,0,0,1,0,3.049L7.343,14.155a2.161,2.161,0,0,1-3.062,0,2.187,2.187,0,0,1,0-3.062l.193-.116a.823.823,0,0,0,0-1.145.811.811,0,0,0-1.132,0l-.193.193a3.86,3.86,0,0,0,0,5.339,3.86,3.86,0,0,0,5.339,0l3.126-3.139A3.731,3.731,0,0,0,12.72,9.562a3.769,3.769,0,0,0-1.094-2.74A.823.823,0,0,0,10.482,6.822Z" transform="translate(0 1.37)"/>
-            </g>
-          </svg>
-          <svg id="icon--copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
-            <g></g>
-            <path d="M30.286 6.857q0.714 0 1.214 0.5t0.5 1.214v21.714q0 0.714-0.5 1.214t-1.214 0.5h-17.143q-0.714 0-1.214-0.5t-0.5-1.214v-5.143h-9.714q-0.714 0-1.214-0.5t-0.5-1.214v-12q0-0.714 0.357-1.571t0.857-1.357l7.286-7.286q0.5-0.5 1.357-0.857t1.571-0.357h7.429q0.714 0 1.214 0.5t0.5 1.214v5.857q1.214-0.714 2.286-0.714h7.429zM20.571 10.661l-5.339 5.339h5.339v-5.339zM9.143 3.804l-5.339 5.339h5.339v-5.339zM12.643 15.357l5.643-5.643v-7.429h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h9.143v-4.571q0-0.714 0.357-1.571t0.857-1.357zM29.714 29.714v-20.571h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h16z"/>
-          </svg>
-        </slot>
-      </div>
-      `}
+    <button class="pfe-clipboard__button" aria-disabled=${this._ariaDisabled}>
       <div class="pfe-clipboard__text">
-        ${useNewLabelSlot ? html`
-        <slot name="label" id="label">${this.labelDefault}</slot>
-        ` : html`
-        <slot name="text" id="text">${this.labelDefault}</slot>
+        <!-- icon slot -->
+        ${this.noIcon ? '' : html`
+        <div class="pfe-clipboard__icon" aria-hidden="true">
+          <slot name="icon" id="icon">
+            <svg class="icon--url" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 15.277 16">
+              <g transform="translate(-2.077 -1.807)">
+                <path class="a" d="M15.34,2.879a3.86,3.86,0,0,0-5.339,0L6.347,6.545a3.769,3.769,0,0,0,0,5.339.81.81,0,0,0,1.132,0,.823.823,0,0,0,0-1.145A2.144,2.144,0,0,1,7.5,7.677l3.641-3.654a2.161,2.161,0,1,1,3.049,3.062l-.8.8a.811.811,0,1,0,1.145,1.132l.8-.8a3.769,3.769,0,0,0,0-5.339Z" transform="translate(0.906 0)"/>
+                <path class="a" d="M10.482,6.822a.823.823,0,0,0,0,1.145,2.161,2.161,0,0,1,0,3.049L7.343,14.155a2.161,2.161,0,0,1-3.062,0,2.187,2.187,0,0,1,0-3.062l.193-.116a.823.823,0,0,0,0-1.145.811.811,0,0,0-1.132,0l-.193.193a3.86,3.86,0,0,0,0,5.339,3.86,3.86,0,0,0,5.339,0l3.126-3.139A3.731,3.731,0,0,0,12.72,9.562a3.769,3.769,0,0,0-1.094-2.74A.823.823,0,0,0,10.482,6.822Z" transform="translate(0 1.37)"/>
+              </g>
+            </svg>
+            <svg class="icon--copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
+              <g></g>
+              <path d="M30.286 6.857q0.714 0 1.214 0.5t0.5 1.214v21.714q0 0.714-0.5 1.214t-1.214 0.5h-17.143q-0.714 0-1.214-0.5t-0.5-1.214v-5.143h-9.714q-0.714 0-1.214-0.5t-0.5-1.214v-12q0-0.714 0.357-1.571t0.857-1.357l7.286-7.286q0.5-0.5 1.357-0.857t1.571-0.357h7.429q0.714 0 1.214 0.5t0.5 1.214v5.857q1.214-0.714 2.286-0.714h7.429zM20.571 10.661l-5.339 5.339h5.339v-5.339zM9.143 3.804l-5.339 5.339h5.339v-5.339zM12.643 15.357l5.643-5.643v-7.429h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h9.143v-4.571q0-0.714 0.357-1.571t0.857-1.357zM29.714 29.714v-20.571h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h16z"/>
+            </svg>
+          </slot>
+        </div>
         `}
+          ${useNewLabelSlot ? html`
+          <slot name="label" id="label">${this.labelDefault}</slot>
+          ` : html`
+          <slot name="text" id="text">${this.labelDefault}</slot>
+          `}
       </div>
-      <div class="pfe-clipboard__text--success" role="alert">
-        ${useNewSuccessSlot ? html`
-        <slot name="success" id="success">Copied</slot>
-        ` : html`
-        <slot name="text--success" id="text--success">Copied</slot>
+
+      <!-- success message -->
+      <div class="pfe-clipboard__text--success" role="alert" tabindex="0">
+        <!-- icon slot -->
+        ${this.noIcon ? '' : html`
+        <div class="pfe-clipboard__icon" aria-hidden="true">
+          <slot name="icon" id="icon">
+            <svg class="icon--url" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 15.277 16">
+              <g transform="translate(-2.077 -1.807)">
+                <path class="a" d="M15.34,2.879a3.86,3.86,0,0,0-5.339,0L6.347,6.545a3.769,3.769,0,0,0,0,5.339.81.81,0,0,0,1.132,0,.823.823,0,0,0,0-1.145A2.144,2.144,0,0,1,7.5,7.677l3.641-3.654a2.161,2.161,0,1,1,3.049,3.062l-.8.8a.811.811,0,1,0,1.145,1.132l.8-.8a3.769,3.769,0,0,0,0-5.339Z" transform="translate(0.906 0)"/>
+                <path class="a" d="M10.482,6.822a.823.823,0,0,0,0,1.145,2.161,2.161,0,0,1,0,3.049L7.343,14.155a2.161,2.161,0,0,1-3.062,0,2.187,2.187,0,0,1,0-3.062l.193-.116a.823.823,0,0,0,0-1.145.811.811,0,0,0-1.132,0l-.193.193a3.86,3.86,0,0,0,0,5.339,3.86,3.86,0,0,0,5.339,0l3.126-3.139A3.731,3.731,0,0,0,12.72,9.562a3.769,3.769,0,0,0-1.094-2.74A.823.823,0,0,0,10.482,6.822Z" transform="translate(0 1.37)"/>
+              </g>
+            </svg>
+            <svg class="icon--copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
+              <g></g>
+              <path d="M30.286 6.857q0.714 0 1.214 0.5t0.5 1.214v21.714q0 0.714-0.5 1.214t-1.214 0.5h-17.143q-0.714 0-1.214-0.5t-0.5-1.214v-5.143h-9.714q-0.714 0-1.214-0.5t-0.5-1.214v-12q0-0.714 0.357-1.571t0.857-1.357l7.286-7.286q0.5-0.5 1.357-0.857t1.571-0.357h7.429q0.714 0 1.214 0.5t0.5 1.214v5.857q1.214-0.714 2.286-0.714h7.429zM20.571 10.661l-5.339 5.339h5.339v-5.339zM9.143 3.804l-5.339 5.339h5.339v-5.339zM12.643 15.357l5.643-5.643v-7.429h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h9.143v-4.571q0-0.714 0.357-1.571t0.857-1.357zM29.714 29.714v-20.571h-6.857v7.429q0 0.714-0.5 1.214t-1.214 0.5h-7.429v11.429h16z"/>
+            </svg>
+          </slot>
+        </div>
         `}
+          ${useNewSuccessSlot ? html`
+          <slot name="success" id="success">
+            Copied <span class="sr-only">successful.</span>
+          </slot>
+          ` : html`
+          <slot name="text--success" id="text--success">
+            Copied <span class="sr-only">successful.</span>
+          </slot>
+          `}
       </div>
+    </button>
     `;
   }
 
@@ -190,12 +217,15 @@ export class PfeClipboard extends LitElement {
     if (this.copyFrom === 'property') {
       if (!this.contentToCopy) {
         this.setAttribute('disabled', '');
+        this._ariaDisabled = true;
       } else if (this.hasAttribute('disabled')) {
         this.removeAttribute('disabled');
+        this._ariaDisabled = false;
       }
     } else if (this.copyFrom.length) {
       // If target is set to anything else, we're not doing checks for it
       this.removeAttribute('disabled');
+      this._ariaDisabled = false;
     }
   }
 
@@ -203,7 +233,11 @@ export class PfeClipboard extends LitElement {
    * Event handler for any activation of the copy button
    */
   @bound private async _clickHandler() {
+    // UI focus management variable
+    const textSuccess = this.shadowRoot?.querySelector<HTMLElement>('.pfe-clipboard__text--success');
+
     let text;
+
     switch (this.copyFrom) {
       // Copy current URL
       case 'url':
@@ -215,6 +249,7 @@ export class PfeClipboard extends LitElement {
           text = this.contentToCopy;
         } else {
           this.setAttribute('disabled', '');
+          this._ariaDisabled = true;
           this.logger.error('Set to copy property, but this.contentToCopy is not set');
           return;
         }
@@ -243,6 +278,7 @@ export class PfeClipboard extends LitElement {
     if (!text || (typeof text === 'string' && !text.length)) {
       this.logger.error('Couldn\'t find text to copy.');
       this.setAttribute('disabled', '');
+      this._ariaDisabled = true;
       return;
     }
 
@@ -258,20 +294,26 @@ export class PfeClipboard extends LitElement {
         copiedText,
       }));
       // Toggle the copied state. Use the this._formattedCopiedTimeout function
-      // to an appropraite setTimout length.
+      // to set an appropriate setTimout length.
       this.setAttribute('copied', '');
+
+      // Programmatically set focus to success message to alert the user that the copy was successful
+      textSuccess?.focus();
+
       setTimeout(() => {
         this.removeAttribute('copied');
       }, this._formattedCopiedTimeout());
     } catch (error) {
       this.logger.warn(error as string);
       this._checkForCopyTarget();
+      return;
     }
   }
 
   protected _contentToCopyChanged() {
     if (this.contentToCopy) {
       this.removeAttribute('disabled');
+      this.removeAttribute('aria-disabled');
     }
   }
 
@@ -281,10 +323,14 @@ export class PfeClipboard extends LitElement {
    */
   private _formattedCopiedTimeout() {
     const copiedDuration = Number(this.copiedDuration * 1000);
-    if (!(copiedDuration > -1)) {
-      this.logger.warn(`copied-duration must be a valid number. Defaulting to 3 seconds.`);
-      // default to 3 seconds
-      return 3000;
+    if ((copiedDuration < -1)) {
+      this.logger.warn(`copied-duration must be a valid number. Defaulting to 4 seconds.`);
+      // default to 4 seconds
+      // accessibility note: ensure that the user has enough time to read and also hear the text changes, for longer amounts of text increase the duration time to at least 6 seconds
+      return 4000;
+    } else if ((copiedDuration < 4000)) {
+      this.logger.warn(`copied-duration must be 4 seconds or more. Defaulting to 4 seconds.`);
+      return 4000;
     } else {
       return copiedDuration;
     }

--- a/elements/pfe-clipboard/test/pfe-clipboard.spec.ts
+++ b/elements/pfe-clipboard/test/pfe-clipboard.spec.ts
@@ -30,10 +30,10 @@ describe('<pfe-clipboard>', async function() {
     const el = await createFixture<PfeClipboard>(element);
     // strip icon text and whitespace
     const normalizedTextContent = el.shadowRoot!.textContent!.replace(/Copy URL|\s+/g, ' ').trim();
-    expect(normalizedTextContent).to.equal('Copied');
+    expect(normalizedTextContent).to.equal('Copied successful.');
     expect(el.shadowRoot!.querySelector<HTMLSlotElement>(`#icon`)!.assignedElements().length).to.equal(0);
-    expect(el.shadowRoot!.querySelectorAll('[role="alert"] slot').length).to.equal(1);
-    expect(el.shadowRoot!.querySelector<HTMLSlotElement>('[role="alert"] slot')!.assignedElements().length).to.equal(0);
+    expect(el.shadowRoot!.querySelector<HTMLSlotElement>(`.pfe-clipboard__text--success`)!.getAttribute('role')).to.equal('alert');
+    expect(el.shadowRoot!.querySelector<HTMLSlotElement>(`.pfe-clipboard__text--success`)!.getAttribute('tabindex')).to.equal('0');
     expect(el.shadowRoot!.querySelector<HTMLSlotElement>(`#success--text`)!).to.not.be.ok;
   });
 
@@ -128,9 +128,21 @@ describe('<pfe-clipboard>', async function() {
 
   it(`should have the correct accessibility attributes`, async function() {
     const el = await createFixture<PfeClipboard>(element);
-    // Add global event listener for the copy event
-    expect(el.getAttribute('role')).to.equal('button');
-    expect(el.getAttribute('tabindex')).to.equal('0');
+    // manually set the contentToCopy property
+    const copyText = `<div>Copy this text</div>`;
+
+
+    expect(el.shadowRoot!.querySelector<HTMLSlotElement>(`.pfe-clipboard__icon`)!.getAttribute('aria-hidden')).to.equal('true');
+
+    el.copyFrom = 'property';
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector(`.pfe-clipboard__button`)!.hasAttribute('aria-disabled'),
+      'pfe-clipboard button should be aria-disabled when target=property'
+    ).to.be.true;
+    el.contentToCopy = copyText;
+    el.click();
+    expect(navigator.clipboard.writeText).to.have.been.calledWith(copyText);
   });
 
   it(`should support copying the url by default`, async function() {
@@ -182,8 +194,8 @@ describe('<pfe-clipboard>', async function() {
     expect(navigator.clipboard.writeText).to.have.been.calledWith(copyText);
   });
 
-  it(`it should display the success state for 3 seconds`, async function(this: Mocha.Context) {
-    this.timeout(3500);
+  it(`it should display the success state for 4 seconds`, async function(this: Mocha.Context) {
+    this.timeout(4500);
     const el = await createFixture<PfeClipboard>(element);
     const textStyle = getComputedStyle(el.shadowRoot!.querySelector('.pfe-clipboard__text')!);
     const successStyle =
@@ -200,14 +212,14 @@ describe('<pfe-clipboard>', async function() {
       successStyle
         .getPropertyValue('display'),
       'success style'
-    ).to.equal('block');
-    // after 3 seconds it should return to normal
+    ).to.equal('flex');
+    // after 4 seconds it should return to normal
     // increase the timeout for this test
-    await aTimeout(3001);
+    await aTimeout(4001);
     // There should be a copied attribute on the host
     expect(el.hasAttribute('copied')).equal(false);
     // The text should be hidden
-    expect(textStyle.getPropertyValue('display'), 'text style').to.equal('block');
+    expect(textStyle.getPropertyValue('display'), 'text style').to.equal('flex');
     // The text--success should be visible
     expect(successStyle.getPropertyValue('display'), 'success style').to.equal('none');
   });
@@ -215,7 +227,7 @@ describe('<pfe-clipboard>', async function() {
   it('should use the deprecated text--success slot if specified', async function() {
     const el = await createFixture<PfeClipboard>(html`
       <pfe-clipboard>
-        <span slot="text--success">Corpied</span>
+        <span slot="text--success">Copied successful.</span>
       </pfe-clipboard>
     `);
 
@@ -226,14 +238,14 @@ describe('<pfe-clipboard>', async function() {
     const $slot = (name: string) => el.shadowRoot!.querySelector(`slot[name="${name}"]`) as HTMLSlotElement;
     const slottedText = (s: string) => $slot(s).assignedNodes({ flatten: true }).map(i => i.textContent!.trim()).join(' ');
 
-    expect(getComposedText(el).trim()).to.equal('Corpied');
+    expect(getComposedText(el).trim()).to.equal('Copied successful.');
     expect($slot('success')).to.be.null;
-    expect(slottedText('text--success')).to.equal('Corpied');
+    expect(slottedText('text--success')).to.equal('Copied successful.');
   });
 
   it('should use the deprecated text--success slot if added via innerHTML', async function() {
     const el = await createFixture<PfeClipboard>(element);
-    el.innerHTML = `<span slot="text--success">Corpied</span>`;
+    el.innerHTML = `<span slot="text--success">Copied successful.</span>`;
     await el.updateComplete;
     await aTimeout(1);
     el.click();
@@ -243,23 +255,28 @@ describe('<pfe-clipboard>', async function() {
 
     await aTimeout(50);
 
-    expect(getComposedText(el).trim()).to.equal('Corpied');
+    expect(getComposedText(el).trim()).to.equal('Copied successful.');
     expect($slot('success')).to.be.null;
-    expect(slottedText('text--success')).to.equal('Corpied');
+    expect(slottedText('text--success')).to.equal('Copied successful.');
   });
 
-  it(`should have a customizable copied state duration.`, async function() {
+  it(`should have a customizable copied state duration.`, async function(this: Mocha.Context) {
+    // increase timeout max for this test
+    this.timeout(5500);
+
     const el = await createFixture<PfeClipboard>(element);
-    // Set the copied state duration to 1 second
-    el.setAttribute('copied-duration', '1');
+    // Set the copied state duration to 5 seconds
+    el.setAttribute('copied-duration', '5');
     await el.updateComplete;
     el.click();
     // wait for the copy promise to resolve
     await aTimeout(50);
     // the success message should be immediately showing
     const success = el.shadowRoot!.querySelector('.pfe-clipboard__text--success')!;
-    expect(getComputedStyle(success).getPropertyValue('display')).to.equal('block');
-    await aTimeout(1001);
+    expect(getComputedStyle(success).getPropertyValue('display')).to.equal('flex');
+
+    // wait for copy state to be set back to the default state
+    await aTimeout(5001);
     // After the second duration the success message should be hidden
     expect(getComputedStyle(success).getPropertyValue('display')).to.equal('none');
   });


### PR DESCRIPTION
- Updated accessibility features for pfe-clipboard
- Address some issues found by Lighthouse and aXe DevTools
- Fixed some comment typos
- Added appropriate aria features and js updates
- Addressed major issues found during screen reader testing.
- Updated the component to function for all users rather than just sighted mouse users
- Added default state of 4 seconds and logic to ensure that the timeout is never set below 4 seconds so that users have enough time to hear and read the text state changes

## Related issues
https://github.com/patternfly/patternfly-elements/issues/1873

## Preview
1. Check out the fix/a11y-update-pfe-clipboard branch
1. Run npm start
1. Go to http://localhost:8000/demo/pfe-clipboard

## What has changed and why
- pfe-clipboard.ts
  - Added new state property for aria-disabled to added aria features
  - Added comments for changes
  - Updated the HTML in render() to add aria features
  - Cleaned up some comment typos
- pfe-clipboard.scss
  - Added sr-only class to utilize with pfe-clipboard to improve the success message output for screen readers
  - Adjusted the padding and changes some ids to be classes to go with new HTML structure
- pfe-clipboard.html
  - Removed role button and tabindex from pfe-clipboard tags because that is being set within the shadowDom now
- pfe-clipboard.js
  - Removed role button and tabindex from pfe-clipboard tags because that is being set within the shadowDom now

## Testing instructions
1. Follow the link to the demo
1. Turn on the screen reader that goes with your OS
1. Tab through the demo section for pfe-clipboard and activate the buttons
### Expected behavior
the visual text changes to "Copied" and the screen reader reads out loud the success message. Then after at least 4 seconds, the copy feature flips back to the initial state.
Browser requirements
Your component should work in all of the following environments:

- [ ] Latest 2 versions of Edge
- [ ] Internet Explorer 11 (should be useable, not pixel perfect)
- [ ] Latest 2 versions of Firefox (one on Mac OS, one of Windows OS)
- [ ] Firefox 78 (or latest version for Red Hat Enterprise Linux distribution)
- [ ] Latest 2 versions of Chrome (one on Mac OS, one of Windows OS)
- [ ] Latest 2 versions of Safari
- [ ] Android mobile device (such as the Galaxy S9)
- [ ] Apple mobile device (such as the iPhone X)
- [ ] Apple tablet device (such as the iPhone Pro)

## Ready-for-merge Checklist
- [x] Expected files: all files in this pull request are related to one request or issue (no stragglers or scope-creep).
- [x] Tests have been updated to cover these changes.
- [x] Browser testing passed.
- [ ] Changelog updated.

## Merging
Please squash when merging and ensure your commit message uses [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) formatting.

Be sure to share your updates with the [patternfly-elements-contribute@redhat.com](mailto:patternfly-elements-contribute@redhat.com) mailing list!