### PR TITLE
fix(tools): serve changes to ts sources

### DIFF
--- a/.changeset/green-jobs-guess.md
+++ b/.changeset/green-jobs-guess.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Serve changes to TypeScript sources

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -221,7 +221,7 @@ function normalizeOptions(options?: PfeDevServerConfigOptions): PfeDevServerInte
   config.sourceControlURLPrefix ??= 'https://github.com/patternfly/patternfly-elements/tree/main/';
   config.demoURLPrefix ??= 'https://patternflyelements.org/';
   config.loadDemo ??= true;
-  config.watchFiles ??= '{elements,core}/**/*.{ts,js,css,scss,html}';
+  config.watchFiles ??= '{elements,core}/**/*.{css,scss,html}';
   config.litcssOptions ??= { include: /\.scss$/, transform: transformSass };
   return config as PfeDevServerInternalConfig;
 }


### PR DESCRIPTION
## What I did
- remove `.ts` files from the default `watchFiles` dev server config, as this somehow prevented wds from serving the updated content