### PR TITLE
chore: fix netlify command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,9 @@
 [build.environment]
-  NPM_FLAGS = '--dry-run'
+  # used when netlify runs `npm install` before running the build commmand
+  # we don't want to use netlify's cache because its non-deterministic
+  # so we ignore scripts and don't actually install anything
+  # defering instead to the build command to run npm ci
+  NPM_FLAGS = '--dry-run --ignore-scripts'
 [build]
   command = "npm ci && npm run site"
 


### PR DESCRIPTION
use the --ignore-scripts npm flag when netlify runs `npm install` before running the build commmand
we don't want to use netlify's cache because its non-deterministic
so we ignore scripts and don't actually install anything
defering instead to the build command to run npm ci