### PR TITLE
fix(core): make export map explicit

### DIFF
--- a/.changeset/nervous-meals-turn.md
+++ b/.changeset/nervous-meals-turn.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+Explicitly adds each module to the export map

--- a/core/pfe-core/package.json
+++ b/core/pfe-core/package.json
@@ -13,25 +13,93 @@
       "esbuild": "./core.ts",
       "default": "./core.js"
     },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
+    "./core.js": {
+      "esbuild": "./core.ts",
+      "default": "./core.js"
     },
-    "./controllers/*": {
-      "esbuild": "./controllers/*.ts",
-      "default": "./controllers/*.js"
+    "./context.js": {
+      "esbuild": "./context.ts",
+      "default": "./context.js"
     },
-    "./decorators/*": {
-      "esbuild": "./decorators/*.ts",
-      "default": "./decorators/*.js"
+    "./decorators.js": {
+      "esbuild": "./decorators.ts",
+      "default": "./decorators.js"
     },
-    "./directives/*": {
-      "esbuild": "./directives/*.ts",
-      "default": "./directives/*.js"
+    "./controllers/cascade-controller.js": {
+      "esbuild": "./controllers/cascade-controller.ts",
+      "default": "./controllers/cascade-controller.js"
     },
-    "./functions/*": {
-      "esbuild": "./functions/*.ts",
-      "default": "./functions/*.js"
+    "./controllers/color-context-controller.js": {
+      "esbuild": "./controllers/color-context-controller.ts",
+      "default": "./controllers/color-context-controller.js"
+    },
+    "./controllers/css-variable-controller.js": {
+      "esbuild": "./controllers/css-variable-controller.ts",
+      "default": "./controllers/css-variable-controller.js"
+    },
+    "./controllers/light-dom-controller.js": {
+      "esbuild": "./controllers/light-dom-controller.ts",
+      "default": "./controllers/light-dom-controller.js"
+    },
+    "./controllers/logger.js": {
+      "esbuild": "./controllers/logger.ts",
+      "default": "./controllers/logger.js"
+    },
+    "./controllers/perf-controller.js": {
+      "esbuild": "./controllers/perf-controller.ts",
+      "default": "./controllers/perf-controller.js"
+    },
+    "./controllers/property-observer-controller.js": {
+      "esbuild": "./controllers/property-observer-controller.ts",
+      "default": "./controllers/property-observer-controller.js"
+    },
+    "./controllers/slot-controller.js": {
+      "esbuild": "./controllers/slot-controller.ts",
+      "default": "./controllers/slot-controller.js"
+    },
+    "./controllers/style-controller.js": {
+      "esbuild": "./controllers/style-controller.ts",
+      "default": "./controllers/style-controller.js"
+    },
+    "./decorators/bound.js": {
+      "esbuild": "./decorators/bound.ts",
+      "default": "./decorators/bound.js"
+    },
+    "./decorators/cascades.js": {
+      "esbuild": "./decorators/cascades.ts",
+      "default": "./decorators/cascades.js"
+    },
+    "./decorators/initializer.js": {
+      "esbuild": "./decorators/initializer.ts",
+      "default": "./decorators/initializer.js"
+    },
+    "./decorators/observed.js": {
+      "esbuild": "./decorators/observed.ts",
+      "default": "./decorators/observed.js"
+    },
+    "./decorators/pfelement.js": {
+      "esbuild": "./decorators/pfelement.ts",
+      "default": "./decorators/pfelement.js"
+    },
+    "./decorators/time.js": {
+      "esbuild": "./decorators/time.ts",
+      "default": "./decorators/time.js"
+    },
+    "./decorators/trace.js": {
+      "esbuild": "./decorators/trace.ts",
+      "default": "./decorators/trace.js"
+    },
+    "./functions/debounce.js": {
+      "esbuild": "./functions/debounce.ts",
+      "default": "./functions/debounce.js"
+    },
+    "./functions/deprecateCustomEvent.js": {
+      "esbuild": "./functions/deprecateCustomEvent.ts",
+      "default": "./functions/deprecateCustomEvent.js"
+    },
+    "./functions/random.js": {
+      "esbuild": "./functions/random.ts",
+      "default": "./functions/random.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
Makes each module from core explicit in the export map.

This enables node-based tools to read the files specified.

See https://github.com/rhdemo/2022-game-app/pull/20#issuecomment-1067527033


### Testing instructions

- create a fresh project with `npm init -y`
- Set the repo's `type` to `module`.
- Install pfe-core via `npm link`.
- try to import a file from core via the node repl
