### PR TITLE
chore: fix netlify build by adding plugin-local-install-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ core/pfe-core/demo/*
 /test
 browserstack.err
 !docs/demo/web-dev-server.demo.config.js
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,10 @@
   command = "npm ci && npm run site"
 
 [[plugins]]
-  package = "/tools/netlify-plugin-github-actions"
+  package = "@netlify/plugin-local-install-core"
+
+[[plugins]]
+  package = "netlify-plugin-github-actions"
 
   [plugins.inputs]
     owner = "patternfly"


### PR DESCRIPTION
Attempting to fix the Netlify build by following the guidance here:
https://github.com/netlify/build/issues/1640

The issue with the local plugin is that the dependencies are not installed. The additional plugin should fix the issue.