### PR TITLE
docs: point to next dist tag

### DIFF
--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -43,7 +43,7 @@ tags:
   Once again, if we were building this app locally, we’d install our dependencies from npm using yarn.
 
   ```bash
-  yarn add @patternfly/pfe-card @patternfly/pfe-cta
+  yarn add @patternfly/pfe-card@next @patternfly/pfe-cta@next
   ```
   But if you’re using CodeSandbox, just search for "@patternfly/pfe-card" and "@patternfly/pfe-cta".
 
@@ -101,7 +101,7 @@ tags:
   If we were building this app locally, we’d install our dependencies from npm using yarn.
 
   ```bash
-  yarn add @patternfly/pfe-accordion
+  yarn add @patternfly/pfe-accordion@next
   ```
 
   If you’re using CodeSandbox, just search for “@patternfly/pfe-accordion”.
@@ -372,7 +372,7 @@ tags:
   we’d install our dependencies from npm using yarn.
 
   ```bash
-  yarn add @patternfly/pfe-styles
+  yarn add @patternfly/pfe-styles@next
   ```
 
   If you’re using CodeSandbox, search for “@patternfly/pfe-styles”.

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -41,7 +41,7 @@ tags:
   Once again, if we were building this app locally, we’d install our dependencies from npm.
 
   ```bash
-  npm install --save @patternfly/pfe-card @patternfly/pfe-cta
+  npm install --save @patternfly/pfe-card@next @patternfly/pfe-cta@next
   ```
 
   But if you’re using CodeSandbox, just search for “@patternfly/pfe-card” and “@patternfly/pfe-cta”.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -16,8 +16,8 @@ title: Get started
   you’d like as a dependency of your project like this:
 
   ```shell
-  npm install --save @patternfly/pfe-card
-  npm install --save @patternfly/pfe-cta
+  npm install --save @patternfly/pfe-card@next
+  npm install --save @patternfly/pfe-cta@next
   ```
 
   This will install not only the pfe-card and pfe-cta, but also the core utilities and styles,
@@ -35,8 +35,8 @@ title: Get started
   In this example, we load the [card](/components/card/) and [cta](/components/cta/) modules from [`https://unpkg.com`](https://unpkg.com).
 
   ```html
-  <script type="module" src="https://unpkg.com/@patternfly/pfe-card?module"></script>
-  <script type="module" src="https://unpkg.com/@patternfly/pfe-cta?module"></script>
+  <script type="module" src="https://unpkg.com/@patternfly/pfe-card@next?module"></script>
+  <script type="module" src="https://unpkg.com/@patternfly/pfe-cta@next?module"></script>
   ```
 
   <a id="in-an-app"></a>
@@ -185,7 +185,7 @@ title: Get started
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PatternFly Elements - Avoiding the FOUC</title>
     <!-- Add PFE core styles to the head -->
-    <link rel="stylesheet" href="https://jspm.dev/@patternfly/pfe-styles@2.0.0/pfe.min.css">
+    <link rel="stylesheet" href="https://jspm.dev/@patternfly/pfe-styles@next/pfe.min.css">
     <style>
       :root {
         /* Optional: customize the delay until the body is revealed regardless */
@@ -196,9 +196,9 @@ title: Get started
     </style>
     <!-- Add noscript styles to immediately reveal content when JavaScript is disabled -->
     <noscript>
-      <link rel="stylesheet" href="https://jspm.dev/@patternfly/pfe-styles@2.0.0/pfe--noscript.min.css">
+      <link rel="stylesheet" href="https://jspm.dev/@patternfly/pfe-styles@next/pfe--noscript.min.css">
     </noscript>
-    <script type="module" src="https://jspm.dev/@patternfly/pfe-band@2.0.0"></script>
+    <script type="module" src="https://jspm.dev/@patternfly/pfe-band@next"></script>
   </head>
   <!-- Add the unresolved attribute to the body tag -->
   <!-- The pfe-core library and pfe.min.css file automatically remove the unresolved attribute -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ templateEngineOverride: njk,md
 
 ```html
 <script type="module"
-        src="https://unpkg.com/@patternfly/pfe-card?module"></script>
+        src="https://unpkg.com/@patternfly/pfe-card@next?module"></script>
 <script type="module"
-        src="https://unpkg.com/@patternfly/pfe-cta?module"></script>
+        src="https://unpkg.com/@patternfly/pfe-cta@next?module"></script>
 
 <pfe-card color-palette="lightest">
   <h2 slot="header">Card component</h2>
@@ -89,7 +89,7 @@ templateEngineOverride: njk,md
           <div class="pfe-l-grid__item pfe-m-12-col pfe-m-8-col-on-md pfe-m-7-col-on-lg">
 
 ```shell
-npm install @patternfly/pfe-accordion
+npm install @patternfly/pfe-accordion@next
 ```
 
 ```jsx

--- a/docs/quick-start/index.md
+++ b/docs/quick-start/index.md
@@ -23,8 +23,8 @@ The template below utilizes [UNPKG](https://unpkg.com/) to deliver PatternFly El
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="PatternFly Elements - Quick start">
   <title>PatternFly Elements - Quick start</title>
-  <link rel="stylesheet" href="https://unpkg.com/@patternfly/pfe-styles/pfe.min.css">
-  <link rel="stylesheet" href="https://unpkg.com/@patternfly/pfe-styles/pfe-layouts.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/@patternfly/pfe-styles@next/pfe.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/@patternfly/pfe-styles@next/pfe-layouts.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700&family=Red+Hat+Text&display=swap" rel="stylesheet">
   <style>
     html,
@@ -38,11 +38,11 @@ The template below utilizes [UNPKG](https://unpkg.com/) to deliver PatternFly El
     }
   </style>
   <script type="module">
-    import "https://unpkg.com/@patternfly/pfe-card?module";
-    import "https://unpkg.com/@patternfly/pfe-band?module";
-    import "https://unpkg.com/@patternfly/pfe-cta?module";
-    import "https://unpkg.com/@patternfly/pfe-accordion?module";
-    import "https://unpkg.com/@patternfly/pfe-tabs?module";
+    import "https://unpkg.com/@patternfly/pfe-card@next?module";
+    import "https://unpkg.com/@patternfly/pfe-band@next?module";
+    import "https://unpkg.com/@patternfly/pfe-cta@next?module";
+    import "https://unpkg.com/@patternfly/pfe-accordion@next?module";
+    import "https://unpkg.com/@patternfly/pfe-tabs@next?module";
   </script>
 </head>
 <body unresolved>


### PR DESCRIPTION
## What I did
Advise site visitors to install the `@next` npm dist tag.

See https://github.com/patternfly/patternfly-elements/discussions/2071#discussioncomment-3265153