### PR TITLE
feat(tools): config file

### DIFF
--- a/.changeset/chatty-cherries-rush.md
+++ b/.changeset/chatty-cherries-rush.md
@@ -1,0 +1,27 @@
+---
+"@patternfly/pfe-tools": minor
+---
+
+Adds an optional unified config file for custom elements manifest, dev server, and docs pages
+
+Create a `.pfe.config.json` file at the root of your project to customize the pfe tools builds.
+
+The default values are:
+
+```json
+{
+  "tagPrefix": "pfe",
+  "demoURLPrefix": "https://patternflyelements.org/",
+  "sourceControlURLPrefix": "https://github.com/patternfly/patternfly-elements/tree/main/",
+  "aliases": {},
+  "site": {
+    "title": "PatternFly Elements",
+    "description": "PatternFly Elements: A set of community-created web components based on PatternFly design.",
+    "favicon": "/brand/logo/svg/pfe-icon-blue.svg",
+    "logoUrl": "/brand/logo/svg/pfe-icon-white-shaded.svg",
+    "stylesheets": []
+  }
+}
+```
+
+See `@patternfly/pfe-tools/config.d.ts` for more information.

--- a/tools/pfe-tools/11ty/DocsPage.ts
+++ b/tools/pfe-tools/11ty/DocsPage.ts
@@ -1,12 +1,19 @@
-import type {
-  ClassMethod,
-} from 'custom-elements-manifest/schema';
+import type { PfeConfig } from '../config.js';
+import type { ClassMethod } from 'custom-elements-manifest/schema';
 
 import { fileURLToPath } from 'url';
 
 import { Manifest } from '../custom-elements-manifest/lib/Manifest.js';
 
+import slugify from 'slugify';
+
 import nunjucks, { Environment } from 'nunjucks';
