### PR TITLE
feat(modal): PF1:1

### DIFF
--- a/.changeset/pfe-modal-pfv4-feats.md
+++ b/.changeset/pfe-modal-pfv4-feats.md
@@ -1,0 +1,12 @@
+---
+"@patternfly/pfe-modal": minor
+---
+
+Several new features align `<pfe-modal>` to PatternFly v4.
+
+Added `header` and `footer` CSS Shadow parts
+Added PF4 CSS Custom Properties
+Added `position="top"` attribute
+Added `description` slot
+
+See the [docs](https://patternflyelements.org/components/modal) for more info

--- a/.changeset/pfe-modal-pfv4.md
+++ b/.changeset/pfe-modal-pfv4.md
@@ -2,12 +2,19 @@
 "@patternfly/pfe-modal": major
 ---
 
-Align to PatternFly v4.
+Several changes align `<pfe-modal>` to PatternFly v4.
 
-- deprecate the `width` attribute in favour of `variant`
-- implement many `--pf-` css variables
-- add `renderHeaderSlot`, `renderDescriptionSlot`, `renderContentSlot`, and `renderFooterSlot` optional override methods
-- remove _all_ `--pfe-` css variables.
-  If you were relying on any of the (previously undocumented) `--pfe` variables,
-  please use their `--pf` equivalents.
-  See the [docs](https://patternflyelements.org/components/modal) for more info
+The `pfelement` attribute and `PFElement` class are **removed** from the `<pfe-modal>` element by default
+The `width` attribute is **deprecated** in favour of `variant`.
+_All_ the `--pfe-*` css variables are **removed** in favour of their `--pf-*` equivalents.
+The `trigger` slot is **removed**. Use the `trigger` attribute instead, or the `setTrigger`, `toggle`, or `showModal` methods.
+   ```diff
+   - <pfe-modal>
+   -   <pfe-button slot="trigger"><button>Open Modal</button></pfe-button>
+   + <pfe-modal trigger="trigger-modal">
+   +   <pfe-button slot="trigger"><button>Open Modal</button></pfe-button>
+     </pfe-modal>
+   + <pfe-button id="trigger-modal"><button>Open Modal</button></pfe-button>
+   ```
+
+See the [docs](https://patternflyelements.org/components/modal) for more info

--- a/.changeset/pfe-modal-pfv4.md
+++ b/.changeset/pfe-modal-pfv4.md
@@ -10,10 +10,11 @@ _All_ the `--pfe-*` css variables are **removed** in favour of their `--pf-*` eq
 The `trigger` slot is **removed**. Use the `trigger` attribute instead, or the `setTrigger`, `toggle`, or `showModal` methods.
    ```diff
    - <pfe-modal>
-   -   <pfe-button slot="trigger"><button>Open Modal</button></pfe-button>
    + <pfe-modal trigger="trigger-modal">
-   +   <pfe-button slot="trigger"><button>Open Modal</button></pfe-button>
+   -   <pfe-button slot="trigger"><button>Open Modal</button></pfe-button>
+       Modals can have content
      </pfe-modal>
+     Arbitrary content can intervene between modals and their triggers
    + <pfe-button id="trigger-modal"><button>Open Modal</button></pfe-button>
    ```
 

--- a/.changeset/pfe-modal-pfv4.md
+++ b/.changeset/pfe-modal-pfv4.md
@@ -1,0 +1,12 @@
+---
+"@patternfly/pfe-modal": major
+---
+
+Align to PatternFly v4.
+
+- deprecate the `width` attribute in favour of `variant`
+- implement many `--pf-` css variables
+- remove _all_ `--pfe-` css variables.
+  If you were relying on any of the (previously undocumented) `--pfe` variables,
+  please use their `--pf` equivalents.
+  See the [docs](https://patternflyelements.org/components/modal) for more info

--- a/.changeset/pfe-modal-pfv4.md
+++ b/.changeset/pfe-modal-pfv4.md
@@ -6,6 +6,7 @@ Align to PatternFly v4.
 
 - deprecate the `width` attribute in favour of `variant`
 - implement many `--pf-` css variables
+- add `renderHeaderSlot`, `renderDescriptionSlot`, `renderContentSlot`, and `renderFooterSlot` optional override methods
 - remove _all_ `--pfe-` css variables.
   If you were relying on any of the (previously undocumented) `--pfe` variables,
   please use their `--pf` equivalents.

--- a/.changeset/pfe-modal-pfv4.md
+++ b/.changeset/pfe-modal-pfv4.md
@@ -4,7 +4,7 @@
 
 Several changes align `<pfe-modal>` to PatternFly v4.
 
-The `pfelement` attribute and `PFElement` class are **removed** from the `<pfe-modal>` element by default
+The `pfelement` attribute and `PFElement` class are **removed** from the `<pfe-modal>` element by default.
 The `width` attribute is **deprecated** in favour of `variant`.
 _All_ the `--pfe-*` css variables are **removed** in favour of their `--pf-*` equivalents.
 The `trigger` slot is **removed**. Use the `trigger` attribute instead, or the `setTrigger`, `toggle`, or `showModal` methods.

--- a/.changeset/pink-news-fail.md
+++ b/.changeset/pink-news-fail.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Remove pfe-specific styles from demo pages

--- a/docs/main.css
+++ b/docs/main.css
@@ -33,19 +33,17 @@ summary :is(h1,h2,h3,h4,h5,h6) {
   display: inline-block;
 }
 
-h1,
-h2,
-h3,
+:is(h1, h2, h3):not([slot]),
 p.subtitle {
   font-weight: 400;
   font-family: 'Red Hat Display', sans-serif;
 }
 
-h1 {
+h1:not([slot]) {
   font-size: 2rem;
 }
 
-h3,
+h3:not([slot]),
 p.subtitle {
   margin-top: 0.83em;
   font-weight: 500;
@@ -63,28 +61,28 @@ pfe-band.header h1 {
   margin: 0;
 }
 
-pfe-band h2[id]:not(.no-header-styles) {
+pfe-band > h2[id]:not(.no-header-styles) {
   font-size: 1.5rem;
   line-height: 1.9375rem;
   font-weight: bold;
   margin-top: 2em;
 }
 
-pfe-band h3[id] {
+pfe-band > h3[id] {
   font-size: 1.3rem;
   font-weight: bold;
   margin-top: 2em;
 }
 
-pfe-band h2 + h3[id],
-pfe-band p + h3[id] {
+pfe-band > h2 + h3[id],
+pfe-band > p + h3[id] {
   margin-top: 0;
 }
 
-pfe-band h1+p,
-pfe-band h2+p,
-pfe-band h3+p,
-pfe-band h4+p {
+pfe-band > h1+p,
+pfe-band > h2+p,
+pfe-band > h3+p,
+pfe-band > h4+p {
   margin-top: 0;
 }
 
@@ -642,7 +640,7 @@ nav.toc li {
 }
 
 @media (min-width: 1200px) {
-  pfe-band h2[id]:not(.no-header-styles) {
+  pfe-band > h2[id]:not(.no-header-styles) {
     font-size: 2rem;
     line-height: 2.3125rem;
   }

--- a/elements/pfe-modal/README.md
+++ b/elements/pfe-modal/README.md
@@ -26,41 +26,42 @@ import '@patternfly/pfe-modal';
 
 ## Usage
 
+Open a modal dialog with the `showModal()` method, or by setting the `open` boolean attribute.
+
+```html
+<pfe-modal>
+  <h2 slot="header">Modal with a header</h2>
+  <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  <pfe-cta slot="footer">
+    <a href="#bar">Learn more</a>
+  </pfe-cta>
+</pfe-modal>
+
+<script>
+document.querySelector('pfe-modal').showModal();
+</script>
+```
+
 ### With a trigger
+
+You may assign a button-like trigger element to the modal by setting the modal element's `trigger` attribute to the trigger's ID.
+
 ```html
-<pfe-modal>
-  <button slot="trigger">Open modal</button>
+<pfe-modal trigger="trigger-button">
   <h2 slot="header">Modal with a header</h2>
   <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-  <pfe-cta>
+  <pfe-cta slot="footer">
     <a href="#bar">Learn more</a>
   </pfe-cta>
 </pfe-modal>
+
+<button id="trigger-button">Open modal</button>
 ```
 
-### Without a trigger
-```html
-<pfe-modal>
-  <h2 slot="header">Modal with a header</h2>
-  <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-  <pfe-cta>
-    <a href="#bar">Learn more</a>
-  </pfe-cta>
-</pfe-modal>
-```
-
-### With a separate trigger
-```html
-<pfe-button>
-  <button id="modal-trigger">Open modal</button>
-</pfe-button>
-
-<pfe-modal trigger="modal-trigger">
-  <h2 slot="header">Modal with a header</h2>
-  <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-  <pfe-cta>
-    <a href="#bar">Learn more</a>
-  </pfe-cta>
-</pfe-modal>
+You may also imperatively set the trigger element with the `setTrigger()` method:
+```js
+const modal = document.querySelector('pfe-modal');
+const trigger = document.querySelector('button#my-trigger');
+modal.setTrigger(trigger);
 ```
 

--- a/elements/pfe-modal/demo/demo.css
+++ b/elements/pfe-modal/demo/demo.css
@@ -1,3 +1,25 @@
+@font-face {
+  font-family: "RedHatDisplayUpdated";
+  src: url(https://patternfly.org/v4/fonts/RedHatDisplay-updated-Regular.woff2) format("woff2");
+  font-style: normal;
+  font-weight: 300;
+  text-rendering: optimizeLegibility;
+}
+@font-face {
+  font-family: "RedHatDisplayUpdated";
+  src: url(https://patternfly.org/v4/fonts/RedHatDisplay-updated-Medium.woff2) format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+@font-face {
+  font-family: "RedHatDisplayUpdated";
+  src: url(https://patternfly.org/v4/fonts/RedHatDisplay-updated-Bold.woff2) format("woff2");
+  font-style: normal;
+  font-weight: 700;
+  text-rendering: optimizeLegibility;
+}
+
 :host {
   --pfe-modal--MinWidth: 800px;
   --pfe-modal--MaxWidth: 800px;

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -157,8 +157,8 @@
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
-  <h2 slot="header">pfe-modal-width CSS Custom Property</h2>
-  <pfe-modal style="--pfe-modal-width: 50%">
+  <h2 slot="header"><code>--pf-c-modal-box--Width</code> CSS Custom Property</h2>
+  <pfe-modal style="--pf-c-modal-box--Width: 50%">
     <h2 slot="header">Width 50% header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -7,7 +7,7 @@
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Basic</h2>
-  <pfe-modal>
+  <pfe-modal trigger="simple-modal-header-trigger">
     <h2 slot="header">Simple modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -20,16 +20,16 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="simple-modal-header-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">With description</h2>
-  <pfe-modal>
-    <h2 slot="header">Simple modal header</h2>
+  <pfe-modal trigger="with-description-trigger">
+    <h2 slot="header">Modal with description</h2>
     <p slot="description">A description is used when you want to provide more info about the modal than the title is
       able to describe. The content in the description is static and will not scroll with the rest of the modal body.
     </p>
@@ -66,15 +66,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="with-description-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Top aligned</h2>
-  <pfe-modal position="top">
+  <pfe-modal position="top" trigger="top-aligned-trigger">
     <h2 slot="header">Top modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -87,15 +87,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="top-aligned-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Small</h2>
-  <pfe-modal variant="small">
+  <pfe-modal variant="small" trigger="small-header-trigger">
     <h2 slot="header">Small modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -108,15 +108,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="small-header-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Medium</h2>
-  <pfe-modal variant="medium">
+  <pfe-modal variant="medium" trigger="medium-header-trigger">
     <h2 slot="header">Medium modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -129,15 +129,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="medium-header-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Large</h2>
-  <pfe-modal variant="large">
+  <pfe-modal variant="large" id="large-modal-header">
     <h2 slot="header">Large modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -150,15 +150,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="large-modal-header" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header"><code>--pf-c-modal-box--Width</code> CSS Custom Property</h2>
-  <pfe-modal style="--pf-c-modal-box--Width: 50%">
+  <pfe-modal trigger="width-50-trigger" style="--pf-c-modal-box--Width: 50%">
     <h2 slot="header">Width 50% header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -171,15 +171,15 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="width-50-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Custom header and footer</h2>
-  <pfe-modal aria-describedby="custom-modal-description">
+  <pfe-modal trigger="custom-header-footer-trigger" aria-describedby="custom-modal-description">
     <h2 slot="header">With custom header/footer content.</h2>
     <p slot="header">Allows for custom content in the header and/or footer by slotting HTML.</p>
     <p slot="header" id="custom-modal-description">When static text describing the modal is available, it can be wrapped
@@ -192,27 +192,27 @@
       <pfe-icon icon="web-icon-alert-warning" size="1x"></pfe-icon>
       Custom modal footer.
     </h4>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="custom-header-footer-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">No header</h2>
-  <pfe-modal aria-describedby="custom-modal-description">
+  <pfe-modal trigger="no-header-trigger" aria-describedby="custom-modal-description">
     <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
       aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
       occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="no-header-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Custom icon</h2>
-  <pfe-modal aria-describedby="custom-modal-description">
+  <pfe-modal trigger="custom-icons-trigger" aria-describedby="custom-modal-description">
     <h2 slot="header">
       <pfe-icon role="presentation" icon="rh-icon-megaphone" size="1x"></pfe-icon>
       Modal Header
@@ -220,15 +220,15 @@
     <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
       aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
       occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="custom-icons-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Warning alert</h2>
-  <pfe-modal aria-describedby="custom-modal-description">
+  <pfe-modal trigger="warning-alert-trigger" aria-describedby="custom-modal-description">
     <h2 slot="header">
       <pfe-icon role="presentation" icon="web-icon-alert-warning" color="moderate" size="1x"></pfe-icon>
       Modal Header
@@ -236,10 +236,10 @@
     <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
       aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
       occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="warning-alert-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <!-- TODO: wizard -->
@@ -252,7 +252,7 @@
   <h2 slot="header">With overflowing content</h2>
   <p>If the content that you're passing to the modal is likely to overflow the modal content area, it is still
     accessible via keyboard scrolling.</p>
-  <pfe-modal>
+  <pfe-modal trigger="overflowing-content-trigger">
     <h2 slot="header">Modal with overflowing content</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -287,10 +287,10 @@
     <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
-    <pfe-button slot="trigger">
-      <button>Show modal</button>
-    </pfe-button>
   </pfe-modal>
+  <pfe-button id="overflowing-content-trigger" slot="footer">
+    <button>Show modal</button>
+  </pfe-button>
 </pfe-band>
 
 <pfe-band color-palette="lightest" size="small">

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -5,21 +5,70 @@
 <link rel="stylesheet" href="/core/pfe-styles/pfe-layouts.css">
 <link rel="stylesheet" href="/elements/pfe-modal/demo/demo.css">
 
-<pfe-band color-palette="lightest">
-  <h2 slot="header">Modal: Standard modal</h2>
+<pfe-band color-palette="lightest" size="smallest">
+  <h2 slot="header">Basic</h2>
   <pfe-modal>
-    <pfe-cta slot="trigger">
-      <button id="first-modal">Open modal</button>
-    </pfe-cta>
-    <h2 slot="header">Modal with a header</h2>
+    <h2 slot="header">Simple modal header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
       ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-cta>
-      <a href="#bar">Learn more</a>
-    </pfe-cta>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
+<pfe-band color-palette="lightest" size="smallest">
+  <h2 slot="header">With description</h2>
+  <pfe-modal>
+    <h2 slot="header">Simple modal header</h2>
+    <p slot="description">A description is used when you want to provide more info about the modal than the title is
+      able to describe. The content in the description is static and will not scroll with the rest of the modal body.
+    </p>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <p>Nullam dapibus, leo quis suscipit semper, nisi sapien ultricies turpis, ac tincidunt ipsum risus in nibh. Ut
+      consequat dolor risus. Vivamus ultricies lacinia ipsum, mattis egestas nisi scelerisque sit amet. Fusce eleifend,
+      sapien vel tempor convallis, magna nisl dapibus tortor, vel lobortis metus turpis vel odio. Suspendisse pharetra
+      ex nec volutpat tristique. Cras posuere et augue id maximus. Duis lobortis rutrum luctus. Integer cursus odio ac
+      enim vehicula sollicitudin. Morbi feugiat urna nulla, vel molestie enim tempus et. Fusce pellentesque ligula a
+      nibh viverra mattis. Vestibulum tincidunt diam quis enim feugiat finibus in eu felis. Morbi ac fringilla ligula.
+      Praesent nec ex nec sapien laoreet suscipit. Nullam sit amet tempor metus, a consequat purus. Pellentesque non
+      maximus nulla, tempus accumsan enim.</p>
+    <p>Etiam semper metus sed urna blandit lacinia. Maecenas nibh nisl, pharetra elementum enim sed, porta vehicula
+      felis. Donec at ante consequat, aliquet urna vitae, imperdiet urna. Nam vel molestie nibh, quis ornare arcu. Donec
+      faucibus enim id accumsan laoreet. Sed laoreet leo id eleifend sagittis. Praesent eget lacinia lectus, sit amet
+      cursus eros. Aenean et augue risus.</p>
+    <p>Aliquam erat volutpat. Integer nisi justo, molestie a dolor ut, ultricies efficitur est. Lorem ipsum dolor sit
+      amet, consectetur adipiscing elit. In et diam dignissim, aliquet odio quis, efficitur erat. Integer cursus
+      convallis ligula, dapibus elementum sem. Mauris blandit vitae risus id pharetra. Donec et diam eros.</p>
+    <p>Curabitur urna est, mollis vitae leo nec, vehicula pharetra dui. Mauris non est viverra, semper lacus in,
+      sollicitudin est. Fusce pharetra neque vel orci congue dignissim. Curabitur ac sem viverra, molestie mauris ac,
+      egestas tortor. Aenean ut aliquet ligula, id gravida metus. Sed semper et quam et sagittis. Pellentesque egestas
+      magna id eros interdum facilisis. Nam dignissim ante quis augue finibus tristique. Donec at augue sem. Nulla
+      mollis risus at ligula finibus, vitae volutpat ex auctor. Morbi vel cursus felis. Maecenas lobortis porttitor
+      odio, non venenatis risus varius vitae. Proin gravida mi odio, sed pretium neque luctus vitae. Mauris ut libero
+      bibendum, finibus dui non, rutrum sapien. Quisque ac bibendum erat. Vestibulum tincidunt risus nisi.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
   </pfe-modal>
 </pfe-band>
 
@@ -27,7 +76,7 @@
   <h2 slot="header">Modal: No header region</h2>
   <pfe-modal>
     <pfe-cta priority="secondary" slot="trigger">
-      <button>Open modal</button>
+      <button>Show modal</button>
     </pfe-cta>
     <h3>This has no header region</h3>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -45,7 +94,7 @@
   <h2>Modal: No headings</h2>
   <pfe-modal>
     <pfe-cta priority="secondary" slot="trigger">
-      <button>Open modal</button>
+      <button>Show modal</button>
     </pfe-cta>
     <p>This modal doesn't have any headings. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
@@ -94,7 +143,7 @@
   <pfe-card color-palette="complement">
     <h2 slot="header">Modal: a lot of content</h2>
     <pfe-modal color-palette="darkest" id="testit">
-      <pfe-cta slot="trigger"><button>Open modal</button></pfe-cta>
+      <pfe-cta slot="trigger"><button>Show modal</button></pfe-cta>
       <h2 slot="header">Modal with a header with a super duper long title and a lot of content</h2>
       <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor
         incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -292,3 +292,29 @@
     </pfe-button>
   </pfe-modal>
 </pfe-band>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">External trigger</h2>
+  <p>You may set an external button as the trigger by setting its' ID as the modal's <code>trigger</code> attribute.</p>
+  <pfe-modal trigger="external-trigger">
+    <h2 slot="header">External trigger</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button slot="footer">
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary" slot="footer">
+      <button>Cancel</button>
+    </pfe-button>
+  </pfe-modal>
+
+  <p>Arbitrary content can intervene between the external trigger and the modal element, as long as they are within the
+    same root.</p>
+
+  <pfe-button id="external-trigger">
+    <button>Show modal with external trigger</button>
+  </pfe-button>
+</pfe-band>

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -72,6 +72,27 @@
   </pfe-modal>
 </pfe-band>
 
+<pfe-band color-palette="lightest" size="smallest">
+  <h2 slot="header">Top aligned</h2>
+  <pfe-modal position="top">
+    <h2 slot="header">Top modal header</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
 <pfe-band color-palette="darkest" id="test-dark">
   <h2 slot="header">Modal: No header region</h2>
   <pfe-modal>

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -14,10 +14,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -60,10 +60,10 @@
       mollis risus at ligula finibus, vitae volutpat ex auctor. Morbi vel cursus felis. Maecenas lobortis porttitor
       odio, non venenatis risus varius vitae. Proin gravida mi odio, sed pretium neque luctus vitae. Mauris ut libero
       bibendum, finibus dui non, rutrum sapien. Quisque ac bibendum erat. Vestibulum tincidunt risus nisi.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -81,10 +81,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -102,10 +102,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -123,10 +123,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -144,10 +144,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -165,10 +165,10 @@
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
       fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
       anim id est laborum.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">
@@ -281,10 +281,10 @@
       mollis risus at ligula finibus, vitae volutpat ex auctor. Morbi vel cursus felis. Maecenas lobortis porttitor
       odio, non venenatis risus varius vitae. Proin gravida mi odio, sed pretium neque luctus vitae. Mauris ut libero
       bibendum, finibus dui non, rutrum sapien. Quisque ac bibendum erat. Vestibulum tincidunt risus nisi.</p>
-    <pfe-button>
+    <pfe-button slot="footer">
       <button>Confirm</button>
     </pfe-button>
-    <pfe-button variant="secondary">
+    <pfe-button variant="secondary" slot="footer">
       <button>Cancel</button>
     </pfe-button>
     <pfe-button slot="trigger">

--- a/elements/pfe-modal/demo/pfe-modal.html
+++ b/elements/pfe-modal/demo/pfe-modal.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="/core/pfe-styles/pfe-layouts.css">
 <link rel="stylesheet" href="/elements/pfe-modal/demo/demo.css">
 
-<pfe-band color-palette="lightest" size="smallest">
+<pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Basic</h2>
   <pfe-modal>
     <h2 slot="header">Simple modal header</h2>
@@ -26,7 +26,7 @@
   </pfe-modal>
 </pfe-band>
 
-<pfe-band color-palette="lightest" size="smallest">
+<pfe-band color-palette="lightest" size="small">
   <h2 slot="header">With description</h2>
   <pfe-modal>
     <h2 slot="header">Simple modal header</h2>
@@ -72,7 +72,7 @@
   </pfe-modal>
 </pfe-band>
 
-<pfe-band color-palette="lightest" size="smallest">
+<pfe-band color-palette="lightest" size="small">
   <h2 slot="header">Top aligned</h2>
   <pfe-modal position="top">
     <h2 slot="header">Top modal header</h2>
@@ -93,97 +93,202 @@
   </pfe-modal>
 </pfe-band>
 
-<pfe-band color-palette="darkest" id="test-dark">
-  <h2 slot="header">Modal: No header region</h2>
-  <pfe-modal>
-    <pfe-cta priority="secondary" slot="trigger">
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Small</h2>
+  <pfe-modal variant="small">
+    <h2 slot="header">Small modal header</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
       <button>Show modal</button>
-    </pfe-cta>
-    <h3>This has no header region</h3>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-      pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-      laborum.</p>
-    <pfe-cta id="test-dark-child">
-      <a href="#">Call-to-action</a>
-    </pfe-cta>
+    </pfe-button>
   </pfe-modal>
 </pfe-band>
 
-<pfe-band color-palette="complement">
-  <h2>Modal: No headings</h2>
-  <pfe-modal>
-    <pfe-cta priority="secondary" slot="trigger">
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Medium</h2>
+  <pfe-modal variant="medium">
+    <h2 slot="header">Medium modal header</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
       <button>Show modal</button>
-    </pfe-cta>
-    <p>This modal doesn't have any headings. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-      laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
-      officia deserunt mollit anim id est laborum.</p>
-    <pfe-cta>
-      <a href="#">Call-to-action</a>
-    </pfe-cta>
+    </pfe-button>
   </pfe-modal>
 </pfe-band>
 
-<pfe-band id="external-lots" color-palette="lightest">
-  <pfe-card color-palette="darkest">
-    <h2 slot="header">Modal: External trigger</h2>
-    <pfe-cta><button id="custom-trigger">Custom open modal</button></pfe-cta>
-    <pfe-modal id="custom-modal">
-      <h2 slot="header">Custom open modal</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
-        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-        ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-        nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-        anim id est laborum.</p>
-      <pfe-cta>
-        <a href="#bar">Learn more</a>
-      </pfe-cta>
-    </pfe-modal>
-  </pfe-card>
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Large</h2>
+  <pfe-modal variant="large">
+    <h2 slot="header">Large modal header</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
 
-  <pfe-card>
-    <h2 slot="header">Modal: External trigger By Id</h2>
-    <pfe-cta><button id="id-trigger">Custom open modal</button></pfe-cta>
-    <pfe-modal id="custom-modal" trigger="id-trigger">
-      <h2 slot="header">Trigger by ID</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
-        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-        ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-        nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-        anim id est laborum.</p>
-      <pfe-cta>
-        <a href="#bar">Learn more</a>
-      </pfe-cta>
-    </pfe-modal>
-  </pfe-card>
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">pfe-modal-width CSS Custom Property</h2>
+  <pfe-modal style="--pfe-modal-width: 50%">
+    <h2 slot="header">Width 50% header</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
 
-  <pfe-card color-palette="complement">
-    <h2 slot="header">Modal: a lot of content</h2>
-    <pfe-modal color-palette="darkest" id="testit">
-      <pfe-cta slot="trigger"><button>Show modal</button></pfe-cta>
-      <h2 slot="header">Modal with a header with a super duper long title and a lot of content</h2>
-      <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor
-        incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit
-        esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
-        qui officia deserunt mollit anim id est laborum.</p>
-      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Sed posuere
-        consectetur est at lobortis. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
-      <p>Cras justo odio, dapibus ac facilisis in, egestas eget quam. Cum sociis natoque penatibus et magnis dis
-        parturient montes, nascetur ridiculus mus. Curabitur blandit tempus porttitor. Lorem ipsum dolor sit amet,
-        consectetur adipiscing elit. Curabitur blandit tempus porttitor. Duis mollis, est non commodo luctus, nisi
-        erat porttitor ligula, eget lacinia odio sem nec elit. Curabitur blandit tempus porttitor.</p>
-      <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed
-        odio dui. Maecenas faucibus mollis interdum. Fusce dapibus, tellus ac cursus commodo, tortor mauris
-        condimentum nibh, ut fermentum massa justo sit amet risus.</p>
-      <pfe-cta>
-        <!-- TODO: find out why this gets on=light, should be on=dark b/c closest modal is color-palette=darkest -->
-        <a href="#bar">Learn more</a>
-      </pfe-cta>
-    </pfe-modal>
-  </pfe-card>
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Custom header and footer</h2>
+  <pfe-modal aria-describedby="custom-modal-description">
+    <h2 slot="header">With custom header/footer content.</h2>
+    <p slot="header">Allows for custom content in the header and/or footer by slotting HTML.</p>
+    <p slot="header" id="custom-modal-description">When static text describing the modal is available, it can be wrapped
+      with an ID referring to the
+      modal's aria-describedby value.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+      aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h4 slot="footer">
+      <pfe-icon icon="web-icon-alert-warning" size="1x"></pfe-icon>
+      Custom modal footer.
+    </h4>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">No header</h2>
+  <pfe-modal aria-describedby="custom-modal-description">
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+      aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Custom icon</h2>
+  <pfe-modal aria-describedby="custom-modal-description">
+    <h2 slot="header">
+      <pfe-icon role="presentation" icon="rh-icon-megaphone" size="1x"></pfe-icon>
+      Modal Header
+    </h2>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+      aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">Warning alert</h2>
+  <pfe-modal aria-describedby="custom-modal-description">
+    <h2 slot="header">
+      <pfe-icon role="presentation" icon="web-icon-alert-warning" color="moderate" size="1x"></pfe-icon>
+      Modal Header
+    </h2>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+      aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+      occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
+</pfe-band>
+
+<!-- TODO: wizard -->
+<!-- TODO: dropdown that can break out -->
+<!-- TODO: help popover -->
+<!-- TODO: with form fields -->
+
+
+<pfe-band color-palette="lightest" size="small">
+  <h2 slot="header">With overflowing content</h2>
+  <p>If the content that you're passing to the modal is likely to overflow the modal content area, it is still
+    accessible via keyboard scrolling.</p>
+  <pfe-modal>
+    <h2 slot="header">Modal with overflowing content</h2>
+    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+      anim id est laborum.</p>
+    <p>Nullam dapibus, leo quis suscipit semper, nisi sapien ultricies turpis, ac tincidunt ipsum risus in nibh. Ut
+      consequat dolor risus. Vivamus ultricies lacinia ipsum, mattis egestas nisi scelerisque sit amet. Fusce eleifend,
+      sapien vel tempor convallis, magna nisl dapibus tortor, vel lobortis metus turpis vel odio. Suspendisse pharetra
+      ex nec volutpat tristique. Cras posuere et augue id maximus. Duis lobortis rutrum luctus. Integer cursus odio ac
+      enim vehicula sollicitudin. Morbi feugiat urna nulla, vel molestie enim tempus et. Fusce pellentesque ligula a
+      nibh viverra mattis. Vestibulum tincidunt diam quis enim feugiat finibus in eu felis. Morbi ac fringilla ligula.
+      Praesent nec ex nec sapien laoreet suscipit. Nullam sit amet tempor metus, a consequat purus. Pellentesque non
+      maximus nulla, tempus accumsan enim.</p>
+    <p>Etiam semper metus sed urna blandit lacinia. Maecenas nibh nisl, pharetra elementum enim sed, porta vehicula
+      felis. Donec at ante consequat, aliquet urna vitae, imperdiet urna. Nam vel molestie nibh, quis ornare arcu. Donec
+      faucibus enim id accumsan laoreet. Sed laoreet leo id eleifend sagittis. Praesent eget lacinia lectus, sit amet
+      cursus eros. Aenean et augue risus.</p>
+    <p>Aliquam erat volutpat. Integer nisi justo, molestie a dolor ut, ultricies efficitur est. Lorem ipsum dolor sit
+      amet, consectetur adipiscing elit. In et diam dignissim, aliquet odio quis, efficitur erat. Integer cursus
+      convallis ligula, dapibus elementum sem. Mauris blandit vitae risus id pharetra. Donec et diam eros.</p>
+    <p>Curabitur urna est, mollis vitae leo nec, vehicula pharetra dui. Mauris non est viverra, semper lacus in,
+      sollicitudin est. Fusce pharetra neque vel orci congue dignissim. Curabitur ac sem viverra, molestie mauris ac,
+      egestas tortor. Aenean ut aliquet ligula, id gravida metus. Sed semper et quam et sagittis. Pellentesque egestas
+      magna id eros interdum facilisis. Nam dignissim ante quis augue finibus tristique. Donec at augue sem. Nulla
+      mollis risus at ligula finibus, vitae volutpat ex auctor. Morbi vel cursus felis. Maecenas lobortis porttitor
+      odio, non venenatis risus varius vitae. Proin gravida mi odio, sed pretium neque luctus vitae. Mauris ut libero
+      bibendum, finibus dui non, rutrum sapien. Quisque ac bibendum erat. Vestibulum tincidunt risus nisi.</p>
+    <pfe-button>
+      <button>Confirm</button>
+    </pfe-button>
+    <pfe-button variant="secondary">
+      <button>Cancel</button>
+    </pfe-button>
+    <pfe-button slot="trigger">
+      <button>Show modal</button>
+    </pfe-button>
+  </pfe-modal>
 </pfe-band>

--- a/elements/pfe-modal/demo/pfe-modal.js
+++ b/elements/pfe-modal/demo/pfe-modal.js
@@ -3,9 +3,17 @@ import '@patternfly/pfe-card';
 import '@patternfly/pfe-cta';
 import '@patternfly/pfe-button';
 import '@patternfly/pfe-modal';
+import '@patternfly/pfe-icon';
+import '@patternfly/pfe-dropdown';
 
 const root = document.querySelector('[data-demo="pfe-modal"]')?.shadowRoot ?? document;
 const trigger = root.querySelector('#custom-trigger');
 const customTriggerModal = root.querySelector('#custom-modal');
 
 customTriggerModal.setTrigger(trigger);
+
+for (const button of root.querySelectorAll('pfe-modal pfe-button:not([slot])')) {
+  button.addEventListener('click', e => {
+    e.target.closest('pfe-modal').close();
+  });
+}

--- a/elements/pfe-modal/demo/pfe-modal.js
+++ b/elements/pfe-modal/demo/pfe-modal.js
@@ -1,6 +1,7 @@
 import '@patternfly/pfe-band';
 import '@patternfly/pfe-card';
 import '@patternfly/pfe-cta';
+import '@patternfly/pfe-button';
 import '@patternfly/pfe-modal';
 
 const root = document.querySelector('[data-demo="pfe-modal"]')?.shadowRoot ?? document;

--- a/elements/pfe-modal/demo/pfe-modal.js
+++ b/elements/pfe-modal/demo/pfe-modal.js
@@ -7,12 +7,8 @@ import '@patternfly/pfe-icon';
 import '@patternfly/pfe-dropdown';
 
 const root = document.querySelector('[data-demo="pfe-modal"]')?.shadowRoot ?? document;
-const trigger = root.querySelector('#custom-trigger');
-const customTriggerModal = root.querySelector('#custom-modal');
 
-customTriggerModal.setTrigger(trigger);
-
-for (const button of root.querySelectorAll('pfe-modal pfe-button:not([slot])')) {
+for (const button of root.querySelectorAll('pfe-modal pfe-button:not([slot]) button')) {
   button.addEventListener('click', e => {
     e.target.closest('pfe-modal').close();
   });

--- a/elements/pfe-modal/demo/pfe-modal.js
+++ b/elements/pfe-modal/demo/pfe-modal.js
@@ -8,8 +8,8 @@ import '@patternfly/pfe-dropdown';
 
 const root = document.querySelector('[data-demo="pfe-modal"]')?.shadowRoot ?? document;
 
-for (const button of root.querySelectorAll('pfe-modal pfe-button:not([slot]) button')) {
+for (const button of root.querySelectorAll('pfe-modal pfe-button:not([slot="trigger"]) button')) {
   button.addEventListener('click', e => {
-    e.target.closest('pfe-modal').close();
+    e.target.closest('pfe-modal').close(e.target.textContent.toLowerCase());
   });
 }

--- a/elements/pfe-modal/docs/index.md
+++ b/elements/pfe-modal/docs/index.md
@@ -1,81 +1,65 @@
 {% renderOverview %}
-  <pfe-modal>
-    <pfe-button slot="trigger">
-      <button>Open modal</button>
-    </pfe-button>
+  <pfe-modal trigger="overview-trigger">
     <h2 slot="header">Modal with a header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <pfe-cta>
       <a href="#bar">Learn more</a>
     </pfe-cta>
   </pfe-modal>
+  <pfe-button id="overview-trigger">
+    <button>Open modal</button>
+  </pfe-button>
 {% endrenderOverview %}
 
 {% band header="Usage" %}
-  ### With a trigger
-  The `trigger` slot can be used with a trigger element, like a button, to provide a mechanism to open a modal without any additional JavaScript.
 
   ```html
-  <pfe-modal>
-    <button slot="trigger">Open modal</button>
+  <pfe-modal trigger="usage-trigger">
     <h2 slot="header">Modal with a header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <pfe-cta>
       <a href="#bar">Learn more</a>
     </pfe-cta>
   </pfe-modal>
+  <button id="usage-trigger">Open modal</button>
   ```
-
-  ### Without a trigger
-  Using `pfe-modal` without utilizing the `trigger` slot requires additional JavaScript to programmatically open a modal. Uses for this type of modal are meant for scenarios where a modal needs to be programmatically triggered: a user is being logged out, a user needs to accept terms before continuing, etc.
-
-  ```html
-  <pfe-modal>
-    <h2 slot="header">Modal with a header</h2>
-    <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <pfe-cta>
-      <a href="#bar">Learn more</a>
-    </pfe-cta>
-  </pfe-modal>
-  ```
-
 {% endband %}
 
 {% renderSlots %}{% endrenderSlots %}
 
 {% renderAttributes %}
-  <pfe-modal width="small">
-    <pfe-button slot="trigger">
-      <button>Open a small modal</button>
-    </pfe-button>
+  <pfe-modal width="small" trigger="rendered-slot-small">
     <h2 slot="header">Small modal with a header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <pfe-cta>
       <a href="#bar">Learn more</a>
     </pfe-cta>
   </pfe-modal>
+  <pfe-button id="rendered-slot-small">
+    <button>Open a small modal</button>
+  </pfe-button>
 
-  <pfe-modal width="medium">
-    <pfe-button slot="trigger">
-      <button>Open a medium modal</button>
-    </pfe-button>
+  <pfe-modal width="medium" trigger="rendered-slot-medium">
     <h2 slot="header">Medium modal with a header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <pfe-cta>
       <a href="#bar">Learn more</a>
     </pfe-cta>
   </pfe-modal>
+  <pfe-button id="rendered-slot-medium">
+    <button>Open a medium modal</button>
+  </pfe-button>
 
-  <pfe-modal width="large">
-    <pfe-button slot="trigger">
-      <button>Open a large modal</button>
-    </pfe-button>
+  <pfe-modal width="large" trigger="rendered-slot-large">
     <h2 slot="header">Large modal with a header</h2>
     <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <pfe-cta>
       <a href="#bar">Learn more</a>
     </pfe-cta>
   </pfe-modal>
+  <pfe-button id="rendered-slot-large">
+    <button>Open a large modal</button>
+  </pfe-button>
 {% endrenderAttributes %}
 
 {% renderProperties %}{% endrenderProperties %}

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -80,16 +80,19 @@ section {
     max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
   }
 
-  :host([width="small"]) & {
-    max-width: pfe-local(MaxWidth--small);
+  :host([width="small"]) &,
+  :host([variant="small"]) & {
+    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--small));
   }
 
-  :host([width="medium"]) & {
-    max-width: pfe-local(MaxWidth--medium);
+  :host([width="medium"]) &,
+  :host([variant="medium"]) & {
+    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--medium));
   }
 
-  :host([width="large"]) & {
-    max-width: pfe-local(MaxWidth--large);
+  :host([width="large"]) &,
+  :host([variant="large"]) & {
+    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
   }
 }
 

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -136,20 +136,37 @@ header {
     color: var(--pf-c-button--m-plain--focus--Color, var(--pf-global--Color--100, #151515));
   }
 
-  @media screen and (min-width: $pfe-modal--breakpoint--medium) {
-    top: 	pfe-var(container-padding);
-    right: 	pfe-var(container-padding);
-  }
-
-  @media screen and (max-height: $pfe-modal--breakpoint--medium) and (min-width: $pfe-modal--breakpoint--medium) {
-    top: 	calc(#{pfe-var(container-padding)} / 2);
-    right: 	calc(#{pfe-var(container-padding)} / 2);
-  }
-
   > svg {
     height: pfe-var(ui--element--size);
     width: 	pfe-var(ui--element--size);
     height: pfe-local(size, $region: close);
     width: 	pfe-local(size, $region: close);
   }
+}
+
+@media screen and (min-width: $pfe-modal--breakpoint--medium) {
+  [part=close-button] {
+    top: 	pfe-var(container-padding);
+    right: 	pfe-var(container-padding);
+  }
+}
+
+@media screen and (max-height: $pfe-modal--breakpoint--medium) and (min-width: $pfe-modal--breakpoint--medium) {
+  [part=close-button] {
+    top: 	calc(#{pfe-var(container-padding)} / 2);
+    right: 	calc(#{pfe-var(container-padding)} / 2);
+  }
+}
+
+:host([position="top"]) #dialog {
+  position: fixed;
+  align-self: flex-start;
+
+  top: var(--pf-c-modal-box--m-align-top--MarginTop, var(--pf-c-modal-box--m-align-top--spacer, 0.5rem));
+
+  $spacer: var(--pf-c-modal-box--m-align-top--spacer, var(--pf-global--spacer--sm, 0.5rem));
+  $height-offset: min($spacer, var(--pf-global--spacer--2xl, 3rem));
+
+  max-width:  var(--pf-c-modal-box--m-align-top--MaxWidth,  calc(100% - min(calc($spacer * 2), var(--pf-global--spacer--xl, 2rem))));
+  max-height: var(--pf-c-modal-box--m-align-top--MaxHeight, calc(100% - $height-offset - $spacer));
 }

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -1,28 +1,7 @@
-@use "sass:map";
-@use "@patternfly/pfe-sass" as *;
-
-@include configure(
-  $name: 'modal',
-  $variables: (
-		context: light,
-		MaxHeight: 90vh,
-		MaxWidth: 70vw,
-		MaxWidth--mobile: 94vw,
-		MaxWidth--small: #{"min(35rem, 94vw)"},
-		MaxWidth--medium: #{"min(52.5rem, 94vw)"},
-		MaxWidth--large: #{"min(70rem, 94vw)"},
-		MinWidth: 0,
-		Padding: calc(#{pfe-var(container-padding)} * 2) calc(#{pfe-var(container-padding)} * 3.5) calc(#{pfe-var(container-padding)} * 2) calc(#{pfe-var(container-padding)} * 2),
-		overlay: (
-			BackgroundColor: pfe-var(overlay)
-		),
-		close: (
-			size: calc(#{pfe-var(ui--element--size)} - 4px)
-		),
-	),
-);
-
-$pfe-modal--breakpoint--medium: 640px;
+$spacer-align-top: var(--pf-c-modal-box--m-align-top--spacer,
+  var(--pf-global--spacer--sm,
+    0.5rem));
+$height-offset: min($spacer-align-top, var(--pf-global--spacer--2xl, 3rem));
 
 :host {
 	display: block;
@@ -40,10 +19,11 @@ section {
   width: 100%;
   top: 0;
   left: 0;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: pfe-zindex(modal);
+  z-index: var(--pf-c-modal-box--ZIndex,
+    var(--pf-global--ZIndex--xl,
+      500));
 }
 
 #container {
@@ -57,64 +37,69 @@ section {
   width: 100%;
   top: 0;
   left: 0;
-  background-color: pfe-local(BackgroundColor, $region: overlay);
+  background-color: var(--pf-c-backdrop--BackgroundColor,
+      var(--pf-global--BackgroundColor--dark-transparent-100,
+        rgba(3, 3, 3, 0.62)));
 }
 
 [part=dialog] {
-	--pfe-theme--color--text: var(--pfe-broadcasted--text);
-
   position: relative;
-  max-width: pfe-local(MaxWidth--mobile);
-  min-width: pfe-local(MinWidth);
-  max-height: pfe-local(MaxHeight);
   margin: 0 auto;
-  box-shadow: pfe-var(box-shadow--lg);
-  background-color: pfe-var(surface--lightest);
-  color: pfe-var(text);
-  border-radius: pfe-var(ui--border-radius);
-	background-color: var(--pfe-context-background-color);
-	color: var(--pfe-broadcasted--text);
+
+  width: var(--pf-c-modal-box--Width,
+    calc(100% - var(--pf-global--spacer--xl,2rem)));
+
+  max-width: var(--pf-c-modal-box--MaxWidth,
+    calc(100% - var(--pf-global--spacer--xl,2rem)));
+
+  max-height: var(--pf-c-modal-box--MaxHeight,
+    calc(100% - var(--pf-global--spacer--2xl,3rem)));
+
+  box-shadow: var(--pf-c-modal-box--BoxShadow,
+    var(--pf-global--BoxShadow--xl,
+      0 1rem 2rem 0 rgba(3, 3, 3, 0.16),
+      0 0 0.5rem 0 rgba(3, 3, 3, 0.1)));
+
+	background-color: var(--pf-c-modal-box--BackgroundColor,
+    var(--pf-global--BackgroundColor--100,
+      var(--pf-global--BackgroundColor--100, #fff)));
+
   padding: var(--pf-global--spacer--lg, 1.5rem);
-
-  @media screen and (min-width: $pfe-modal--breakpoint--medium) {
-    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
-  }
-
-  :host([width="small"]) &,
-  :host([variant="small"]) & {
-    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--small));
-  }
-
-  :host([width="medium"]) &,
-  :host([variant="medium"]) & {
-    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--medium));
-  }
-
-  :host([width="large"]) &,
-  :host([variant="large"]) & {
-    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
-  }
+  margin-inline: var(--pf-global--spacer--md, 1rem);
 }
+
+:host([width]) [part=dialog],
+:host([variant]) [part=dialog] {
+  margin-inline: 0;
+}
+
+:host([width="small"]) [part=dialog],
+:host([variant="small"]) [part=dialog] {
+  --pf-c-modal-box--Width: var(--pf-c-modal-box--m-sm--sm--MaxWidth, 35rem);
+}
+
+:host([width="medium"]) [part=dialog],
+:host([variant="medium"]) [part=dialog] {
+  --pf-c-modal-box--Width: var(--pf-c-modal-box--m-md--Width, 52.5rem);
+}
+
+:host([width="large"]) [part=dialog],
+:host([variant="large"]) [part=dialog] {
+  --pf-c-modal-box--Width: var(--pf-c-modal-box--m-lg--lg--MaxWidth, 70rem);
+}
+
 
 [part=content] {
   overflow-y: auto;
   overscroll-behavior: contain;
-  max-height: pfe-local(MaxHeight);
+
+  max-height: var(--pf-c-modal-box--MaxHeight,
+    calc(100% - var(--pf-global--spacer--2xl,
+      3rem)));
+
   box-sizing: border-box;
 
-  @media screen and (max-height: $pfe-modal--breakpoint--medium) {
-    padding: pfe-local(Padding, $fallback: pfe-var(container-padding) calc(#{pfe-var(container-padding)} * 3) pfe-var(container-padding) pfe-var(container-padding));
-  }
-
-  &:not(.hasHeader) {
-    // Remove margin-top on the first slotted element that is not the header.
-    ::slotted(*:nth-child(2)),
-    ::slotted(*:nth-child(1)) {
-      margin-top: 0 !important;
-    }
-  }
-
-  ::slotted([slot$="header"]) {
+  ::slotted([slot="header"]) {
     margin-top: 0 !important;
   }
 }
@@ -122,54 +107,75 @@ section {
 header {
   position: sticky;
   top: 0;
-  background: var(--pfe-context-background-color);
+	background-color: var(--pf-c-modal-box--BackgroundColor,
+    var(--pf-global--BackgroundColor--100,
+      var(--pf-global--BackgroundColor--100,
+        #fff)));
+}
+
+header ::slotted(:is(h1,h2,h3,h4,h5,h6)[slot="header"]) {
+  font-size: var(--pf-c-modal-box__title--FontSize,
+    var(--pf-global--FontSize--2xl,
+      1.5rem));
+  font-weight: var(--pf-global--FontWeight--normal, 400);
+  font-family: var(--pf-c-modal-box__title--FontFamily,
+    var(--pf-global--FontFamily--heading--sans-serif,
+      var(--pf-global--FontFamily--redhat-updated--heading--sans-serif,
+        "RedHatDisplayUpdated", "Overpass", overpass, helvetica, arial, sans-serif)));
 }
 
 [part=close-button] {
-  @extend %reset-button;
+  background-color: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+
   position: absolute;
-  top: 	calc(#{pfe-var(container-padding)} * .25);
-  right: 	calc(#{pfe-var(container-padding)} * .25);
   cursor: pointer;
-  line-height: .5;
-  padding: pfe-var(container-padding);
-  color: 	var(--pf-c-button--m-plain--Color, var(--pf-global--Color--200, #6a6e73));
+  line-height: 24px;
+  padding-block:
+    var(--pf-c-button--PaddingTop,
+      var(--pf-global--spacer--form-element, 0.375rem));
+  padding-inline:
+    var(--pf-c-button--PaddingRight,
+      var(--pf-global--spacer--md, 1rem));
+  top: 0;
+  right: calc(var(--pf-global--spacer--lg, 1.5rem) / -3);
+  color: var(--pf-c-button--m-plain--Color,
+    var(--pf-global--Color--200,
+      #6a6e73));
+  font-size: var(--pf-c-button--FontSize,
+    var(--pf-global--FontSize--md,
+      1rem));
 
   &:is(:focus-within, :focus-visible, :hover) {
     color: var(--pf-c-button--m-plain--focus--Color, var(--pf-global--Color--100, #151515));
   }
 
   > svg {
-    height: pfe-var(ui--element--size);
-    width: 	pfe-var(ui--element--size);
-    height: pfe-local(size, $region: close);
-    width: 	pfe-local(size, $region: close);
-  }
-}
-
-@media screen and (min-width: $pfe-modal--breakpoint--medium) {
-  [part=close-button] {
-    top: 	pfe-var(container-padding);
-    right: 	pfe-var(container-padding);
-  }
-}
-
-@media screen and (max-height: $pfe-modal--breakpoint--medium) and (min-width: $pfe-modal--breakpoint--medium) {
-  [part=close-button] {
-    top: 	calc(#{pfe-var(container-padding)} / 2);
-    right: 	calc(#{pfe-var(container-padding)} / 2);
+    font-size: 16px;
+    width: var(--pf-global--spacer--md, 1rem);
+    aspect-ratio: 1/1;
   }
 }
 
 :host([position="top"]) #dialog {
-  position: fixed;
-  align-self: flex-start;
+  align-self: start;
 
-  top: var(--pf-c-modal-box--m-align-top--MarginTop, var(--pf-c-modal-box--m-align-top--spacer, 0.5rem));
+  margin-block: var(--pf-c-modal-box--m-align-top--MarginTop,
+    var(--pf-c-modal-box--m-align-top--spacer,
+      2rem));
 
-  $spacer: var(--pf-c-modal-box--m-align-top--spacer, var(--pf-global--spacer--sm, 0.5rem));
-  $height-offset: min($spacer, var(--pf-global--spacer--2xl, 3rem));
+  margin-inline: var(--pf-global--spacer--md, 1rem);
 
-  max-width:  var(--pf-c-modal-box--m-align-top--MaxWidth,  calc(100% - min(calc($spacer * 2), var(--pf-global--spacer--xl, 2rem))));
-  max-height: var(--pf-c-modal-box--m-align-top--MaxHeight, calc(100% - $height-offset - $spacer));
+  width: 100%;
+
+  max-width: var(--pf-c-modal-box--m-align-top--MaxWidth,
+    calc(100% - min(
+      var(--pf-c-modal-box--m-align-top--spacer, 2rem) * 2,
+      var(--pf-global--spacer--xl, 2rem))));
+
+  max-height: var(--pf-c-modal-box--m-align-top--MaxHeight,
+    calc(100% - $height-offset - $spacer-align-top));
 }

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -1,6 +1,5 @@
 $spacer-align-top: var(--pf-c-modal-box--m-align-top--spacer,
-  var(--pf-global--spacer--sm,
-    0.5rem));
+  var(--pf-global--spacer--sm, 0.5rem));
 $height-offset: min($spacer-align-top, var(--pf-global--spacer--2xl, 3rem));
 
 :host {

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -29,126 +29,127 @@ $pfe-modal--breakpoint--medium: 640px;
 	position: relative;
 }
 
-.pfe-modal {
-	&__outer {
-		display: flex;
-		position: fixed;
-		height: 100%;
-		width: 100%;
-		top: 0;
-		left: 0;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		z-index: pfe-zindex(modal);
-
-		&[hidden] {
-			display: none;
-		}
-	}
-	&__overlay {
-		position: fixed;
-		height: 100%;
-		width: 100%;
-		top: 0;
-		left: 0;
-		background-color: pfe-local(BackgroundColor, $region: overlay);
-		cursor: pointer;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-	&__window {
-		// --context: #{pfe-local(context)};
-		position: relative;
-		max-width: pfe-local(MaxWidth--mobile);
-		min-width: pfe-local(MinWidth);
-		max-height: pfe-local(MaxHeight);
-		margin: 0 auto;
-		box-shadow: pfe-var(box-shadow--lg);
-		background-color: pfe-var(surface--lightest);
-		color: pfe-var(text);
-		border-radius: pfe-var(ui--border-radius);
-
-		@media screen and (min-width: $pfe-modal--breakpoint--medium) {
-			max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
-		}
-
-		:host([width="small"]) & {
-			max-width: pfe-local(MaxWidth--small);
-		}
-
-		:host([width="medium"]) & {
-			max-width: pfe-local(MaxWidth--medium);
-		}
-
-		:host([width="large"]) & {
-			max-width: pfe-local(MaxWidth--large);
-		}
-	}
-	&__container {
-		position: relative;
-		max-height: inherit;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-	&__content {
-		overflow-y: auto;
-		overscroll-behavior: contain;
-		max-height: pfe-local(MaxHeight);
-		padding: pfe-local(Padding);
-		box-sizing: border-box;
-
-		@media screen and (max-height: $pfe-modal--breakpoint--medium) {
-			padding: pfe-local(Padding, $fallback: pfe-var(container-padding) calc(#{pfe-var(container-padding)} * 3) pfe-var(container-padding) pfe-var(container-padding));
-		}
-
-		&:not(.has-header) {
-			// Remove margin-top on the first slotted element that is not the header.
-			::slotted(*:nth-child(2)),
-			::slotted(*:nth-child(1)) {
-				margin-top: 0 !important;
-			}
-		}
-
-		::slotted([slot$="header"]) {
-			margin-top: 0 !important;
-		}
-	}
-	&__close {
-		@extend %reset-button;
-		position: absolute;
-		top: 	calc(#{pfe-var(container-padding)} * .25);
-		right: 	calc(#{pfe-var(container-padding)} * .25);
-		cursor: pointer;
-		line-height: .5;
-		padding: pfe-var(container-padding);
-
-		@media screen and (min-width: $pfe-modal--breakpoint--medium) {
-			top: 	pfe-var(container-padding);
-			right: 	pfe-var(container-padding);
-		}
-
-		@media screen and (max-height: $pfe-modal--breakpoint--medium) and (min-width: $pfe-modal--breakpoint--medium) {
-			top: 	calc(#{pfe-var(container-padding)} / 2);
-			right: 	calc(#{pfe-var(container-padding)} / 2);
-		}
-
-		> svg {
-			fill: 	pfe-var(text);
-			height: pfe-var(ui--element--size);
-			width: 	pfe-var(ui--element--size);
-			height: pfe-local(size, $region: close);
-			width: 	pfe-local(size, $region: close);
-		}
-	}
+[hidden] {
+  display: none !important;
 }
 
-#dialog {
+section {
+  display: flex;
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: pfe-zindex(modal);
+}
+
+#container {
+  position: relative;
+  max-height: inherit;
+}
+
+[part=overlay] {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  background-color: pfe-local(BackgroundColor, $region: overlay);
+}
+
+[part=dialog] {
 	--pfe-theme--color--text: var(--pfe-broadcasted--text);
+
+  position: relative;
+  max-width: pfe-local(MaxWidth--mobile);
+  min-width: pfe-local(MinWidth);
+  max-height: pfe-local(MaxHeight);
+  margin: 0 auto;
+  box-shadow: pfe-var(box-shadow--lg);
+  background-color: pfe-var(surface--lightest);
+  color: pfe-var(text);
+  border-radius: pfe-var(ui--border-radius);
 	background-color: var(--pfe-context-background-color);
 	color: var(--pfe-broadcasted--text);
+  padding: var(--pf-global--spacer--lg, 1.5rem);
+
+  @media screen and (min-width: $pfe-modal--breakpoint--medium) {
+    max-width: var(--pfe-modal-width, pfe-local(MaxWidth--large));
+  }
+
+  :host([width="small"]) & {
+    max-width: pfe-local(MaxWidth--small);
+  }
+
+  :host([width="medium"]) & {
+    max-width: pfe-local(MaxWidth--medium);
+  }
+
+  :host([width="large"]) & {
+    max-width: pfe-local(MaxWidth--large);
+  }
+}
+
+[part=content] {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  max-height: pfe-local(MaxHeight);
+  box-sizing: border-box;
+
+  @media screen and (max-height: $pfe-modal--breakpoint--medium) {
+    padding: pfe-local(Padding, $fallback: pfe-var(container-padding) calc(#{pfe-var(container-padding)} * 3) pfe-var(container-padding) pfe-var(container-padding));
+  }
+
+  &:not(.hasHeader) {
+    // Remove margin-top on the first slotted element that is not the header.
+    ::slotted(*:nth-child(2)),
+    ::slotted(*:nth-child(1)) {
+      margin-top: 0 !important;
+    }
+  }
+
+  ::slotted([slot$="header"]) {
+    margin-top: 0 !important;
+  }
+}
+
+header {
+  position: sticky;
+  top: 0;
+  background: var(--pfe-context-background-color);
+}
+
+[part=close-button] {
+  @extend %reset-button;
+  position: absolute;
+  top: 	calc(#{pfe-var(container-padding)} * .25);
+  right: 	calc(#{pfe-var(container-padding)} * .25);
+  cursor: pointer;
+  line-height: .5;
+  padding: pfe-var(container-padding);
+  color: 	var(--pf-c-button--m-plain--Color, var(--pf-global--Color--200, #6a6e73));
+
+  &:is(:focus-within, :focus-visible, :hover) {
+    color: var(--pf-c-button--m-plain--focus--Color, var(--pf-global--Color--100, #151515));
+  }
+
+  @media screen and (min-width: $pfe-modal--breakpoint--medium) {
+    top: 	pfe-var(container-padding);
+    right: 	pfe-var(container-padding);
+  }
+
+  @media screen and (max-height: $pfe-modal--breakpoint--medium) and (min-width: $pfe-modal--breakpoint--medium) {
+    top: 	calc(#{pfe-var(container-padding)} / 2);
+    right: 	calc(#{pfe-var(container-padding)} / 2);
+  }
+
+  > svg {
+    height: pfe-var(ui--element--size);
+    width: 	pfe-var(ui--element--size);
+    height: pfe-local(size, $region: close);
+    width: 	pfe-local(size, $region: close);
+  }
 }

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -179,3 +179,9 @@ header ::slotted(:is(h1,h2,h3,h4,h5,h6)[slot="header"]) {
   max-height: var(--pf-c-modal-box--m-align-top--MaxHeight,
     calc(100% - $height-offset - $spacer-align-top));
 }
+
+footer {
+  display: flex;
+  align-items: center;
+  gap: var(--pf-global--spacer--xl, 0.5rem);
+}

--- a/elements/pfe-modal/pfe-modal.scss
+++ b/elements/pfe-modal/pfe-modal.scss
@@ -94,7 +94,7 @@ section {
   overscroll-behavior: contain;
 
   max-height: var(--pf-c-modal-box--MaxHeight,
-    calc(100% - var(--pf-global--spacer--2xl,
+    calc(100vh - var(--pf-global--spacer--2xl,
       3rem)));
 
   box-sizing: border-box;

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -39,10 +39,25 @@ export class ModalOpenEvent extends ComposedEvent {
  *
  * @summary Displays information or helps a user focus on a task
  *
+ * @slot - The default slot can contain any type of content. When the header is not present this unnamed slot appear at the top of the modal window (to the left of the close button). Otherwise it will appear beneath the header.
+ * @slot trigger - The only part visible on page load, the trigger opens the modal window. The trigger can be a button, a cta or a link. While it is part of the modal web component, it does not contain any intrinsic styles.
+ * @slot header - The header is an optional slot that appears at the top of the modal window. It should be a header tag (h2-h6).
+ * @slot footer - Optional footer content. Good place to put action buttons.
+ * @slot pfe-modal--trigger - {@deprecated use `trigger`}
+ * @slot pfe-modal--header - {@deprecated use `header`}
+ *
+ * @fires {ModalOpenEvent} open - Fires when a user clicks on the trigger or manually opens a modal.
+ * @fires {ModalCloseEvent} close - Fires when either a user clicks on either the close button or the overlay or manually closes a modal.
+ * @fires {CustomEvent<{ open: true; trigger?: HTMLElement }>} pfe-modal:open - {@deprecated Use `open`} When the modal opens
+ * @fires {CustomEvent<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
+ *
  * @csspart overlay - The modal overlay which lies under the dialog and above the page body
  * @csspart dialog - The dialog element
  * @csspart content - The container for the dialog content
+ * @csspart header - The container for the optional dialog header
+ * @csspart description - The container for the optional dialog description in the header
  * @csspart close-button - The modal's close button
+ * @csspart footer - Actions footer container
  *
  * @cssprop {<length>} --pf-c-modal-box--ZIndex {@default 500}
  * @cssprop {<length>} --pf-c-modal-box--Width - Width of the modal {@default calc(100% - 2rem)}
@@ -58,18 +73,6 @@ export class ModalOpenEvent extends ComposedEvent {
  * @cssprop {<length>} --pf-c-modal-box--m-align-top--MaxHeight
  * @cssprop {<color>} --pf-c-modal-box--BackgroundColor - {@default #fff}
  * @cssprop --pf-c-modal-box__title--FontFamily - default font family for header-slotted headings
- *
- * @fires {ModalOpenEvent} open - Fires when a user clicks on the trigger or manually opens a modal.
- * @fires {ModalCloseEvent} close - Fires when either a user clicks on either the close button or the overlay or manually closes a modal.
- * @fires {CustomEvent<{ open: true; trigger?: HTMLElement }>} pfe-modal:open - {@deprecated Use `open`} When the modal opens
- * @fires {CustomEvent<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
- *
- * @slot - The default slot can contain any type of content. When the header is not present this unnamed slot appear at the top of the modal window (to the left of the close button). Otherwise it will appear beneath the header.
- * @slot trigger - The only part visible on page load, the trigger opens the modal window. The trigger can be a button, a cta or a link. While it is part of the modal web component, it does not contain any intrinsic styles.
- * @slot header - The header is an optional slot that appears at the top of the modal window. It should be a header tag (h2-h6).
- * @slot footer - Optional footer content. Good place to put action buttons.
- * @slot pfe-modal--trigger - {@deprecated use `trigger`}
- * @slot pfe-modal--header - {@deprecated use `header`}
  */
 @customElement('pfe-modal') @pfelement()
 export class PfeModal extends LitElement implements HTMLDialogElement {
@@ -148,7 +151,7 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
             ?hidden="${!this.open}">
           <div id="container">
             <div id="content" part="content" class=${classMap({ hasHeader, hasDescription, hasFooter })}>
-              <header>
+              <header part="header">
                 <slot name="header"></slot>
                 <slot name="pfe-modal--header"></slot>
                 <div part="description" ?hidden=${!hasDescription}>
@@ -156,7 +159,7 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
                 </div>
               </header>
               <slot></slot>
-              <footer ?hidden=${!hasFooter}>
+              <footer ?hidden=${!hasFooter} part="footer">
                 <slot name="footer"></slot>
               </footer>
             </div>

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -82,6 +82,9 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
 
   static readonly styles = [style];
 
+  /** Should the dialog close when user clicks outside the dialog? */
+  protected static closeOnOutsideClick = false;
+
   /**
    * The `variant` controls the width of the modal.
    * There are three options: `small`, `medium` and `large`. The default is `large`.
@@ -221,9 +224,12 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
   }
 
   @bound private onClick(event: MouseEvent) {
-    if (this.open) {
+    const { open, overlay, dialog } = this;
+    if (open) {
       const path = event.composedPath();
-      if (this.overlay && this.dialog && path.includes(this.overlay) && !path.includes(this.dialog)) {
+      const { closeOnOutsideClick } = this.constructor as typeof PfeModal;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (closeOnOutsideClick && path.includes(overlay!) && !path.includes(dialog!)) {
         event.preventDefault();
         this.cancel();
       }

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -70,7 +70,7 @@ export class PfeModal extends LitElement {
   @property({ reflect: true }) width: 'small' | 'medium' | 'large' = 'large';
 
   @observed('_openChanged')
-  @property({ type: Boolean }) open = false;
+  @property({ type: Boolean, reflect: true }) open = false;
 
   /** Optional ID of the trigger element */
   @observed
@@ -90,7 +90,7 @@ export class PfeModal extends LitElement {
   private cancelling = false;
 
   private slots = new SlotController(this, {
-    slots: [null, 'trigger', 'header'],
+    slots: [null, 'trigger', 'header', 'description'],
     deprecations: {
       'trigger': 'pfe-modal--trigger',
       'header': 'pfe-modal--header',
@@ -107,37 +107,38 @@ export class PfeModal extends LitElement {
     const headerId = (this.header || this.headings.length) ? this.headerId : undefined;
     const headerLabel = this.triggerElement ? this.triggerElement.innerText : undefined;
     const hasHeader = this.slots.hasSlotted('header', 'pfe-modal--header');
+    const hasDescription = this.slots.hasSlotted('description');
 
     return html`
       <slot name="trigger"></slot>
       <slot name="pfe-modal--trigger"></slot>
-      <section class="pfe-modal__outer" ?hidden="${!this.open}">
-        <div id="overlay"
-            part="overlay"
-            class="pfe-modal__overlay" 
-            ?hidden="${!this.open}"></div>
+      <section ?hidden="${!this.open}">
+        <div id="overlay" part="overlay" ?hidden="${!this.open}"></div>
         <div id="dialog"
             part="dialog"
-            class="pfe-modal__window"
             tabindex="0"
             role="dialog"
             aria-labelledby="${ifDefined(headerId)}"
             aria-label="${ifDefined(headerLabel)}"
             ?hidden="${!this.open}">
-          <div class="pfe-modal__container">
-            <div part="content" class="pfe-modal__content ${classMap({ 'has-header': hasHeader })}">
-              <slot name="header"></slot>
-              <slot name="pfe-modal--header"></slot>
+          <div id="container">
+            <div id="content" part="content" class="${classMap({ hasHeader, hasDescription })}">
+              <header>
+                <slot name="header"></slot>
+                <slot name="pfe-modal--header"></slot>
+                <div part="description" ?hidden=${!hasDescription}>
+                  <slot name="description"></slot>
+                </div>
+              </header>
               <slot></slot>
             </div>
-            <button
+            <button id="close-button"
                 part="close-button"
-                class="pfe-modal__close"
                 aria-label="Close dialog"
                 @keydown="${this._keydownHandler}"
                 @click="${this.close}">
-              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="-11 11 22 23">
-                <path d="M30 16.669v-1.331c0-0.363-0.131-0.675-0.394-0.938s-0.575-0.394-0.938-0.394h-10.669v-10.65c0-0.362-0.131-0.675-0.394-0.938s-0.575-0.394-0.938-0.394h-1.331c-0.363 0-0.675 0.131-0.938 0.394s-0.394 0.575-0.394 0.938v10.644h-10.675c-0.362 0-0.675 0.131-0.938 0.394s-0.394 0.575-0.394 0.938v1.331c0 0.363 0.131 0.675 0.394 0.938s0.575 0.394 0.938 0.394h10.669v10.644c0 0.363 0.131 0.675 0.394 0.938 0.262 0.262 0.575 0.394 0.938 0.394h1.331c0.363 0 0.675-0.131 0.938-0.394s0.394-0.575 0.394-0.938v-10.637h10.669c0.363 0 0.675-0.131 0.938-0.394 0.269-0.262 0.4-0.575 0.4-0.938z" transform="rotate(45)"/>
+              <svg fill="currentColor" viewBox="0 0 352 512">
+                <path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path>
               </svg>
             </button>
           </div>

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -69,6 +69,11 @@ export class PfeModal extends LitElement {
    */
   @property({ reflect: true }) width: 'small' | 'medium' | 'large' = 'large';
 
+  /**
+   * `position="top"` aligns the dialog with the top of the page
+   */
+  @property({ reflect: true }) position?: 'top';
+
   @observed('_openChanged')
   @property({ type: Boolean, reflect: true }) open = false;
 

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -63,10 +63,12 @@ export class ModalOpenEvent extends ComposedEvent {
  * @fires {ModalCloseEvent} close - Fires when either a user clicks on either the close button or the overlay or manually closes a modal.
  *
  * @fires {CustomEvent<{ open: true; trigger?: HTMLElement }>} pfe-modal:open - {@deprecated Use `open`} When the modal opens
- * @fires {CustomEvent<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
+ * @fires {CustomEven
+ * t<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
  * @slot - The default slot can contain any type of content. When the header is not present this unnamed slot appear at the top of the modal window (to the left of the close button). Otherwise it will appear beneath the header.
  * @slot trigger - The only part visible on page load, the trigger opens the modal window. The trigger can be a button, a cta or a link. While it is part of the modal web component, it does not contain any intrinsic styles.
  * @slot header - The header is an optional slot that appears at the top of the modal window. It should be a header tag (h2-h6).
+ * @slot footer - Optional footer content. Good place to put action buttons.
  * @slot pfe-modal--trigger - {@deprecated use `trigger`}
  * @slot pfe-modal--header - {@deprecated use `header`}
  */

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -154,16 +154,16 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
             ?hidden="${!this.open}">
           <div id="container">
             <div id="content" part="content" class=${classMap({ hasHeader, hasDescription, hasFooter })}>
-              <header part="header">
+              <header part="header">${this.renderHeaderSlot?.() ?? html`
                 <slot name="header"></slot>
-                <slot name="pfe-modal--header"></slot>
-                <div part="description" ?hidden=${!hasDescription}>
-                  <slot name="description"></slot>
+                <slot name="pfe-modal--header"></slot>`}
+                <div part="description" ?hidden=${!hasDescription}>${this.renderDescriptionSlot?.() ?? html`
+                  <slot name="description"></slot>`}
                 </div>
-              </header>
-              <slot></slot>
-              <footer ?hidden=${!hasFooter} part="footer">
-                <slot name="footer"></slot>
+              </header>${this.renderContentSlot?.() ?? html`
+              <slot></slot>`}
+              <footer ?hidden=${!hasFooter} part="footer">${this.renderFooterSlot?.() ?? html`
+                <slot name="footer"></slot>`}
               </footer>
             </div>
             <button id="close-button"
@@ -180,6 +180,18 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
       </section>
     `;
   }
+
+  /** Optional override for the header slot template */
+  protected renderHeaderSlot?(): ReturnType<LitElement['render']>;
+
+  /** Optional override for the description slot template */
+  protected renderDescriptionSlot?(): ReturnType<LitElement['render']>;
+
+  /** Optional override for the content slot template */
+  protected renderContentSlot?(): ReturnType<LitElement['render']>;
+
+  /** Optional override for the footer slot template */
+  protected renderFooterSlot?(): ReturnType<LitElement['render']>;
 
   disconnectedCallback() {
     super.disconnectedCallback();

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -44,6 +44,21 @@ export class ModalOpenEvent extends ComposedEvent {
  * @csspart content - The container for the dialog content
  * @csspart close-button - The modal's close button
  *
+ * @cssprop {<length>} --pf-c-modal-box--ZIndex {@default 500}
+ * @cssprop {<length>} --pf-c-modal-box--Width - Width of the modal {@default calc(100% - 2rem)}
+ * @cssprop {<length>} --pf-c-modal-box--MaxWidth - Max width of the modal {@default calc(100% - 2rem)}
+ * @cssprop {<length>} --pf-c-modal-box--m-sm--sm--MaxWidth - Max width of the small variant modal {@default 35rem}
+ * @cssprop {<length>} --pf-c-modal-box--m-md--MaxWidth - Max width of the small variant modal {@default 52.5rem}
+ * @cssprop {<length>} --pf-c-modal-box--m-lg--lg--MaxWidth - Max width of the large variant modal {@default 70rem}
+ * @cssprop {<length>} --pf-c-modal-box--MaxHeight - Max height of the modal {@default calc(100% - 3rem)}
+ * @cssprop {<length>} --pf-c-modal-box--BoxShadow - {@default var(--pf-global--BoxShadow--xl)}
+ * @cssprop {<length>} --pf-c-modal-box__title--FontSize - {@default 1.5rem}
+ * @cssprop {<length>} --pf-c-modal-box--m-align-top--MarginTop - {@default 2rem}
+ * @cssprop {<length>} --pf-c-modal-box--m-align-top--MaxWidth
+ * @cssprop {<length>} --pf-c-modal-box--m-align-top--MaxHeight
+ * @cssprop {<color>} --pf-c-modal-box--BackgroundColor - {@default #fff}
+ * @cssprop --pf-c-modal-box__title--FontFamily - default font family for header-slotted headings
+ *
  * @fires {ModalOpenEvent} open - Fires when a user clicks on the trigger or manually opens a modal.
  * @fires {ModalCloseEvent} close - Fires when either a user clicks on either the close button or the overlay or manually closes a modal.
  *
@@ -67,7 +82,7 @@ export class PfeModal extends LitElement {
    * The `variant` controls the width of the modal.
    * There are three options: `small`, `medium` and `large`. The default is `large`.
    */
-  @property({ reflect: true }) variant: 'small' | 'medium' | 'large' = 'large';
+  @property({ reflect: true }) variant?: 'small' | 'medium' | 'large';
 
   @deprecation({ alias: 'variant', attribute: 'width' }) width?: 'small' | 'medium' | 'large';
 

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -61,10 +61,9 @@ export class ModalOpenEvent extends ComposedEvent {
  *
  * @fires {ModalOpenEvent} open - Fires when a user clicks on the trigger or manually opens a modal.
  * @fires {ModalCloseEvent} close - Fires when either a user clicks on either the close button or the overlay or manually closes a modal.
- *
  * @fires {CustomEvent<{ open: true; trigger?: HTMLElement }>} pfe-modal:open - {@deprecated Use `open`} When the modal opens
- * @fires {CustomEven
- * t<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
+ * @fires {CustomEvent<{ open: false }>} pfe-modal:close - {@deprecated Use `close`} When the modal closes
+ *
  * @slot - The default slot can contain any type of content. When the header is not present this unnamed slot appear at the top of the modal window (to the left of the close button). Otherwise it will appear beneath the header.
  * @slot trigger - The only part visible on page load, the trigger opens the modal window. The trigger can be a button, a cta or a link. While it is part of the modal web component, it does not contain any intrinsic styles.
  * @slot header - The header is an optional slot that appears at the top of the modal window. It should be a header tag (h2-h6).
@@ -73,7 +72,7 @@ export class ModalOpenEvent extends ComposedEvent {
  * @slot pfe-modal--header - {@deprecated use `header`}
  */
 @customElement('pfe-modal') @pfelement()
-export class PfeModal extends LitElement {
+export class PfeModal extends LitElement implements HTMLDialogElement {
   static readonly shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
   static readonly version = '{{version}}';
@@ -100,6 +99,7 @@ export class PfeModal extends LitElement {
   @observed
   @property() trigger?: string;
 
+  /** @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue */
   public returnValue?: string;
 
   @query('#overlay') private overlay?: HTMLElement;
@@ -295,9 +295,9 @@ export class PfeModal extends LitElement {
   }
 
   /**
-   * Manually toggles a modal.
-   * ```javascript
-   * document.querySelector('pfe-modal').toggle();
+   * Manually toggles the modal.
+   * ```js
+   * modal.toggle();
    * ```
    */
   @bound toggle() {
@@ -305,9 +305,9 @@ export class PfeModal extends LitElement {
   }
 
   /**
-   * Manually opens a modal.
-   * ```javascript
-   * document.querySelector('pfe-modal').open();
+   * Manually opens the modal.
+   * ```js
+   * modal.open();
    * ```
    */
   @bound show() {
@@ -315,13 +315,14 @@ export class PfeModal extends LitElement {
   }
 
   @bound showModal() {
+    // TODO: non-modal mode
     this.show();
   }
 
   /**
-   * Manually closes a modal.
-   * ```javascript
-   * document.querySelector('pfe-modal').close();
+   * Manually closes the modal.
+   * ```js
+   * modal.close();
    * ```
    */
   @bound close(returnValue?: string) {

--- a/elements/pfe-modal/test/pfe-modal.spec.ts
+++ b/elements/pfe-modal/test/pfe-modal.spec.ts
@@ -10,9 +10,6 @@ const TEMPLATES = {
 
   smallModal: html`
     <pfe-modal width="small">
-      <pfe-button slot="trigger">
-        <button>Open a small modal</button>
-      </pfe-button>
       <h2 slot="header">Small modal</h2>
       <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </pfe-modal>
@@ -20,9 +17,6 @@ const TEMPLATES = {
 
   mediumModal: html`
     <pfe-modal width="medium">
-      <pfe-button slot="trigger">
-        <button>Open a medium modal</button>
-      </pfe-button>
       <h2 slot="header">Medium modal</h2>
       <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </pfe-modal>
@@ -30,9 +24,6 @@ const TEMPLATES = {
 
   largeModal: html`
     <pfe-modal width="large">
-      <pfe-button slot="trigger">
-        <button>Open a large modal</button>
-      </pfe-button>
       <h2 slot="header">Large modal</h2>
       <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </pfe-modal>
@@ -54,9 +45,6 @@ describe('<pfe-modal>', function() {
     // Use the same markup that's declared at the top of the file.
     const el = await createFixture<PfeModal>(html`
       <pfe-modal>
-        <pfe-button slot="trigger">
-          <button>Open a modal</button>
-        </pfe-button>
         <h2 slot="header">Modal with a header</h2>
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
@@ -75,9 +63,6 @@ describe('<pfe-modal>', function() {
     // Use the same markup that's declared at the top of the file.
     const el = await createFixture<PfeModal>(html`
       <pfe-modal>
-        <pfe-button slot="pfe-modal--trigger">
-          <button>Open a modal</button>
-        </pfe-button>
         <h2 slot="pfe-modal--header">Modal with a header</h2>
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
@@ -94,17 +79,16 @@ describe('<pfe-modal>', function() {
 
   it('should open the modal window when the trigger is clicked', async function() {
     const el = await createFixture<PfeModal>(html`
-      <pfe-modal>
-        <pfe-button slot="trigger">
-          <button>Open a modal</button>
-        </pfe-button>
+      <pfe-modal trigger="trigger">
         <h2 slot="header">Modal with a header</h2>
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
+      <pfe-button id="trigger">
+        <button>Open a modal</button>
+      </pfe-button>
     `);
     const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
-    const button = el.shadowRoot!.querySelector<HTMLButtonElement>('[part=close-button]')!;
-    const trigger = el.querySelector<HTMLButtonElement>('[slot="trigger"]')!;
+    const trigger = document.getElementById('trigger')!;
 
     trigger.click();
     await el.updateComplete;
@@ -112,7 +96,7 @@ describe('<pfe-modal>', function() {
     expect(modalWindow.hasAttribute('hidden')).to.not.be.true;
 
     // reset
-    button.click();
+    el.close();
     await el.updateComplete;
 
     expect(modalWindow.hasAttribute('hidden')).to.be.true;

--- a/elements/pfe-modal/test/pfe-modal.spec.ts
+++ b/elements/pfe-modal/test/pfe-modal.spec.ts
@@ -136,7 +136,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('560px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -145,7 +145,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('840px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -154,7 +154,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('1120px');
+          .to.equal('calc(100% - 32px)');
       });
     });
   });
@@ -169,7 +169,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('560px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -178,7 +178,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('840px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -187,7 +187,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('940px');
+          .to.equal('calc(100% - 32px)');
       });
     });
   });
@@ -202,7 +202,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('560px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -211,7 +211,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('721.92px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -220,7 +220,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('721.92px');
+          .to.equal('calc(100% - 32px)');
       });
     });
   });
@@ -235,7 +235,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('451.2px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -244,7 +244,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('451.2px');
+          .to.equal('calc(100% - 32px)');
       });
     });
 
@@ -253,7 +253,7 @@ describe('<pfe-modal>', function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
         const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
-          .to.equal('451.2px');
+          .to.equal('calc(100% - 32px)');
       });
     });
   });

--- a/elements/pfe-modal/test/pfe-modal.spec.ts
+++ b/elements/pfe-modal/test/pfe-modal.spec.ts
@@ -61,12 +61,12 @@ describe('<pfe-modal>', function() {
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
     `);
-    const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
-    const button = el.shadowRoot!.querySelector('.pfe-modal__close')!;
+    const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
+    const button = el.shadowRoot!.querySelector('[part=close-button]')!;
 
     await nextFrame();
 
-    expect(modalWindow.getAttribute('tabindex'), 'modal__window tabindex').to.equal('0');
+    expect(modalWindow.getAttribute('tabindex'), 'dialog tabindex').to.equal('0');
     expect(modalWindow.hasAttribute('hidden'), 'hidden').to.be.true;
     expect(button.getAttribute('aria-label'), 'button aria-label').to.equal('Close dialog');
   });
@@ -82,8 +82,8 @@ describe('<pfe-modal>', function() {
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
     `);
-    const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
-    const button = el.shadowRoot!.querySelector('.pfe-modal__close')!;
+    const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
+    const button = el.shadowRoot!.querySelector('[part=close-button]')!;
 
     await nextFrame();
 
@@ -102,8 +102,8 @@ describe('<pfe-modal>', function() {
         <p>Lorem ipsum dolor sit amet, <a href="#foo">consectetur adipisicing</a> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </pfe-modal>
     `);
-    const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
-    const button = el.shadowRoot!.querySelector<HTMLButtonElement>('.pfe-modal__close')!;
+    const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
+    const button = el.shadowRoot!.querySelector<HTMLButtonElement>('[part=close-button]')!;
     const trigger = el.querySelector<HTMLButtonElement>('[slot="trigger"]')!;
 
     trigger.click();
@@ -134,7 +134,7 @@ describe('<pfe-modal>', function() {
     describe('with width=small attribute', function() {
       it('has small modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('560px');
       });
@@ -143,7 +143,7 @@ describe('<pfe-modal>', function() {
     describe('with width=medium attribute', function() {
       it('has medium modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('840px');
       });
@@ -152,7 +152,7 @@ describe('<pfe-modal>', function() {
     describe('with width=large attribute', function() {
       it('has large modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('1120px');
       });
@@ -167,7 +167,7 @@ describe('<pfe-modal>', function() {
     describe('with width=small attribute', function() {
       it('has small modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('560px');
       });
@@ -176,7 +176,7 @@ describe('<pfe-modal>', function() {
     describe('with width=medium attribute', function() {
       it('has medium modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('840px');
       });
@@ -185,7 +185,7 @@ describe('<pfe-modal>', function() {
     describe('with width=large attribute', function() {
       it('has large modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('940px');
       });
@@ -200,7 +200,7 @@ describe('<pfe-modal>', function() {
     describe('with width=small attribute', function() {
       it('has small modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('560px');
       });
@@ -209,7 +209,7 @@ describe('<pfe-modal>', function() {
     describe('with width=medium attribute', function() {
       it('has medium modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('721.92px');
       });
@@ -218,7 +218,7 @@ describe('<pfe-modal>', function() {
     describe('with width=large attribute', function() {
       it('has large modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('721.92px');
       });
@@ -233,7 +233,7 @@ describe('<pfe-modal>', function() {
     describe('with width=small attribute', function() {
       it('has small modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.smallModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('451.2px');
       });
@@ -242,7 +242,7 @@ describe('<pfe-modal>', function() {
     describe('with width=medium attribute', function() {
       it('has medium modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.mediumModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('451.2px');
       });
@@ -251,7 +251,7 @@ describe('<pfe-modal>', function() {
     describe('with width=large attribute', function() {
       it('has large modal width', async function() {
         const el = await createFixture<PfeModal>(TEMPLATES.largeModal);
-        const modalWindow = el.shadowRoot!.querySelector('.pfe-modal__window')!;
+        const modalWindow = el.shadowRoot!.querySelector('#dialog')!;
         expect(getComputedStyle(modalWindow).getPropertyValue('max-width'))
           .to.equal('451.2px');
       });

--- a/tools/pfe-tools/demo/demo.css
+++ b/tools/pfe-tools/demo/demo.css
@@ -158,3 +158,8 @@ api-viewer {
   max-width: 100%;
   z-index: 1;
 }
+
+.logo-bar a:visited {
+  color: white;
+  text-decoration: none;
+}

--- a/tools/pfe-tools/demo/demo.css
+++ b/tools/pfe-tools/demo/demo.css
@@ -49,12 +49,6 @@ header {
   justify-content: space-between
 }
 
-[slot=header] {
-  display: flex;
-  align-items: end;
-  gap: 16px;
-}
-
 [slot=header] fieldset {
   border: 0;
   margin: 0;

--- a/tools/pfe-tools/demo/index.njk
+++ b/tools/pfe-tools/demo/index.njk
@@ -67,12 +67,8 @@
       </form>
     </pfe-band>
 
-    <vaadin-split-layout orientation="vertical">
-      <div data-demo="{{ element }}">
-        <template shadowroot="open" data-demo="{{ element }}">{{ demo | safe }}</template>
-      </div>
-      <api-viewer src="{{ manifest }}" only="{{ element }}"></api-viewer>
-    </vaadin-split-layout>
+    <div data-demo="{{ element }}">{{ demo | safe }}</div>
+    <api-viewer src="{{ manifest }}" only="{{ element }}"></api-viewer>
   </main>
 </body>
 

--- a/tools/pfe-tools/esbuild.ts
+++ b/tools/pfe-tools/esbuild.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'esbuild';
 import type { Meta as LitCSSModuleMeta } from '@pwrs/lit-css';
+import type { LitCSSOptions } from 'esbuild-plugin-lit-css';
 
 import esbuild from 'esbuild';
 import glob from 'glob';
@@ -8,7 +9,7 @@ import CleanCSS from 'clean-css';
 
 import { externalSubComponents } from './esbuild-plugins/external-sub-components.js';
 import { packageVersion } from './esbuild-plugins/package-version.js';
-import { LitCSSOptions, litCssPlugin } from 'esbuild-plugin-lit-css';
+import { litCssPlugin } from 'esbuild-plugin-lit-css';
 
 import { minifyHTMLLiteralsPlugin } from 'esbuild-plugin-minify-html-literals';
 import { nodeExternalsPlugin } from 'esbuild-node-externals';


### PR DESCRIPTION
## What I did
- deprecate the `width` attribute in favour of `variant`
- implement many `--pf-` css variables
- remove _all_ `--pfe-` css variables

## Testing Instructions
- Load up the deploy preview for this branch
- Load up [PatternFly v4 Modal](https://www.patternfly.org/v4/components/modal/)
- Compare and contrast
- Read over the [docs](https://deploy-preview-2036--patternfly-elements.netlify.app/components/modal/) and see if anything's missing or no longer relevant

## Notes to reviewers
This PR is *BREAKING*. It aligns pfe-modal with pfv4. the previously-pfe-specific styles and APIs will be moved over to https://github.com/RedHat-UX/red-hat-design-system/pull/288
So dip into the percy tests to see if anything wild broke
