### PR TITLE
fix(tools): include devserver webfonts

### DIFF
--- a/.changeset/tender-waves-bow.md
+++ b/.changeset/tender-waves-bow.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Include dev server webfonts in npm tarball

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -45,7 +45,7 @@
     "demo/**/*",
     "custom-elements.json",
     "**/*.LEGAL.txt",
-    "**/*.{njk,html,md,css}",
+    "**/*.{njk,html,md,css,woff,woff2}",
     "**/*.{js,cjs,d.ts,map}"
   ],
   "scripts": {


### PR DESCRIPTION
## What I did
- add dev server's web fonts to the npm tarball

In keeping with the theme from #2081 and #2080, i'm planning to merge this small change w/o review