### PR TITLE
fix(create): ship js to npm

### DIFF
--- a/.changeset/blue-emus-draw.md
+++ b/.changeset/blue-emus-draw.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/create-element": major
+---
+
+- fix build script (ship .js to npm)
+- bump version to 1.0.0

--- a/tools/create-element/package.json
+++ b/tools/create-element/package.json
@@ -25,7 +25,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "prepublishOnly": "tsc -b .",
+    "prepublishOnly": "npm run build",
     "clean": "rimraf './main.{js,d.ts}' './generator/*.{js,d.ts}' bin/main.d.ts",
     "build": "run-p build:*",
     "build:esbuild": "esbuild main.ts generator/element.ts generator/files.ts generator/fp.ts --outdir=. --target=es2020",


### PR DESCRIPTION
also bump version number to 1.0

-----

See how `create-element` is shipped without js sources? that prevents anyone from actually using it 🤦 

https://unpkg.com/browse/@patternfly/create-element@next/

