### PR TITLE
hotfix(tools): dev server workspaces

### DIFF
--- a/.changeset/big-dingos-taste.md
+++ b/.changeset/big-dingos-taste.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+fail gracefully when dev server can't find workspace packages

--- a/.changeset/hip-cats-change.md
+++ b/.changeset/hip-cats-change.md
@@ -1,0 +1,24 @@
+---
+"@patternfly/pfe-tools": major
+---
+
+Remove support for custom `esbuild` export condition
+
+Previously, the dev-server config would try to import typescript sources using
+the `esbuild` export condition, but this proved awkward when daughter repos
+would try to import the same packages by the esbuild condition, only to
+discover that there was no typescript source file because it was compiled away
+before hitting NPM
+
+Therefore, removed export conditions entirely and now rely on a hacky mod to
+the built-in web dev server node-resolution algorithm
+
+In our tests, this appeared to work in both primary cases:
+1. Developing local packages in `patternfly/patternfly-elements`
+2. Developing local packages in a 'daughter' repo which installed
+   `@patternfly/pfe-tools`
+
+If you find that you're getting 404 errors to modules you're sure exist, or
+other such weird behaviour when resolving js sources from your monorepo, please
+open a [new
+issue](https://github.com/patternfly/patternfly-elements/issues/new/choose)

--- a/.changeset/silver-fans-lie.md
+++ b/.changeset/silver-fans-lie.md
@@ -1,0 +1,35 @@
+---
+"@patternfly/pfe-core": patch
+"@patternfly/pfe-accordion": patch
+"@patternfly/pfe-autocomplete": patch
+"@patternfly/pfe-avatar": patch
+"@patternfly/pfe-badge": patch
+"@patternfly/pfe-band": patch
+"@patternfly/pfe-button": patch
+"@patternfly/pfe-card": patch
+"@patternfly/pfe-clipboard": patch
+"@patternfly/pfe-codeblock": patch
+"@patternfly/pfe-collapse": patch
+"@patternfly/pfe-cta": patch
+"@patternfly/pfe-datetime": patch
+"@patternfly/pfe-dropdown": patch
+"@patternfly/pfe-health-index": patch
+"@patternfly/pfe-icon": patch
+"@patternfly/pfe-icon-panel": patch
+"@patternfly/pfe-jump-links": patch
+"@patternfly/pfe-label": patch
+"@patternfly/pfe-markdown": patch
+"@patternfly/pfe-modal": patch
+"@patternfly/pfe-number": patch
+"@patternfly/pfe-page-status": patch
+"@patternfly/pfe-primary-detail": patch
+"@patternfly/pfe-progress-indicator": patch
+"@patternfly/pfe-progress-steps": patch
+"@patternfly/pfe-readtime": patch
+"@patternfly/pfe-select": patch
+"@patternfly/pfe-tabs": patch
+"@patternfly/pfe-toast": patch
+"@patternfly/create-element": patch
+---
+
+Remove `esbuild` export condition, as this anyways was a runtime error

--- a/core/pfe-core/package.json
+++ b/core/pfe-core/package.json
@@ -9,98 +9,29 @@
   "module": "./core.js",
   "types": "./core.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./core.ts",
-      "default": "./core.js"
-    },
-    "./core.js": {
-      "esbuild": "./core.ts",
-      "default": "./core.js"
-    },
-    "./context.js": {
-      "esbuild": "./context.ts",
-      "default": "./context.js"
-    },
-    "./decorators.js": {
-      "esbuild": "./decorators.ts",
-      "default": "./decorators.js"
-    },
-    "./controllers/cascade-controller.js": {
-      "esbuild": "./controllers/cascade-controller.ts",
-      "default": "./controllers/cascade-controller.js"
-    },
-    "./controllers/color-context-controller.js": {
-      "esbuild": "./controllers/color-context-controller.ts",
-      "default": "./controllers/color-context-controller.js"
-    },
-    "./controllers/css-variable-controller.js": {
-      "esbuild": "./controllers/css-variable-controller.ts",
-      "default": "./controllers/css-variable-controller.js"
-    },
-    "./controllers/light-dom-controller.js": {
-      "esbuild": "./controllers/light-dom-controller.ts",
-      "default": "./controllers/light-dom-controller.js"
-    },
-    "./controllers/logger.js": {
-      "esbuild": "./controllers/logger.ts",
-      "default": "./controllers/logger.js"
-    },
-    "./controllers/perf-controller.js": {
-      "esbuild": "./controllers/perf-controller.ts",
-      "default": "./controllers/perf-controller.js"
-    },
-    "./controllers/property-observer-controller.js": {
-      "esbuild": "./controllers/property-observer-controller.ts",
-      "default": "./controllers/property-observer-controller.js"
-    },
-    "./controllers/slot-controller.js": {
-      "esbuild": "./controllers/slot-controller.ts",
-      "default": "./controllers/slot-controller.js"
-    },
-    "./controllers/style-controller.js": {
-      "esbuild": "./controllers/style-controller.ts",
-      "default": "./controllers/style-controller.js"
-    },
-    "./decorators/bound.js": {
-      "esbuild": "./decorators/bound.ts",
-      "default": "./decorators/bound.js"
-    },
-    "./decorators/cascades.js": {
-      "esbuild": "./decorators/cascades.ts",
-      "default": "./decorators/cascades.js"
-    },
-    "./decorators/initializer.js": {
-      "esbuild": "./decorators/initializer.ts",
-      "default": "./decorators/initializer.js"
-    },
-    "./decorators/observed.js": {
-      "esbuild": "./decorators/observed.ts",
-      "default": "./decorators/observed.js"
-    },
-    "./decorators/pfelement.js": {
-      "esbuild": "./decorators/pfelement.ts",
-      "default": "./decorators/pfelement.js"
-    },
-    "./decorators/time.js": {
-      "esbuild": "./decorators/time.ts",
-      "default": "./decorators/time.js"
-    },
-    "./decorators/trace.js": {
-      "esbuild": "./decorators/trace.ts",
-      "default": "./decorators/trace.js"
-    },
-    "./functions/debounce.js": {
-      "esbuild": "./functions/debounce.ts",
-      "default": "./functions/debounce.js"
-    },
-    "./functions/deprecateCustomEvent.js": {
-      "esbuild": "./functions/deprecateCustomEvent.ts",
-      "default": "./functions/deprecateCustomEvent.js"
-    },
-    "./functions/random.js": {
-      "esbuild": "./functions/random.ts",
-      "default": "./functions/random.js"
-    }
+    ".": "./core.js",
+    "./core.js": "./core.js",
+    "./context.js": "./context.js",
+    "./decorators.js": "./decorators.js",
+    "./controllers/cascade-controller.js": "./controllers/cascade-controller.js",
+    "./controllers/color-context-controller.js": "./controllers/color-context-controller.js",
+    "./controllers/css-variable-controller.js": "./controllers/css-variable-controller.js",
+    "./controllers/light-dom-controller.js": "./controllers/light-dom-controller.js",
+    "./controllers/logger.js": "./controllers/logger.js",
+    "./controllers/perf-controller.js": "./controllers/perf-controller.js",
+    "./controllers/property-observer-controller.js": "./controllers/property-observer-controller.js",
+    "./controllers/slot-controller.js": "./controllers/slot-controller.js",
+    "./controllers/style-controller.js": "./controllers/style-controller.js",
+    "./decorators/bound.js": "./decorators/bound.js",
+    "./decorators/cascades.js": "./decorators/cascades.js",
+    "./decorators/initializer.js": "./decorators/initializer.js",
+    "./decorators/observed.js": "./decorators/observed.js",
+    "./decorators/pfelement.js": "./decorators/pfelement.js",
+    "./decorators/time.js": "./decorators/time.js",
+    "./decorators/trace.js": "./decorators/trace.js",
+    "./functions/debounce.js": "./functions/debounce.js",
+    "./functions/deprecatedCustomEvent.js": "./functions/deprecatedCustomEvent.js",
+    "./functions/random.js": "./functions/random.js"
   },
   "publishConfig": {
     "access": "public",

--- a/docs/demo/demo.ts
+++ b/docs/demo/demo.ts
@@ -1,3 +1,7 @@
+import 'html-include-element';
+import 'api-viewer-element';
+import '@vaadin/split-layout';
+
 import { html, render } from 'lit';
 import { core, elements } from '@patternfly/pfe-tools/environment.js';
 import { URLPattern } from 'urlpattern-polyfill';

--- a/elements/pfe-accordion/demo/pfe-accordion.js
+++ b/elements/pfe-accordion/demo/pfe-accordion.js
@@ -1,3 +1,4 @@
+import '@patternfly/pfe-accordion';
 import '@patternfly/pfe-band';
 import '@patternfly/pfe-button';
 import '@patternfly/pfe-card';

--- a/elements/pfe-accordion/package.json
+++ b/elements/pfe-accordion/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-accordion.js",
   "types": "./pfe-accordion.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-accordion.ts",
-      "default": "./pfe-accordion.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-accordion.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-autocomplete/package.json
+++ b/elements/pfe-autocomplete/package.json
@@ -9,18 +9,9 @@
   "module": "./pfe-autocomplete.js",
   "types": "./pfe-autocomplete.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-autocomplete.ts",
-      "default": "./pfe-autocomplete.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    },
-    "./*.js": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-autocomplete.js",
+    "./*": "./*.js",
+    "./*.js": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-avatar/package.json
+++ b/elements/pfe-avatar/package.json
@@ -8,14 +8,8 @@
   "module": "./pfe-avatar.js",
   "types": "./pfe-avatar.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-avatar.ts",
-      "default": "./pfe-avatar.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-avatar.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-badge/package.json
+++ b/elements/pfe-badge/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-badge.js",
   "types": "./pfe-badge.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-badge.ts",
-      "default": "./pfe-badge.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-badge.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-band/package.json
+++ b/elements/pfe-band/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-band.js",
   "types": "./pfe-band.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-band.ts",
-      "default": "./pfe-band.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-band.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-button/package.json
+++ b/elements/pfe-button/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-button.js",
   "types": "./pfe-button.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-button.ts",
-      "default": "./pfe-button.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-button.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-card/package.json
+++ b/elements/pfe-card/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-card.js",
   "types": "./pfe-card.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-card.ts",
-      "default": "./pfe-card.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-card.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-clipboard/package.json
+++ b/elements/pfe-clipboard/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-clipboard.js",
   "types": "./pfe-clipboard.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-clipboard.ts",
-      "default": "./pfe-clipboard.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-clipboard.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-codeblock/package.json
+++ b/elements/pfe-codeblock/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-codeblock.js",
   "types": "./pfe-codeblock.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-codeblock.ts",
-      "default": "./pfe-codeblock.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-codeblock.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-collapse/package.json
+++ b/elements/pfe-collapse/package.json
@@ -8,14 +8,8 @@
   "main": "./pfe-collapse.js",
   "module": "./pfe-collapse.js",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-collapse.ts",
-      "default": "./pfe-collapse.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-collapse.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-cta/package.json
+++ b/elements/pfe-cta/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-cta.js",
   "types": "./pfe-cta.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-cta.ts",
-      "default": "./pfe-cta.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-cta.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-datetime/package.json
+++ b/elements/pfe-datetime/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-datetime.js",
   "types": "./pfe-datetime.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-datetime.ts",
-      "default": "./pfe-datetime.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-datetime.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-dropdown/package.json
+++ b/elements/pfe-dropdown/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-dropdown.js",
   "types": "./pfe-dropdown.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-dropdown.ts",
-      "default": "./pfe-dropdown.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-dropdown.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-health-index/package.json
+++ b/elements/pfe-health-index/package.json
@@ -8,14 +8,8 @@
   "main": "./pfe-health-index.js",
   "module": "./pfe-health-index.js",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-health-index.ts",
-      "default": "./pfe-health-index.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-health-index.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-icon-panel/package.json
+++ b/elements/pfe-icon-panel/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-icon-panel.js",
   "types": "./pfe-icon-panel.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-icon-panel.ts",
-      "default": "./pfe-icon-panel.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-icon-panel.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-icon/package.json
+++ b/elements/pfe-icon/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-icon.js",
   "types": "./pfe-icon.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-icon.ts",
-      "default": "./pfe-icon.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-icon.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-jump-links/package.json
+++ b/elements/pfe-jump-links/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-jump-links.js",
   "types": "./pfe-jump-links.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-jump-links.ts",
-      "default": "./pfe-jump-links.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-jump-links.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-label/package.json
+++ b/elements/pfe-label/package.json
@@ -12,14 +12,8 @@
     "test": "tests"
   },
   "exports": {
-    ".": {
-      "esbuild": "./pfe-label.ts",
-      "default": "./pfe-label.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-label.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-markdown/package.json
+++ b/elements/pfe-markdown/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-markdown.js",
   "types": "./pfe-markdown.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-markdown.ts",
-      "default": "./pfe-markdown.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-markdown.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-modal/package.json
+++ b/elements/pfe-modal/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-modal.js",
   "types": "./pfe-modal.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-modal.ts",
-      "default": "./pfe-modal.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-modal.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-number/package.json
+++ b/elements/pfe-number/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-number.js",
   "types": "./pfe-number.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-number.ts",
-      "default": "./pfe-number.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-number.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-page-status/package.json
+++ b/elements/pfe-page-status/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-page-status.js",
   "types": "./pfe-page-status.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-page-status.ts",
-      "default": "./pfe-page-status.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-page-status.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-primary-detail/package.json
+++ b/elements/pfe-primary-detail/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-primary-detail.js",
   "types": "./pfe-primary-detail.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-primary-detail.ts",
-      "default": "./pfe-primary-detail.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-primary-detail.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-progress-indicator/package.json
+++ b/elements/pfe-progress-indicator/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-progress-indicator.js",
   "types": "./pfe-progress-indicator.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-progress-indicator.ts",
-      "default": "./pfe-progress-indicator.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-progress-indicator.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-progress-steps/package.json
+++ b/elements/pfe-progress-steps/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-progress-steps.js",
   "types": "./pfe-progress-steps.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-progress-steps.ts",
-      "default": "./pfe-progress-steps.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-progress-steps.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-readtime/package.json
+++ b/elements/pfe-readtime/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-readtime.js",
   "types": "./pfe-readtime.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-readtime.ts",
-      "default": "./pfe-readtime.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-readtime.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-select/package.json
+++ b/elements/pfe-select/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-select.js",
   "types": "./pfe-select.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-select.ts",
-      "default": "./pfe-select.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-select.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-tabs/package.json
+++ b/elements/pfe-tabs/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-tabs.js",
   "types": "./pfe-tabs.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-tabs.ts",
-      "default": "./pfe-tabs.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-tabs.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/elements/pfe-toast/package.json
+++ b/elements/pfe-toast/package.json
@@ -9,14 +9,8 @@
   "module": "./pfe-toast.js",
   "types": "./pfe-toast.d.ts",
   "exports": {
-    ".": {
-      "esbuild": "./pfe-toast.ts",
-      "default": "./pfe-toast.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./pfe-toast.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
   <link rel="stylesheet" href="/core/pfe-styles/pfe-layouts.min.css">
   <link rel="stylesheet" href="/core/pfe-styles/red-hat-font.min.css">
   <script type="module">
-    import 'html-include-element';
-    import 'api-viewer-element';
-    import '@vaadin/split-layout';
     import '/docs/demo/demo.ts';
   </script>
 </head>

--- a/tools/create-element/templates/element/demo/element.js
+++ b/tools/create-element/templates/element/demo/element.js
@@ -1,3 +1,5 @@
+import '<%= packageName =>';
+
 const root = document.querySelector('[data-demo="<%= tagName %>"]')?.shadowRoot ?? document;
 
 root.querySelector('<%= tagName %>');

--- a/tools/create-element/templates/element/demo/element.js
+++ b/tools/create-element/templates/element/demo/element.js
@@ -1,4 +1,4 @@
-import '<%= packageName =>';
+import '<%= packageName %>';
 
 const root = document.querySelector('[data-demo="<%= tagName %>"]')?.shadowRoot ?? document;
 

--- a/tools/create-element/templates/element/package.json
+++ b/tools/create-element/templates/element/package.json
@@ -12,14 +12,8 @@
     "test": "tests"
   },
   "exports": {
-    ".": {
-      "esbuild": "./<%= tagName %>.ts",
-      "default": "./<%= tagName %>.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    }
+    ".": "./<%= tagName %>.js",
+    "./*": "./*.js"
   },
   "publishConfig": {
     "access": "public",

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -26,6 +26,10 @@ function appendLines(body: string, ...lines: string[]): string {
   return [body, ...lines].join('\n');
 }
 
+async function tryRead(pathname: string) {
+  return readdir(pathname).catch(() => []);
+}
+
 /**
  * Binds data from the node context to the dev-server's browser context.
  * exposed data is available by importing `@patternfly/pfe-tools/environment.js`.
@@ -38,12 +42,12 @@ function bindNodeDataToBrowser(options?: PfeDevServerConfigOptions): Plugin {
       if (context.path.endsWith('pfe-tools/environment.js')) {
         // TODO: calculate export names from npm workspaces
         //       for now, `elements` is the only conventionally-supported workspace
-        const elements = await readdir(join(rootDir, 'elements'));
-        const core = await readdir(join(rootDir, 'core'));
+        const elements = await tryRead(join(rootDir, 'elements'));
+        const core = await tryRead(join(rootDir, 'core'));
         const transformed = appendLines(
           context.body as string,
           `export const elements = ${JSON.stringify(elements)};`,
-          `export const core = ${JSON.stringify(core)};`
+          `export const core     = ${JSON.stringify(core)};`
         );
         return transformed;
       }

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -2,8 +2,8 @@ import type { Plugin } from '@web/dev-server-core';
 import type { DevServerConfig } from '@web/dev-server';
 import type { InjectSetting } from '@web/dev-server-import-maps/dist/importMapsPlugin';
 
-import { readdir } from 'fs/promises';
-import { join } from 'path';
+import { readdir, stat } from 'fs/promises';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 import litcssRollup from 'rollup-plugin-lit-css';
@@ -12,6 +12,10 @@ import { fromRollup } from '@web/dev-server-rollup';
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
 import { transformSass } from './esbuild.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const exists = (x: string) => stat(x).then(() => true, () => false);
 
 export interface PfeDevServerConfigOptions extends DevServerConfig {
   /** Extra dev server plugins */
@@ -39,7 +43,7 @@ function bindNodeDataToBrowser(options?: PfeDevServerConfigOptions): Plugin {
   return {
     name: 'bind-node-data-to-browser',
     async transform(context) {
-      if (context.path.endsWith('pfe-tools/environment.js')) {
+      if (context.path.match(/pfe-tools\/environment\.(?:j|t)s$/)) {
         // TODO: calculate export names from npm workspaces
         //       for now, `elements` is the only conventionally-supported workspace
         const elements = await tryRead(join(rootDir, 'elements'));
@@ -67,10 +71,65 @@ function scssMimeType(): Plugin {
   };
 }
 
+function tryToResolve(source: string, context: import('koa').Context) {
+  let resolved = '';
+
+  try {
+    resolved = require.resolve(source);
+  } catch (error) {
+    const { message } = error as Error;
+    // try not to look
+    if (message.startsWith('Cannot find module')) {
+      const [, resolved] = /Cannot find module '(.*)'/.exec(message) ?? [];
+      if (!resolved) {
+        throw error;
+      }
+    } else {
+      throw error;
+    }
+  }
+
+  // e.g., a relative path from a file deeper in the module graph
+  // `context.path` here is the abspath to the importee
+  if (!resolved) {
+    resolved = join(dirname(context.path), source);
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolves local monorepo package imports. Needed because we consume our own monorepo packages
+ */
+export function resolveLocalFilesFromTypeScriptSources(options: PfeDevServerConfigOptions): Plugin {
+  const rootDir = options.rootDir as string;
+  return {
+    name: 'resolve-local-monorepo-packages-from-ts-sources',
+    async transformImport({ source, context }) {
+      // already resolved, but had `.js` appended, probably by export map
+      if (source.endsWith('.ts.js')) {
+        return source.replace('.ts.js', '.ts');
+      // don't try to resolve node_modules, they're already resolved
+      } else if (source.match(/node_modules/) || context.path.match(/node_modules/)) {
+        return;
+      } else {
+        const resolved = tryToResolve(source, context);
+        const absToRoot = resolved.replace(rootDir, '/');
+        const replaced = absToRoot.replace(/\.js$/, '.ts');
+        const fileExists = await exists(join(rootDir, replaced));
+        const final = (fileExists ? replaced : resolved);
+        return final;
+      }
+    },
+  };
+}
+
 /**
  * Creates a default config for PFE's dev server.
  */
-export function pfeDevServerConfig(options?: PfeDevServerConfigOptions): DevServerConfig {
+export function pfeDevServerConfig(_options?: PfeDevServerConfigOptions): DevServerConfig {
+  const { importMap, ...options } = _options ?? {};
+
   /**
    * Plain case: this file is running from `/node_modules/@patternfly/pfe-tools`.
    *             two dirs up from here is `node_modules`, so we just shear it clean off the path string
@@ -80,30 +139,14 @@ export function pfeDevServerConfig(options?: PfeDevServerConfigOptions): DevServ
    * Edge/Corner cases: all other cases must set the `rootDir` option themselves so as to avoid 404s
    */
   const rootDir = options?.rootDir ?? fileURLToPath(new URL('../..', import.meta.url))
-    .replace(/\/node_modules$/, '');
-
-  /** Default set of import maps */
-  const imports = {
-    'lit': '/node_modules/lit/index.js',
-    'lit/': '/node_modules/lit/',
-
-    'html-include-element': '/node_modules/html-include-element/html-include-element.js',
-    'api-viewer-element': '/node_modules/api-viewer-element/lib/api-viewer.js',
-    '@vaadin/split-layout': '/node_modules/@vaadin/split-layout/vaadin-split-layout.js',
-
-    '@patternfly/pfe-tools/': '/node_modules/@patternfly/pfe-tools/',
-    '@patternfly/pfe-core': '/node_modules/@patternfly/pfe-core/core.js',
-    '@patternfly/pfe-core/': '/node_modules/@patternfly/pfe-core/',
-    ...options?.importMap?.imports,
-  };
+    .replace(/node_modules\/$/, '/')
+    .replace(/\/node_modules$/, '/')
+    .replace('//', '/');
 
   return {
     appIndex: 'index.html',
 
-    nodeResolve: {
-      exportConditions: ['esbuild', 'import', 'default'],
-      extensions: ['.ts', '.mjs', '.js', '.scss'],
-    },
+    nodeResolve: true,
 
     rootDir,
 
@@ -119,8 +162,18 @@ export function pfeDevServerConfig(options?: PfeDevServerConfigOptions): DevServ
 
     plugins: [
       ...options?.plugins ?? [],
-      scssMimeType(),
-      importMapsPlugin({ inject: { importMap: { imports } } }),
+      ...(importMap) ? [importMapsPlugin({ inject: { importMap } })] : [],
+      // ordinarily, the packages' export conditions specify to
+      //   1. import the root from a '.js'
+      //   2. append '.js' to any subpath imports
+      // that's great when we're importing *actual* node_modules, since we want the build artifacts
+      // but when we're importing a monorepo package, we want to load up the typescript sources
+      // that's the whole idea of 'buildless' via esbuild plugin - no need to run a file watcher
+      // so we run this cheap hack to manually resolve those file paths
+      // we hope it will work in most cases. If you have a problem loading from packages in the dev
+      // server, please open an issue at https://github.com/patternfly/patternfly-elements/issues/new/
+      resolveLocalFilesFromTypeScriptSources({ ...options, rootDir }),
+      // importMapsPlugin({ inject: { importMap: { imports } } }),
       // serve typescript sources as javascript
       esbuildPlugin({ ts: true }),
       // bind data from node to the browser
@@ -129,6 +182,8 @@ export function pfeDevServerConfig(options?: PfeDevServerConfigOptions): DevServ
       bindNodeDataToBrowser({ rootDir }),
       // load .scss files as lit CSSResult modules
       litcss({ include: ['**/*.scss'], transform: transformSass }),
+      // Ensure .scss files are loaded as js modules, as `litcss` plugin transforms them to such
+      scssMimeType(),
     ],
   };
 }

--- a/tools/pfe-tools/esbuild.ts
+++ b/tools/pfe-tools/esbuild.ts
@@ -44,11 +44,11 @@ export interface PfeEsbuildSingleFileOptions {
   minify?: boolean;
 }
 
-/** abs-path to repo root */
-const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+/** best guess at abs-path to repo root */
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url)).replace(/node_modules\/$/, '');
 
 /** abs-path to root node_modules */
-const NODE_MODULES = fileURLToPath(new URL('../../node_modules', import.meta.url));
+const NODE_MODULES = join(REPO_ROOT, 'node_modules/');
 
 /** memoization cache for temporary component entrypoint files */
 const COMPONENT_ENTRYPOINTS_CACHE = new Map();

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -21,18 +21,8 @@
   },
   "exports": {
     "./11ty": "./11ty/index.js",
-    "./*.js": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    },
-    "./*": {
-      "esbuild": "./*.ts",
-      "default": "./*.js"
-    },
-    "./environment.js": {
-      "esbuild": "./environment.ts",
-      "default": "./environment.js"
-    }
+    "./*.js": "./*.js",
+    "./*": "./*.js"
   },
   "contributors": [
     "Kyle Buchanan <kylebuch8@gmail.com>, (https://github.com/kylebuch8)",

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -1,33 +1,5 @@
 import { pfeDevServerConfig } from '@patternfly/pfe-tools/dev-server.js';
 
-/**
- * Resolves local monorepo package imports. Needed because we consume our own monorepo packages
- * @return {import('@web/dev-server-core').Plugin}
- */
-export function resolvePFEMonorepoPlugin() {
-  return {
-    name: 'resolve-patternfly-elements-monorepo-packages',
-    resolveImport({ source }) {
-      if (source === '@patternfly/pfe-core') {
-        return `/core/pfe-core/core.ts`;
-      }
-      const [match, pkg, path, ext] = source.match(/^@patternfly\/(pfe-?\w+)\/(.*).(js|scss)$/) ?? [];
-      if (match) {
-        switch (pkg) {
-          case 'pfe-tools':
-            return;
-          case 'pfe-styles':
-          case 'pfe-sass':
-          case 'pfe-core':
-            return `/core/${pkg}/${path}.${ext.replace('js', 'ts')}`;
-          default:
-            return `/elements/${pkg}/${path}.${ext.replace('js', 'ts')}`;
-        }
-      }
-    },
-  };
-}
-
 /** @return {import('@web/dev-server-core').Plugin} */
 export function fakePrismModule() {
   return {
@@ -42,7 +14,6 @@ export function fakePrismModule() {
 
 export default pfeDevServerConfig({
   plugins: [
-    resolvePFEMonorepoPlugin(),
     fakePrismModule(),
   ],
 });

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,12 +1,11 @@
 import { pfeTestRunnerConfig } from '@patternfly/pfe-tools/test-runner.js';
-import { resolvePFEMonorepoPlugin, fakePrismModule } from './web-dev-server.config.js';
+import { fakePrismModule } from './web-dev-server.config.js';
 
 export default pfeTestRunnerConfig({
   files: ['!tools/create-element/templates/**/*'],
   // uncomment to get default wtr reporter
   // reporter: 'default',
   plugins: [
-    resolvePFEMonorepoPlugin(),
     fakePrismModule(),
   ],
 });


### PR DESCRIPTION
- removes export conditions from packages, they were for development use only and thus were a runtime error for consumers, and confusing
- removes default import map from dev server, but keeps the option to specify one
- adds 'double checking' step to dev sever module resolution which resolves local modules from local packages *by typescript source* instead of by js source

can be checked against the lastest commit from pfe-monorepo-template, although you'll have to either merge and publish this then update deps there, or copy (not symlink) these changes into that repo's node_modules