+
+interface DocsPageOptions extends PfeConfig {
+  docsTemplatePath?: string;
+  tagName: string;
+  title?: string;
+}
 
 export interface RenderKwargs {
   title?: string;
@@ -62,14 +69,10 @@ export class DocsPage implements DocsPageRenderer {
 
   constructor(
     public manifest: Manifest,
-    options?: {
-      docsTemplatePath?: string;
-      tagName: string;
-      title?: string;
-  }) {
+    options?: DocsPageOptions) {
     this.tagName = options?.tagName ?? '';
     this.title = options?.title ?? Manifest.prettyTag(this.tagName);
-    this.slug = this.tagName.replace(/^\w+-/, '');
+    this.slug = slugify(options?.aliases?.[this.tagName] ?? this.tagName.replace(/^\w+-/, '')).toLowerCase();
     this.summary = this.manifest.getSummary(this.tagName);
     this.description = this.manifest.getDescription(this.tagName);
     this.templates = nunjucks.configure(DocsPage.#templatesDir);

--- a/tools/pfe-tools/11ty/plugins/types.ts
+++ b/tools/pfe-tools/11ty/plugins/types.ts
@@ -1,3 +1,4 @@
+import type { PfeConfig } from '@patternfly/pfe-tools/config';
 import type { Manifest } from '@patternfly/pfe-tools/custom-elements-manifest/lib/Manifest.js';
 
 export interface DemoRecord {
@@ -12,17 +13,7 @@ export interface DemoRecord {
   url: string;
 }
 
-export interface PluginOptions {
-  /** rootDir of the package. Default process.cwd() */
-  rootDir?: string;
-  /** object mapping custom element name to page title */
-  aliases?: Record<string, string> ;
-  /** absolute URL to the web page representing the repo root in source control, with trailing slash. default 'https://github.com/patternfly/patternfly-elements/tree/main/' */
-  sourceControlURLPrefix?: string ;
-  /** absolute URL prefix for demos, with trailing slash. Default 'https://patternflyelements.org/' */
-  demoURLPrefix?: string ;
-  /** custom elements namespace. Default 'pfe' */
-  tagPrefix?: string;
+export interface PluginOptions extends PfeConfig {
   /** list of extra demo records not included in the custom-elements-manifest. Default [] */
   extraDemos?: DemoRecord[]
 }

--- a/tools/pfe-tools/README.md
+++ b/tools/pfe-tools/README.md
@@ -2,6 +2,41 @@
 
 Tools and utilities for building PatternFly Elements and other design systems.
 
+## Config
+
+Repos using pfe-tools can customize the docs pages, dev server, and custom-elements manifest
+generator by adding a `.pfe.config.json` file to the repository root.
+
+That file can contain the following properties:
+
+```ts
+interface PfeConfig {
+  /** custom elements namespace. Default 'pfe' */
+  tagPrefix?: string;
+  /** absolute URL to the web page representing the repo root in source control, with trailing slash. default 'https://github.com/patternfly/patternfly-elements/tree/main/' */
+  sourceControlURLPrefix?: string ;
+  /** absolute URL prefix for demos, with trailing slash. Default 'https://patternflyelements.org/' */
+  demoURLPrefix?: string ;
+  /** rootDir of the package. Default process.cwd() */
+  rootDir?: string;
+  /** object mapping custom element name to page title */
+  aliases?: Record<string, string> ;
+  /** Dev Server site options */
+  site?: {
+    /** The site's default page description */
+    description?: string;
+    /** URL to the site's favicon */
+    favicon?: string;
+    /** URL to the demo page's main brand logo */
+    logoUrl?: string;
+    /** URLs to stylesheets to add to the demo (absolute from cwd) */
+    stylesheets?: string[];
+    /** Title for main page of the demo */
+    title?: string;
+  };
+}
+```
+
 ## 11ty Helpers
 
 Helpers for collating and rendering

--- a/tools/pfe-tools/config.ts
+++ b/tools/pfe-tools/config.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface SiteOptions {
+  /** The site's default page description */
+  description?: string;
+  /** URL to the site's favicon */
+  favicon?: string;
+  /** URL to the demo page's main brand logo */
+  logoUrl?: string;
+  /** URLs to stylesheets to add to the demo (absolute from cwd) */
+  stylesheets?: string[];
+  /** Title for main page of the demo */
+  title?: string;
+}
+
+export interface PfeConfig {
+  /** rootDir of the package. Default process.cwd() */
+  rootDir?: string;
+  /** object mapping custom element name to page title */
+  aliases?: Record<string, string> ;
+  /** absolute URL to the web page representing the repo root in source control, with trailing slash. default 'https://github.com/patternfly/patternfly-elements/tree/main/' */
+  sourceControlURLPrefix?: string ;
+  /** absolute URL prefix for demos, with trailing slash. Default 'https://patternflyelements.org/' */
+  demoURLPrefix?: string ;
+  /** custom elements namespace. Default 'pfe' */
+  tagPrefix?: string;
+  /** Dev Server site options */
+  site?: SiteOptions;
+}
+
+const SITE_DEFAULTS: Required<SiteOptions> = {
+  description: 'PatternFly Elements: A set of community-created web components based on PatternFly design.',
+  favicon: '/brand/logo/svg/pfe-icon-blue.svg',
+  logoUrl: '/brand/logo/svg/pfe-icon-white-shaded.svg',
+  stylesheets: [],
+  title: 'PatternFly Elements',
+};
+
+const DEFAULT_CONFIG: PfeConfig = {
+  demoURLPrefix: 'https://patternflyelements.org/',
+  sourceControlURLPrefix: 'https://github.com/patternfly/patternfly-elements/tree/main/',
+  tagPrefix: 'pfe',
+  aliases: {},
+};
+
+function tryJson(path: string) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function getPfeConfig(rootDir = process.cwd()): Required<PfeConfig> {
+  const jsonConfig = tryJson(join(rootDir, '.pfe.config.json'));
+  return {
+    ...DEFAULT_CONFIG,
+    rootDir,
+    ...jsonConfig,
+    site: {
+      ...SITE_DEFAULTS,
+      ...jsonConfig.site ?? {}
+    }
+  };
+}

--- a/tools/pfe-tools/custom-elements-manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest.ts
@@ -1,4 +1,5 @@
 import type { Config } from '@custom-elements-manifest/analyzer';
+import type { PfeConfig } from './config.js';
 
 import { moduleFileExtensionsPlugin } from 'cem-plugin-module-file-extensions';
 import { readonlyPlugin } from 'cem-plugin-readonly';
@@ -10,17 +11,16 @@ import { sanitizeEventsPlugin } from './custom-elements-manifest/sanitize-events
 import { summaryPlugin } from './custom-elements-manifest/summary.js';
 import { ecmaPrivateClassMembersPlugin } from './custom-elements-manifest/ecma-private-class-members.js';
 import { versionStaticFieldPlugin } from './custom-elements-manifest/version-static-field.js';
+import { getPfeConfig } from './config.js';
 
-interface Options extends Config {
-  sourceControlURLPrefix?: string;
-  demoURLPrefix?: string;
-}
+type Options = Config & Pick<PfeConfig, 'sourceControlURLPrefix'|'demoURLPrefix'>;
 
 /**
  * PFE Default custom-elements-manifest analyzer config
  */
 export function pfeCustomElementsManifestConfig(options?: Options): Config {
-  const { demoURLPrefix, sourceControlURLPrefix, dev } = options ?? {};
+  const config = getPfeConfig();
+  const { demoURLPrefix, sourceControlURLPrefix, dev } = { ...config, ...options ?? {} };
   return {
     globs: options?.globs ?? ['src/**/*.ts'],
     dev,

--- a/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
@@ -1,3 +1,4 @@
+import type { PfeConfig } from '@patternfly/pfe-tools/config.js';
 import type {
   Attribute,
   ClassField,
@@ -258,14 +259,10 @@ export class Manifest {
       ?.flatMap?.(x => x?.demos ?? []) ?? [];
   }
 
-  getDemoMetadata(tagName: string, options: {
-    rootDir: string;
-    demoURLPrefix: string;
-    sourceControlURLPrefix: string;
-    tagPrefix: string;
-  }): DemoRecord[] {
+  getDemoMetadata(tagName: string, options: Required<PfeConfig>): DemoRecord[] {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const manifest = this;
+    const { prettyTag } = Manifest;
     return this.getDemos(tagName).map(demo => {
       const permalink = demo.url.replace(options.demoURLPrefix, '/');
       const [, slug = ''] = permalink.match(/\/components\/(.*)\/demo/) ?? [];
@@ -273,11 +270,21 @@ export class Manifest {
       const filePath = demo.source?.href.replace(options.sourceControlURLPrefix, `${options.rootDir}/`) ?? '';
       const [last = ''] = filePath.split('/').reverse();
       const filename = last.replace('.html', '');
-      const title = this.getTagNames().includes(filename) ? Manifest.prettyTag(tagName) : last
+      const isMainElementDemo = this.getTagNames().includes(filename);
+      const title = isMainElementDemo ? options.aliases[tagName] ?? prettyTag(tagName) : last
         .replace(/(?:^|[-/\s])\w/g, x => x.toUpperCase())
         .replace(/-/g, ' ')
         .replace('.html', '');
-      return { tagName, primaryElementName, permalink, slug, title, filePath, manifest, ...demo };
+      return {
+        tagName,
+        primaryElementName,
+        permalink,
+        slug,
+        title,
+        filePath,
+        manifest,
+        ...demo
+      };
     });
   }
 }


### PR DESCRIPTION
## What I did
Adds an optional unified config file for custom elements manifest, dev server, and docs pages

Create a `.pfe.config.json` file at the root of your project to customize the pfe tools builds.

The default values are:

```json
{
  "tagPrefix": "pfe",
  "demoURLPrefix": "https://patternflyelements.org/",
  "sourceControlURLPrefix": "https://github.com/patternfly/patternfly-elements/tree/main/",
  "aliases": {},
  "site": {
    "title": "PatternFly Elements",
    "description": "PatternFly Elements: A set of community-created web components based on PatternFly design.",
    "favicon": "/brand/logo/svg/pfe-icon-blue.svg",
    "logoUrl": "/brand/logo/svg/pfe-icon-white-shaded.svg",
    "stylesheets": []
  }
}
```

See `@patternfly/pfe-tools/config.ts` for more information.

This file is consulted when generating
- custom elements manifests
- the dev server ui
- docs pages

And this config will let us also easily specify aliases for components e.g. `rh-cta` => `Call to Action`

## YTHO

see https://github.com/RedHat-UX/red-hat-design-system/pull/495