### PR TITLE
chore(label): exclude certain files from npm package

### DIFF
--- a/elements/pfe-label/package.json
+++ b/elements/pfe-label/package.json
@@ -44,6 +44,19 @@
     "design systems",
     "web components"
   ],
+  "files": [
+    "!*.ts",
+    "custom-elements.json",
+    "**/*.LEGAL.txt",
+    "**/*.css",
+    "**/*.d.ts",
+    "**/*.js",
+    "**/*.js.map",
+    "!custom-elements-manifest.config.js",
+    "!demo/*",
+    "!docs/*",
+    "!test/*"
+  ],
   "dependencies": {
     "@patternfly/pfe-button": "^2.0.0-next.5",
     "@patternfly/pfe-core": "^2.0.0-next.8",


### PR DESCRIPTION
## What I did

1. Added `files` block to `package.json` with file type exclusions.

```json
  "files": [
    "!*.ts",
    "custom-elements.json",
    "**/*.LEGAL.txt",
    "**/*.css",
    "**/*.d.ts",
    "**/*.js",
    "**/*.js.map",
    "!custom-elements-manifest.config.js",
    "!demo/*",
    "!docs/*",
    "!test/*"
  ],
  ```

## Testing instructions

Not testable until deployed to npm.  
