### PR TITLE
fix(tools):  remove esbuild target configuration

### DIFF
--- a/.changeset/calm-trains-tie.md
+++ b/.changeset/calm-trains-tie.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Removed esbuild target configuration relying on tsconfig.json for configuration options.

--- a/tools/pfe-tools/dev-server.ts
+++ b/tools/pfe-tools/dev-server.ts
@@ -263,7 +263,6 @@ export function pfeDevServerConfig(options?: PfeDevServerConfigOptions): DevServ
       // serve typescript sources as javascript
       esbuildPlugin({
         ts: true,
-        target: 'es2022',
         tsconfig,
       }),
 


### PR DESCRIPTION
### What I did

Removed esbuild target configuration relying on tsconfig.json for configuration options.

### Testing Instructions

1. Checkout branch
2. Run `npm start`
3. Validate working components
4. Closes #2166 

### Todo
- [x] update downstream repo (RHDS) with correct `pfeDevServerConfig` to include `tsconfig.json`

Reference: https://github.com/RedHat-UX/red-hat-design-system/issues/568

