### PR TITLE
docs(markdown): Updating docs page link to marked.js

### DIFF
--- a/elements/pfe-markdown/README.md
+++ b/elements/pfe-markdown/README.md
@@ -1,6 +1,6 @@
 # PatternFly Elements Markdown
      
-Use this element to take markdown and have it display as HTML. This element uses the [marked.js library](https://marked.js.org/#/README.md#README.md) to convert the markdown to HTML.
+Use this element to take markdown and have it display as HTML. This element uses the [marked.js library](https://marked.js.org/) to convert the markdown to HTML.
 
 Read more about Markdown in the [PatternFly Elements Markdown documentation](https://patternflyelements.org/components/markdown)
 

--- a/elements/pfe-markdown/pfe-markdown.ts
+++ b/elements/pfe-markdown/pfe-markdown.ts
@@ -9,7 +9,7 @@ import style from './pfe-markdown.scss';
 
 /**
  * Markdown takes markdown as input and displays it as HTML.
- * This element uses the [marked.js library](https://marked.js.org/#/README.md#README.md) to convert the markdown to HTML.
+ * This element uses the [marked.js library](https://marked.js.org/) to convert the markdown to HTML.
  *
  * @summary Takes markdown as input and displays it as HTML
  */


### PR DESCRIPTION
Changing the link to marked.js to now link to the homepage.  Previous page 404s now. 

https://deploy-preview-2100--patternfly-elements.netlify.app/components/markdown/