### PR TITLE
docs(card): fix demo layout in dev server

### DIFF
--- a/elements/pfe-card/demo/demo.css
+++ b/elements/pfe-card/demo/demo.css
@@ -1,5 +1,6 @@
 :host,
-body {
+body,
+[data-demo] {
   padding: 1em;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, calc(25% - 32px)));


### PR DESCRIPTION
## What I did
- apply grid styles to the demo container in the card demo
## Testing instructions
1. run the dev server
2. http://localhost:8000/demo/card/
3. Observe a grid layout with gap between cards