### PR TITLE
fix(modal): returnValue type

### DIFF
--- a/.changeset/curly-pears-retire.md
+++ b/.changeset/curly-pears-retire.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-modal": patch
+---
+
+Fix the type of `returnValue`

--- a/elements/pfe-modal/pfe-modal.ts
+++ b/elements/pfe-modal/pfe-modal.ts
@@ -105,7 +105,7 @@ export class PfeModal extends LitElement implements HTMLDialogElement {
   @property() trigger?: string;
 
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue */
-  public returnValue?: string;
+  public returnValue = '';
 
   @query('#overlay') private overlay?: HTMLElement | null;
   @query('#dialog') private dialog?: HTMLElement | null;


### PR DESCRIPTION
## What I did
- change the type of modal's `returnValue` to string from string | undefined, in line with `HTMLDialogElement`