### PR TITLE
fix(tools): adding @patternfly/create-element to postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "postinstall": "run-s postinstall:**",
     "postinstall:patch": "patch-package",
     "postinstall:husky": "npx husky install",
+    "postinstall:build:create": "npm run build --workspace @patternfly/create-element",
     "postinstall:build:tools": "npm run build --workspace @patternfly/pfe-tools",
     "postinstall:build:styles": "npm run build --workspace @patternfly/pfe-styles",
     "pr": "node scripts/open-pr.js"


### PR DESCRIPTION
## <Pull request description>

The @patternfly/create-element tool is not included in the post install scripts which means to run npm run new you need to first run npm run build -w @patternfly/create-elements if you plan to use the new script. This should be updated so that it is handled by the postinstall scripts.


### Related issues

- (#1963) 