### PR TITLE
feat(tools): use declarative shadow DOM for dev server

### DIFF
--- a/.changeset/fluffy-rockets-swim.md
+++ b/.changeset/fluffy-rockets-swim.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": major
+---
+
+Use declarative shadow DOM for dev server, remove SPA code, calculate demo variables on the server side

--- a/elements/pfe-card/pfe-card.ts
+++ b/elements/pfe-card/pfe-card.ts
@@ -123,7 +123,6 @@ export class PfeCard extends LitElement {
     };
 
     return html`
-      <!-- pfe-card -->
       <div class="pfe-card__header ${classMap(classes)}" part="header">
         <slot name="header"></slot>
         <slot name="pfe-card--header"></slot>

--- a/tools/pfe-tools/demo/demo.css
+++ b/tools/pfe-tools/demo/demo.css
@@ -3,6 +3,10 @@
   --pfe-demo-menu-width: 280px;
 }
 
+html[unresolved] {
+  opacity: 0;
+}
+
 body {
   display: contents !important;
 }

--- a/tools/pfe-tools/demo/demo.ts
+++ b/tools/pfe-tools/demo/demo.ts
@@ -1,164 +1,18 @@
-import type { HTMLIncludeElement } from 'html-include-element';
-
-document.documentElement.toggleAttribute('maximized', localStorage.getItem('pfe-demo-maximized') === 'true');
-
-import 'html-include-element';
 import 'api-viewer-element';
 import '@vaadin/split-layout';
 
-import { html, render } from 'lit';
-import { core, elements } from '@patternfly/pfe-tools/environment.js';
-import { URLPattern } from 'urlpattern-polyfill';
-import { installRouter } from 'pwa-helpers/router.js';
-
-const pattern = new URLPattern({ pathname: '/demo/:element/' });
 const include = document.querySelector<HTMLElement & { src?: string }>('html-include');
 const hamburger = document.getElementById('hamburger');
 const nav = document.getElementById('main-nav');
-const viewer = document.querySelector<HTMLElement & { src?: string }>('api-viewer');
-const github = document.getElementById('github-link') as HTMLAnchorElement;
 const form = document.querySelector<HTMLFormElement>('#component-header form');
 const context = document.getElementById('context-selector') as HTMLElement;
 const contextSelect = context.querySelector('select');
-const componentHeader = document.getElementById('component-header');
 
 const contextToColor = new Map(Object.entries({
   dark: 'darkest',
   saturated: 'accent',
   light: 'lightest',
 }));
-
-function pretty(tagName: string): string {
-  return tagName
-    .replace('pfe-', '')
-    .toLowerCase()
-    .replace(/(?:^|[\s-/])\w/g, x => x.toUpperCase())
-    .replace(/-/g, ' ');
-}
-
-/**
- * Load demo scripts and scroll to element with id in the URL hash.
- * @this {HTMLElement}
- */
-async function onLoad(element: string, base: 'core' | 'elements', location: Location) {
-  // not every demo has a script
-  // eslint-disable-next-line no-console
-  await import(`/${base}/${element}/demo/${element}.js`).catch(console.error.bind(console, element));
-  if (location.hash) {
-    include.shadowRoot?.querySelector(location.hash)?.scrollIntoView({ behavior: 'smooth' });
-  }
-  form.querySelector('fieldset').hidden = include.shadowRoot.querySelectorAll('.contextual').length < 1;
-  include.classList.remove('loading');
-  componentHeader.classList.remove('loading');
-  onContextChange();
-  window.removeEventListener('unhandledrejection', handleBadLoad);
-}
-
-/* eslint-disable no-console */
-/**
- * quick hack to avoid page load errors if subresources are missing from demo files
- * @see https://github.com/justinfagnani/html-include-element/pull/21
- */
-async function handleBadLoad() {
-  await loadPartial.call(document.querySelector('html-include'));
-}
-
-const isLinkAlreadyLoaded = (link: HTMLLinkElement) => {
-  try {
-    return !!(link.sheet && link.sheet.cssRules);
-  } catch (error) {
-    if (error.name === 'InvalidAccessError' || error.name === 'SecurityError') {
-      return false;
-    } else {
-      throw error;
-    }
-  }
-};
-
-const linkLoaded = async function linkLoaded(link: HTMLLinkElement) {
-  return new Promise((resolve, reject) => {
-    if (!('onload' in HTMLLinkElement.prototype)) {
-      resolve(null);
-    } else if (isLinkAlreadyLoaded(link)) {
-      resolve(link.sheet);
-    } else {
-      link.addEventListener('load', () => resolve(link.sheet), { once: true });
-      link.addEventListener('error', () => reject({ link }), { once: true });
-    }
-  });
-};
-
-async function loadPartial(this: HTMLIncludeElement) {
-  let text = '';
-  try {
-    const mode = this.mode || 'cors';
-    const response = await fetch(this.getAttribute('src'), { mode });
-    if (!response.ok) {
-      throw new Error(`html-include fetch failed: ${response.statusText}`);
-    }
-    text = await response.text();
-  } catch (e) {
-    console.error(e);
-  }
-  // Don't destroy the light DOM if we're using shadow DOM, so that slotted content is respected
-  if (this.noShadow) {
-    this.innerHTML = text;
-  }
-
-  this.shadowRoot.innerHTML = `
-    <style>
-      :host {
-        display: block;
-      }
-    </style>
-    ${this.noShadow ? '<slot></slot>' : text}
-  `;
-
-  // If we're not using shadow DOM, then the consuming root
-  // is responsible to load its own resources
-  if (!this.noShadow) {
-    const results = await Promise.allSettled([...this.shadowRoot.querySelectorAll('link')].map(linkLoaded));
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        const { link } = result.reason;
-        const message = `Could not load ${link.href}`;
-        console.error(message);
-      }
-    }
-  }
-
-  this.dispatchEvent(new Event('load'));
-}
-/* eslint-enable no-console */
-
-/** Load up the requested element's demo in a separate shadow root */
-async function go(location = window.location) {
-  const { element } = pattern.exec(location.href)?.pathname?.groups ?? {};
-
-  if (element) {
-    const base = element.match(/^pfe-(core|sass|styles)$/) ? 'core' : 'elements';
-    include.classList.add('loading');
-    componentHeader.classList.add('loading');
-    include.addEventListener('load', onLoad.bind(include, element, base, location), { once: true });
-    include.setAttribute('data-demo', element);
-
-    window.addEventListener('unhandledrejection', handleBadLoad, { once: true });
-
-    include.setAttribute('src', `/${base}/${element}/demo/${element}.html`);
-
-    viewer.src = `/${base}/${element}/custom-elements.json`;
-    viewer.hidden = false;
-    document.title = `${pretty(element)} | PatternFly Elements`;
-    document.querySelector('h1').textContent = `<${element}>`;
-    github.href = `https://github.com/patternfly/patternfly-elements/tree/main/${base}/${element}`;
-    toggleNav(false);
-  } else {
-    viewer.src = '';
-    viewer.hidden = true;
-    document.querySelector('h1').textContent = 'Select a demo from the Menu';
-    onMaximize(false);
-  }
-}
 
 /** Change the context of the accordions */
 function onContextChange() {
@@ -188,31 +42,25 @@ function onMaximize(force?: boolean) {
   localStorage.setItem('pfe-demo-maximized', document.documentElement.hasAttribute('maximized').toString());
 }
 
-const li = (element: string) => html`
-  <li class="site-navigation__item">
-    <a class="site-navigation__link" href="/demo/${element}/">${pretty(element)}</a>
-  </li>
-`;
-
-render([
-  ...core.map(li),
-  html`<li class="separator"></li>`,
-  ...elements.map(li),
-], document.getElementById('elements-container'));
-
-installRouter(go);
-
-go();
+function attachShadowRoots(root: Document | ShadowRoot) {
+  root.querySelectorAll('template[shadowroot]').forEach((template: HTMLTemplateElement) => {
+    const mode = template.getAttribute('shadowroot') as 'open';
+    const shadowRoot: ShadowRoot = (template.parentNode as HTMLElement).attachShadow({ mode });
+    shadowRoot.appendChild(template.content);
+    template.remove();
+    attachShadowRoots(shadowRoot);
+  });
+}
 
 form.addEventListener('submit', e => e.preventDefault());
 form.querySelector('button').addEventListener('click', () => onMaximize());
 
 context.addEventListener('select', onContextChange);
 hamburger.addEventListener('click', toggleNav);
+
 document.addEventListener('click', event => {
   if (hamburger.getAttribute('aria-expanded') === 'true') {
     const path = event.composedPath();
-
     if (!path.includes(nav) && !path.includes(hamburger)) {
       event.preventDefault();
       event.stopPropagation();
@@ -231,3 +79,7 @@ nav.addEventListener('keydown', event => {
     }
   }
 });
+
+attachShadowRoots(document);
+document.documentElement.toggleAttribute('maximized', localStorage.getItem('pfe-demo-maximized') === 'true');
+document.documentElement.removeAttribute('unresolved');

--- a/tools/pfe-tools/demo/index.njk
+++ b/tools/pfe-tools/demo/index.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" unresolved>
 
 <head>
   <meta charset="utf-8">
@@ -14,13 +14,15 @@
   <link rel="stylesheet" href="/node_modules/@patternfly/pfe-tools/demo/demo.css">
   <link rel="stylesheet" href="/docs/main.css">
   <script type="module" src="/node_modules/@patternfly/pfe-tools/demo/demo.ts"></script>
+  <script type="module">{{ script | safe }}
+</script>
 </head>
 
 <body>
   <header class="logo-bar">
     <button id="hamburger" aria-label="Expand Main Navigation">&#9776;</button>
     <a href="/"><img src="{{ logoUrl }}" alt="" />{{ title }}</a>
-    <a id="github-link" href="{{ githubUrl }}">
+      <a id="github-link" href="{{ githubUrl }}tree/main/{{ base }}/{{ element }}">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512">
         <title>GitHub</title>
         <!-- Font Awesome Free 5.15.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
@@ -32,13 +34,17 @@
   <aside id="main-nav">
     <nav class="site-navigation" aria-label="Main Navigation">
       <ul id="elements-container" class="site-navigation__wrapper">
+        {% for element in elements %}
+          <li class="site-navigation__item">
+            <a class="site-navigation__link" href="/demo/{{ element }}/">{{ element | prettyTag }}</a>
+          </li>
+        {% endfor %}
       </ul>
     </nav>
   </aside>
   <main>
     <pfe-band id="component-header" color-palette="base" size="small" full-width>
-      <h1 slot="header">Select a Demo from the Menu</h1>
-
+      <h1 slot="header">{{ ('<' + element + '>') if element else 'Select a Demo from the Menu' }}</h1>
       <form slot="header">
         <fieldset hidden>
           <label for="theme-select">Select a context</label>
@@ -53,7 +59,7 @@
           </pfe-select>
         </fieldset>
         <fieldset>
-          <button id="toggle-max" aria-label="toggle maximize">
+          <button id="toggle-max" aria-label="toggle maximize" {{ 'hidden' if context.path == '/' }}>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384.97 384.97" style="enable-background:new 0 0 384.97 384.97" xml:space="preserve"><path d="M384.97 12.03c0-6.713-5.317-12.03-12.03-12.03H264.847c-6.833 0-11.922 5.39-11.934 12.223 0 6.821 5.101 11.838 11.934 11.838h96.062l-.193 96.519c0 6.833 5.197 12.03 12.03 12.03 6.833-.012 12.03-5.197 12.03-12.03l.193-108.369c0-.036-.012-.06-.012-.084.001-.037.013-.061.013-.097zM120.496 0H12.403c-.036 0-.06.012-.096.012-.024 0-.06-.012-.084-.012C5.51 0 .192 5.317.192 12.03L0 120.399c0 6.833 5.39 11.934 12.223 11.934 6.821 0 11.838-5.101 11.838-11.934l.192-96.339h96.242c6.833 0 12.03-5.197 12.03-12.03C132.514 5.197 127.317 0 120.496 0zM120.123 360.909H24.061v-96.242c0-6.833-5.197-12.03-12.03-12.03S0 257.833 0 264.667v108.092c0 .036.012.06.012.084 0 .036-.012.06-.012.096 0 6.713 5.317 12.03 12.03 12.03h108.092c6.833 0 11.922-5.39 11.934-12.223.001-6.82-5.1-11.837-11.933-11.837zM372.747 252.913c-6.833 0-11.85 5.101-11.838 11.934v96.062h-96.242c-6.833 0-12.03 5.197-12.03 12.03s5.197 12.03 12.03 12.03h108.092c.036 0 .06-.012.084-.012.036-.012.06.012.096.012 6.713 0 12.03-5.317 12.03-12.03V264.847c.001-6.833-5.389-11.934-12.222-11.934z"/></svg>
             <svg hidden xmlns="http://www.w3.org/2000/svg" viewBox="0 0 385.331 385.331" style="enable-background:new 0 0 385.331 385.331" xml:space="preserve"><path d="M264.943 156.665h108.273c6.833 0 11.934-5.39 11.934-12.211 0-6.833-5.101-11.85-11.934-11.838h-96.242V36.181c0-6.833-5.197-12.03-12.03-12.03s-12.03 5.197-12.03 12.03v108.273c0 .036.012.06.012.084 0 .036-.012.06-.012.096-.001 6.713 5.316 12.043 12.029 12.031zM120.291 24.247c-6.821 0-11.838 5.113-11.838 11.934v96.242H12.03c-6.833 0-12.03 5.197-12.03 12.03 0 6.833 5.197 12.03 12.03 12.03h108.273c.036 0 .06-.012.084-.012.036 0 .06.012.096.012 6.713 0 12.03-5.317 12.03-12.03V36.181c.001-6.821-5.389-11.922-12.222-11.934zM120.387 228.666H12.115c-6.833.012-11.934 5.39-11.934 12.223 0 6.833 5.101 11.85 11.934 11.838h96.242v96.423c0 6.833 5.197 12.03 12.03 12.03 6.833 0 12.03-5.197 12.03-12.03V240.877c0-.036-.012-.06-.012-.084 0-.036.012-.06.012-.096.001-6.714-5.317-12.031-12.03-12.031zM373.3 228.666H265.028c-.036 0-.06.012-.084.012-.036 0-.06-.012-.096-.012-6.713 0-12.03 5.317-12.03 12.03v108.273c0 6.833 5.39 11.922 12.223 11.934 6.821.012 11.838-5.101 11.838-11.922v-96.242H373.3c6.833 0 12.03-5.197 12.03-12.03s-5.196-12.031-12.03-12.043z"/></svg>
           </button>
@@ -62,8 +68,10 @@
     </pfe-band>
 
     <vaadin-split-layout orientation="vertical">
-      <html-include delegates-focus></html-include>
-      <api-viewer hidden></api-viewer>
+      <div data-demo="{{ element }}">
+        <template shadowroot="open" data-demo="{{ element }}">{{ demo | safe }}</template>
+      </div>
+      <api-viewer src="{{ manifest }}" only="{{ element }}"></api-viewer>
     </vaadin-split-layout>
   </main>
 </body>

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -18,6 +18,9 @@ import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
 import { transformSass } from './esbuild.js';
 import { createRequire } from 'module';
+import { promisify } from 'util';
+import _glob from 'glob';
+const glob = promisify(_glob);
 
 export interface PfeDevServerConfigOptions extends DevServerConfig {
   /** Extra dev server plugins */
@@ -225,6 +228,16 @@ export function pfeDevServerConfig(_options?: PfeDevServerConfigOptions): DevSer
 
       // Ensure .scss files are loaded as js modules, as `litcss` plugin transforms them to such
       scssMimeType(),
+
+      {
+        name: 'watch-repo-files',
+        async serverStart({ fileWatcher }) {
+          const files = await glob('{elements,core}/**/*.{ts,js,css,scss,html}', { cwd: process.cwd() });
+          for (const file of files) {
+            fileWatcher.add(file);
+          }
+        },
+      },
     ],
   };
 }

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -241,5 +241,3 @@ export function pfeDevServerConfig(_options?: PfeDevServerConfigOptions): DevSer
     ],
   };
 }
-env.addFilter('prettyTag', prettyTag);
-

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -50,7 +50,7 @@ const exists = (x: string) => stat(x).then(() => true, () => false);
 const litcss = fromRollup(litcssRollup);
 const replace = fromRollup(rollupReplace);
 /** Prettify a tag name, stripping the prefix and capitalizing the rest */
-function prettyTag(tagName: string, prefix: PfeDevServerConfigOptions['site']['tagPrefix'] = 'pfe-'): string {
+function prettyTag(tagName: string, prefix: `${string}-` = 'pfe-'): string {
   return tagName
     .replace(prefix, '')
     .toLowerCase()


### PR DESCRIPTION
### What I Did

<!-- Summarize files edited as part of this MR along with a brief description of what was changed/why. -->

Rewrite dev server to use declarative shadow DOM and to be an MPA.

##### Dev Server:
- remove SPA code from demo.ts
- calculate server-side variables in the dev-server
- inject demo markup into a declarative shadow dom template
- inject demo script into the `<head>`
- add declarative shadow DOM polyfill for FF and Safari


### Testing instructions

<!-- Be sure to include detailed instructions on how your update can be tested by another developer. -->

- `npm start`

Closes #2008 
