### PR TITLE
feat(tools): single file build entrypoints

### DIFF
--- a/.changeset/calm-items-cover.md
+++ b/.changeset/calm-items-cover.md
@@ -1,0 +1,36 @@
+---
+"@patternfly/pfe-tools": minor
+---
+
+`singleFileBuild` now scans `node_modules` for installed
+`@patternfly/pfe-*` packages (except `core`, `tools`, `sass`, and
+`styles`) and generates an entrypoint file for them.
+
+Users can alternatively pass `componentsEntryPointsContent`, which is
+the string contents of a javascript module that exports the desired
+components.
+
+These changes make using `singleFileBuild` more useful and ergonomic for
+daughter repositories (e.g. RHDS)
+
+```js
+const elements = await readdir(new URL("../elements", import.meta.url));
+
+/**
+ * @example
+ * export * from '/path/to/redhat-ux/red-hat-design-system/elements/rh-alert/rh-alert.js';
+ * export * from '/path/to/redhat-ux/red-hat-design-system/elements/rh-table/rh-table.js';
+ */
+const componentsEntryPointContents = elements.reduce(
+  (acc, x) => `${acc}
+export * from '${fileURLToPath(
+    new URL(`../elements/${x}/${x}.js`, import.meta.url)
+  )}';`,
+  ""
+);
+
+await singleFileBuild({
+  componentsEntryPointContents,
+  outfile: "rhds.min.js"
+});
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
     },
     "core/pfe-core": {
       "name": "@patternfly/pfe-core",
-      "version": "2.0.0-next.4",
+      "version": "2.0.0-next.5",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.1.2"
@@ -123,7 +123,7 @@
     },
     "elements/pfe-card": {
       "name": "@patternfly/pfe-card",
-      "version": "2.0.0-next.3",
+      "version": "2.0.0-next.4",
       "license": "MIT",
       "dependencies": {
         "@patternfly/pfe-core": "^2.0.0-next.4",
@@ -160,10 +160,10 @@
     },
     "elements/pfe-cta": {
       "name": "@patternfly/pfe-cta",
-      "version": "2.0.0-next.3",
+      "version": "2.0.0-next.4",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-next.4",
+        "@patternfly/pfe-core": "^2.0.0-next.5",
         "lit": "^2.1.2"
       }
     },
@@ -10400,7 +10400,8 @@
     },
     "node_modules/execa": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -24126,7 +24127,7 @@
     },
     "tools/create-element": {
       "name": "@patternfly/create-element",
-      "version": "1.0.0-next.9",
+      "version": "1.0.0-next.10",
       "license": "MIT",
       "dependencies": {
         "case": "^1.6.3",
@@ -24153,7 +24154,7 @@
     },
     "tools/eslint-config": {
       "name": "@patternfly/eslint-config-elements",
-      "version": "0.0.2-next.2",
+      "version": "0.0.2-next.3",
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "^8.4.1",
@@ -24177,7 +24178,7 @@
     },
     "tools/pfe-tools": {
       "name": "@patternfly/pfe-tools",
-      "version": "1.0.0-next.17",
+      "version": "1.0.0-next.19",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^1.0.1",
@@ -24226,6 +24227,7 @@
         "esbuild-plugin-lit-css": "^2.0.0",
         "esbuild-plugin-minify-html-literals": "^1.0.1",
         "eslint": "^8.14.0",
+        "execa": "^6.1.0",
         "glob": "^8.0.1",
         "html-include-element": "^0.3.0",
         "koa-send": "^5.0.1",
@@ -27460,7 +27462,7 @@
     "@patternfly/pfe-cta": {
       "version": "file:elements/pfe-cta",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-next.4",
+        "@patternfly/pfe-core": "^2.0.0-next.5",
         "lit": "^2.1.2"
       }
     },
@@ -27656,6 +27658,7 @@
         "esbuild-plugin-lit-css": "^2.0.0",
         "esbuild-plugin-minify-html-literals": "^1.0.1",
         "eslint": "^8.14.0",
+        "execa": "*",
         "glob": "^8.0.1",
         "html-include-element": "^0.3.0",
         "koa-send": "^5.0.1",
@@ -31523,6 +31526,8 @@
     },
     "execa": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
       "requires": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",

--- a/tools/pfe-tools/11ty/plugins/pfe-assets.cjs
+++ b/tools/pfe-tools/11ty/plugins/pfe-assets.cjs
@@ -60,7 +60,6 @@ async function bundle(options) {
       additionalPackages: options?.additionalPackages,
       minify: process.env.NODE_ENV === 'production' || process.env.ELEVENTY_ENV?.startsWith?.('prod'),
       outfile: 'docs/pfe.min.js',
-      conditions: ['esbuild'],
       plugins: [
         pfeEnvPlugin(),
       ]

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -107,6 +107,7 @@
     "esbuild-plugin-lit-css": "^2.0.0",
     "esbuild-plugin-minify-html-literals": "^1.0.1",
     "eslint": "^8.14.0",
+    "execa": "^6.1.0",
     "glob": "^8.0.1",
     "html-include-element": "^0.3.0",
     "koa-send": "^5.0.1",


### PR DESCRIPTION
## What I did

Added some new APIs for `@patternfly/pfe-tools/esbuild.js` to facilitate building daughter single-package repos (i.e. RHDS)

`singleFileBuild` now scans `node_modules` for installed
`@patternfly/pfe-*` packages (except `core`, `tools`, `sass`, and
`styles`) and generates an entrypoint file for them.

Users can alternatively pass `componentsEntryPointsContent`, which is
the string contents of a javascript module that exports the desired
components.

These changes make using `singleFileBuild` more useful and ergonomic for
daughter repositories (e.g. RHDS)

## Testing Instructions
1. `npm run build` <- verify that the minified bundle is good by inspecting the built docs site (can verify this in the deploy preview)
2. patch this version into RHDS (on footer branch) and verify that the 11ty site builds and that the generated `rhds.min.js` in works