### PR TITLE
fix: change element name referencing function from private to protected

### DIFF
--- a/elements/pfe-progress-steps/pfe-progress-steps.ts
+++ b/elements/pfe-progress-steps/pfe-progress-steps.ts
@@ -31,7 +31,7 @@ export class PfeProgressSteps extends LitElement {
 
   private _resizeObserver = new ResizeObserver(this._build);
 
-  private get stepItems() {
+  protected get stepItems() {
     return [...this.querySelectorAll('pfe-progress-steps-item')];
   }
 


### PR DESCRIPTION
### What has changed and why

- File: `elements/pfe-progress-steps/pfe-progress-steps.ts`
- Change: function `stepItems()` from `private` to `protected`
- Why: The private function uses a DOM querySelector to reference a PFE child element by name. Because the method is private, it cannot be overridden by a classes that extend PfeProgressSteps with the intention of changing element prefixes (e.g. `pfe-progress-steps-item` to `my-progress-steps-item`). In our case it is useful to override PFE classes and change the prefix to help ensure our corporate user base uses our customizations and does not inadvertently use the PFE elements directly. As such, any private methods that make reference to the element names should be protected. There may be more cases across the code base where this occurs, but this is the only element we're working with right now.
