### PR TITLE
fix(button): contrast error

### DIFF
--- a/.changeset/cuddly-icons-fly.md
+++ b/.changeset/cuddly-icons-fly.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+CSS colour test errors are more readable

--- a/.changeset/cyan-islands-lay.md
+++ b/.changeset/cyan-islands-lay.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-button": patch
+---
+
+fixes colour contrast on dark and saturated contexts, secondary variant

--- a/.changeset/selfish-cobras-lie.md
+++ b/.changeset/selfish-cobras-lie.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-cta": patch
+---
+
+fix color contrast on dark context with secondary priority and wind variant

--- a/elements/pfe-button/pfe-button.scss
+++ b/elements/pfe-button/pfe-button.scss
@@ -98,7 +98,7 @@
 :host([variant="secondary"]) {
   #container {
     ::slotted(button) {
-      color: var(--pfe-button--Color, var(--pfe-theme--color--ui-accent,#06c)) !important;
+      --pfe-button--Color: var(--pfe-theme--color--ui-accent,#06c) !important;
       &::after {
         border-color: pfe-local(BorderColor, $region: after, $fallback: pfe-var(ui-accent)) !important;
       }
@@ -109,6 +109,18 @@
 :host([on^=dark]),
 :host([on=saturated]) {
   --pfe-theme--color--text: #ffffff;
+}
+
+:host([on^=dark][variant="secondary"]),
+:host([on=saturated][variant="secondary"]) {
+  #container {
+    ::slotted(button) {
+      --pfe-button--Color: var(--pfe-theme--color--ui-accent--on-dark, #73bcf7) !important;
+      &::after {
+        border-color: pfe-local(BorderColor, $region: after, $fallback: pfe-var(ui-accent--on-dark)) !important;
+      }
+    }
+  }
 }
 
 :host([on^=dark][variant="tertiary"]) {

--- a/elements/pfe-button/test/pfe-button.spec.ts
+++ b/elements/pfe-button/test/pfe-button.spec.ts
@@ -1,78 +1,251 @@
-import { expect, html, oneEvent } from '@open-wc/testing';
-import { spy } from 'sinon';
+import type { ReactiveElement } from 'lit';
+import type { ColorTheme } from '@patternfly/pfe-core';
+
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { sendMouse } from '@web/test-runner-commands';
+import { getElementPosition } from '@patternfly/pfe-tools/test/utils.js';
+import { chai, expect, html, oneEvent } from '@open-wc/testing';
+import { spy, SinonSpy } from 'sinon';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 import { PfeButton } from '@patternfly/pfe-button';
 
-// reference the imported value in runtime code so that typescript doesn't strip the import
-PfeButton;
+import '@patternfly/pfe-band';
 
-const element = html`
+const elementTpl = html`
   <pfe-button>
     <button>Button</button>
   </pfe-button>
 `;
 
-const badElement = html`
+const badElementTpl = html`
   <pfe-button>
     <div>Bad button</div>
   </pfe-button>
 `;
 
 describe('<pfe-button>', function() {
+  let element: PfeButton;
+  let spyConsole: SinonSpy;
+
   it('should upgrade', async function() {
-    const el = await createFixture(element);
-    expect(el, 'pfe-button should be an instance of PfeButton')
+    expect(await createFixture(elementTpl), 'pfe-button should be an instance of PfeButton')
       .to.be.an.instanceOf(customElements.get('pfe-button'))
       .and
       .to.be.an.instanceOf(PfeButton);
   });
 
-  it('should log a console warning if the light dom inside pfe-button is not a button', async function() {
-    const spyConsole = spy(console, 'warn');
-    const el = await createFixture(badElement);
+  describe('with proper light DOM', function() {
+    beforeEach(async function() {
+      element = await createFixture(elementTpl);
+    });
+    it('should synchronize disabled attribute to the light DOM button', async function() {
+      const lightDomBtn = element.querySelector('button')!;
 
-    expect(el).to.exist;
-    expect(spyConsole, 'The only child in the light DOM must be a button tag')
-      .to.have.been.calledWith('[pfe-button]');
-    spyConsole.restore();
+      element.disabled = true;
+      await element.updateComplete;
+
+      expect(lightDomBtn).dom.to.equal('<button disabled>Button</button>');
+
+      element.disabled = false;
+      await element.updateComplete;
+
+      expect(lightDomBtn).dom.to.equal('<button>Button</button>');
+    });
+
+    it('should synchronize type attribute to the light DOM button', async function() {
+      const lightDomBtn = element.querySelector('button')!;
+
+      element.type = 'reset';
+      await element.updateComplete;
+
+      expect(element.type).to.equal('reset');
+      expect(lightDomBtn).dom.to.equal('<button type="reset">Button</button>');
+
+      element.type = undefined;
+      await element.updateComplete;
+
+      expect(lightDomBtn).dom.to.equal('<button>Button</button>');
+    });
+
+    it('should send a pfe-button:click event on click', async function() {
+      setTimeout(() => element.querySelector('button')!.click());
+      const event = await oneEvent(document, 'pfe-button:click');
+      expect(event).to.be.ok;
+      expect(event.type).to.equal('pfe-button:click');
+    });
   });
 
-  it('should synchronize disabled attribute to the light DOM button', async function() {
-    const el = await createFixture<PfeButton>(element);
-    const lightDomBtn = el.querySelector('button')!;
+  describe('with malformed light DOM', function() {
+    beforeEach(async function() {
+      spyConsole = spy(console, 'warn');
+      element = await createFixture(badElementTpl);
+    });
 
-    el.disabled = true;
-    await el.updateComplete;
+    afterEach(function() {
+      spyConsole.restore();
+    });
 
-    expect(lightDomBtn).dom.to.equal('<button disabled>Button</button>');
-
-    el.disabled = false;
-    await el.updateComplete;
-
-    expect(lightDomBtn).dom.to.equal('<button>Button</button>');
+    it('should log a console warning if the light dom inside pfe-button is not a button', async function() {
+      expect(element).to.exist;
+      expect(spyConsole, 'The only child in the light DOM must be a button tag')
+        .to.have.been.calledWith('[pfe-button]');
+    });
   });
 
-  it('should synchronize type attribute to the light DOM button', async function() {
-    const el = await createFixture<PfeButton>(element);
-    const lightDomBtn = el.querySelector('button')!;
+  describe('with color context', function() {
+    let button: HTMLButtonElement;
+    let style: CSSStyleDeclaration;
 
-    el.type = 'reset';
-    await el.updateComplete;
+    function contextFixture(options?: {
+      on?: ColorTheme;
+      disabled?: boolean;
+      variant?: PfeButton['variant'];
+    }) {
+      const bandPalette =
+          options?.on === 'saturated' ? 'accent'
+        : options?.on === 'dark' ? 'darkest'
+        : options?.on === 'light' ? 'lightest'
+        : options?.on === 'base' ? 'base'
+        : undefined;
+      return async function() {
+        const wrapper = await createFixture<ReactiveElement>(html`
+          <pfe-band color-palette=${ifDefined(bandPalette)}>
+            <pfe-button ?disabled=${options?.disabled} variant=${ifDefined(options?.variant)}>
+              <button>Test</button>
+            </pfe-button>
+          </pfe-band>
+        `);
+        element = wrapper.querySelector('pfe-button') as PfeButton;
+        button = element.querySelector('button')!;
+        style = getComputedStyle(button);
+        await wrapper.updateComplete;
+        await element.updateComplete;
+        // ensure element is not hovered
+        await sendMouse({ type: 'move', position: [
+          document.documentElement.clientWidth,
+          document.documentElement.clientHeight,
+        ] });
+      };
+    }
 
-    expect(el.type).to.equal('reset');
-    expect(lightDomBtn).dom.to.equal('<button type="reset">Button</button>');
+    async function hoverElement() {
+      await sendMouse({ type: 'move', position: getElementPosition(element) });
+    }
 
-    el.type = undefined;
-    await el.updateComplete;
+    function focusElement() {
+      element.querySelector('button')!.focus();
+    }
 
-    expect(lightDomBtn).dom.to.equal('<button>Button</button>');
-  });
+    function assertStyles(assertions: {
+      on?: ColorTheme;
+      backgroundColor: string;
+      color: string;
+    }) {
+      const errors: ( Chai.AssertionError & { key: string, actual: string, expected: string } )[] = [];
 
-  it('should send a pfe-button:click event on click', async function() {
-    const el = await createFixture<PfeButton>(element);
-    setTimeout(() => el.querySelector('button')!.click());
-    const event = await oneEvent(document, 'pfe-button:click');
-    expect(event).to.be.ok;
-    expect(event.type).to.equal('pfe-button:click');
+      for (const [key, expected] of Object.entries(assertions)) {
+        let actual: string;
+        try {
+          switch (key) {
+            case 'on':
+              actual = element.on!;
+              expect(actual).to.equal(expected, `uses ${expected} color theme`);
+              break;
+            default:
+              actual = style[key as keyof typeof style] as string;
+              expect(actual).to.be.colored(expected, key);
+          }
+        } catch (e) {
+          errors.push({ ...e as Chai.AssertionError & { actual: string, expected: string }, key });
+        }
+      }
+
+      if (errors.length) {
+        const e = new chai.AssertionError(`styles did not match\n\t${errors.map(e => e.message).join('\n\t')}`, errors.reduce((acc, e) => ({
+          ...acc,
+          actual: { ...acc.actual, [e.key]: e.actual, },
+          expected: { ...acc.expected, [e.key]: e.expected, }
+        }), { actual: {}, expected: {} }));
+        e.showDiff = true;
+        throw e;
+      }
+
+      expect(element).to.be.accessible();
+    }
+
+    describe('unspecified', function() {
+      const on = undefined;
+      describe('variant="primary"', function() {
+        beforeEach(contextFixture({ on }));
+        it('has correct theme values', () => assertStyles({
+          on: 'light',
+          backgroundColor: '#06c',
+          color: 'white',
+
+        }));
+        describe('focused', function() {
+          beforeEach(focusElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: '#004080',
+            color: 'white',
+          }));
+        });
+        describe('hovered', function() {
+          beforeEach(hoverElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: '#004080',
+            color: 'white',
+          }));
+        });
+      });
+    });
+
+    describe('saturated', function() {
+      const on = 'saturated';
+      describe('variant="primary"', function() {
+        beforeEach(contextFixture({ on }));
+        it('has correct theme values', () => assertStyles({
+          on,
+          backgroundColor: '#06c',
+          color: 'white',
+        }));
+        describe('focused', function() {
+          beforeEach(focusElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: '#004080',
+            color: 'white',
+          }));
+        });
+        describe('hovered', function() {
+          beforeEach(hoverElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: '#004080',
+            color: 'white',
+          }));
+        });
+      });
+      describe('variant="secondary"', function() {
+        beforeEach(contextFixture({ on, variant: 'secondary' }));
+        it('has correct theme values', () => assertStyles({
+          on,
+          backgroundColor: 'transparent',
+          color: '#73bcf7',
+        }));
+        describe('focused', function() {
+          beforeEach(focusElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: 'transparent',
+            color: '#73bcf7',
+          }));
+        });
+        describe('hovered', function() {
+          beforeEach(hoverElement);
+          it('has correct theme values', () => assertStyles({
+            backgroundColor: 'transparent',
+            color: '#73bcf7',
+          }));
+        });
+      });
+    });
   });
 });

--- a/elements/pfe-button/tsconfig.json
+++ b/elements/pfe-button/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "."
   },
   "references": [
+    { "path": "../pfe-band" },
     { "path": "../../core/pfe-core" },
     { "path": "../../tools/pfe-tools" }
   ]

--- a/elements/pfe-cta/pfe-cta.scss
+++ b/elements/pfe-cta/pfe-cta.scss
@@ -49,8 +49,8 @@
 // }
 
 :host(:not([aria-disabled="true"]):focus),
-:host(:not([aria-disabled="true"]).focus-within),
-:host(:not([aria-disabled="true"]).focus-within) ::slotted(*),
+:host(:not([aria-disabled="true"]):focus-within),
+:host(:not([aria-disabled="true"]):focus-within) ::slotted(*),
 :host(:not([aria-disabled="true"])) ::slotted(:focus) {
   outline: none !important;
 }
@@ -77,12 +77,6 @@
     :host(:not([priority]):not([aria-disabled="true"])) & {
       @include browser-query(firefox) {
         max-width: calc(100% - 1ch - #{pfe-local(size, $region: arrow)});
-      }
-    }
-    @include browser-query(edge) {
-      button,
-      input {
-        @extend %reset-button;
       }
     }
   }
@@ -219,8 +213,13 @@
 /// WIND CTA VARIANTS
 /// ===========================================================================
 
-:host([priority="secondary"][variant="wind"]) {
+:host([priority=secondary][variant=wind]) {
   @include pfe-print-local($secondary-wind);
+}
+
+:host([on=dark][priority=secondary][variant=wind][color-palette=base]),
+:host([on=saturated][priority=secondary][variant=wind][color-palette=base]) {
+  --pfe-cta--Color--focus: #ffffff;
 }
 
 // @TODO: Deprecated
@@ -238,7 +237,7 @@
 
 // Note: Focus states need to be defined before hover states
 :host(:not([aria-disabled="true"]):focus),
-:host(:not([aria-disabled="true"]).focus-within) {
+:host(:not([aria-disabled="true"]):focus-within) {
   --pfe-cta--BackgroundColor: #{pfe-local(BackgroundColor--focus)};
   --pfe-cta--BorderColor:     #{pfe-local(BorderColor--focus)};
   --pfe-cta--Color:           #{pfe-local(Color--focus)};

--- a/elements/pfe-cta/pfe-cta.ts
+++ b/elements/pfe-cta/pfe-cta.ts
@@ -208,26 +208,12 @@ export class PfeCta extends LitElement {
       this.data.type = 'disabled';
     }
 
-    // Watch the light DOM link for focus and blur events
-    this.cta.addEventListener('focus', this._focusHandler);
-    this.cta.addEventListener('blur', this._blurHandler);
-
     // Attach the click listener
     this.cta.addEventListener('click', this._clickHandler as EventListener);
     this.cta.addEventListener('keyup', this._keyupHandler);
 
     CONTENT.set(this.cta, true);
     this.initializing = false;
-  }
-
-  // On focus, add a focus class
-  @bound private _focusHandler() {
-    this.classList.add('focus-within');
-  }
-
-  // On focus out, remove the focus class
-  @bound private _blurHandler() {
-    this.classList.remove('focus-within');
   }
 
   // On enter press, trigger click event

--- a/tools/pfe-tools/test/create-fixture.ts
+++ b/tools/pfe-tools/test/create-fixture.ts
@@ -50,7 +50,7 @@ const helpers: Promise<TestHelpers> = new Promise(resolve => {
  * - If React is available the fixture will be wrapped in a React app.
  * - By default standard a fixture will be created using lit html.
  *
- * @param element The element code you'd like to generate a fixture for.
+ * @param code The element code you'd like to generate a fixture for.
  *
  * @returns  Returns the new web component fixture rendered and ready for tests.
  */
@@ -71,14 +71,13 @@ chai.use(function(_chai) {
     const message = msg ? `${msg} ` : '';
     this.assert(
       actualNormalized === expectNormalized,
-      `expected ${message}#{act} to be the same color as #{exp}`,
-      `expected ${message}#{act} to be a different color than #{exp}`,
+      `${message}#{act} (actual) should be the same color as #{exp} (expected)`,
+      `${message}#{act} (actual) should be a different color than #{exp} (expected)`,
       expectNormalized,
       actualNormalized
     );
   });
 });
-
 
 declare global {
   // That's just the way the chai boils


### PR DESCRIPTION
- Improves colour contrast for CTA in secondary+wind variant when focused on saturated contexts
- Improves colour contrast for button in secondary variant on saturated and dark contexts

### Related issues

Closes #1997 

### What has changed and why

<!-- Summarize files edited as part of this MR along with a brief description of what was changed/why. -->

- Use UI accent colour for button text on saturated and dark backgrounds
- Use white for CTA text when focused on saturated in secondary+wind variant

## Notes to reviewers:
For **button**, open [current](https://patternflyelements.org/components/button/demo) and [PR preview](https://deploy-preview-2014--patternfly-elements.netlify.app/components/button/demo) in separate tabs, and run this snippet in the browser dev tools console:

```js
document.querySelector("pfe-band:nth-of-type(2)").colorPalette = 'accent';
```

Before:
![Screenshot 2022-04-28 at 15-49-49 Button PatternFly Elements](https://user-images.githubusercontent.com/1466420/165755836-22acd313-8c27-48c7-9d11-f9c6b8c987ca.png)
After:
![Screenshot 2022-04-28 at 15-49-49 Button PatternFly Elements](https://user-images.githubusercontent.com/1466420/165756131-dc008979-f689-49d2-8ff3-1baf0a456a45.png)

For **CTA**, tab to the "Secondary + wind variant" on saturated context, with `color-palette="base"` (i.e. the middle card in that row)

Before:
![image](https://user-images.githubusercontent.com/1466420/165757076-ee7ff45e-3ef4-4432-88c7-c7f4ea915cc7.png)


After:
![image](https://user-images.githubusercontent.com/1466420/165757099-0de36490-6816-4d40-b8ce-e7ddc2536b48.png)




