### PR TITLE
docs(datetime): fixing href & script tags in datetime docs

### DIFF
--- a/elements/pfe-datetime/demo/pfe-datetime.html
+++ b/elements/pfe-datetime/demo/pfe-datetime.html
@@ -1,4 +1,4 @@
-link rel="stylesheet" href="/core/pfe-styles/red-hat-font.min.css">
+<link rel="stylesheet" href="/core/pfe-styles/red-hat-font.min.css">
 <link rel="stylesheet" href="/core/pfe-styles/pfe-base.min.css">
 <link rel="stylesheet" href="/core/pfe-styles/pfe-context.min.css">
 <link rel="stylesheet" href="/core/pfe-styles/pfe-layouts.min.css">

--- a/elements/pfe-datetime/docs/pfe-datetime.md
+++ b/elements/pfe-datetime/docs/pfe-datetime.md
@@ -178,11 +178,9 @@
   const datetimeComponents = [...document.querySelectorAll(".overview-datetime")];
   const minutesAgo = document.querySelector("#minutesago");
   const date = new Date();
-
   datetimeComponents.forEach(component => {
     component.setAttribute("datetime", date);
     component.textContent = date;
   });
-
   minutesAgo.setAttribute('datetime', new Date(Date.now() - 600000).toString());
 </script>


### PR DESCRIPTION
Link to the stylesheet is broken for datetime. Script tag brings in < tag when spaces are put between lines so I went ahead and removed those. 

https://deploy-preview-2101--patternfly-elements.netlify.app/components/datetime/