### PR TITLE
feat(create): `--monorepo` flag

### DIFF
--- a/.changeset/tricky-tools-joke.md
+++ b/.changeset/tricky-tools-joke.md
@@ -1,0 +1,7 @@
+---
+"@patternfly/create-element": minor
+---
+
+Adds `--monorepo` flag to generator.
+In most cases, this is automatically derived from the root package.json.
+Override with `--monorepo` or `--no-monorepo`.

--- a/tools/pfe-tools/11ty/DocsPage.ts
+++ b/tools/pfe-tools/11ty/DocsPage.ts
@@ -14,6 +14,8 @@ import nunjucks, { Environment } from 'nunjucks';
 interface PackageJSON {
   customElements?: string;
   name: string;
+  version: string;
+  workspaces?: string;
 }
 
 export interface RenderKwargs {


### PR DESCRIPTION
Running the generator in a monorepo, the user should be prompted for a scope name, and these files should be written

- tsconfig.json
- custom-elements-manifest.config.js
- package.json

Running the generator in a single package repo, the user should not be prompted for a scope name, and those three files should not be written 