### PR TITLE
chore: remove netlify visual regression workflow

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,17 +7,6 @@
 [build]
   command = "npm ci && npm run site"
 
-[[plugins]]
-  package = "@netlify/plugin-local-install-core"
-
-[[plugins]]
-  package = "netlify-plugin-github-actions"
-
-  [plugins.inputs]
-    owner = "patternfly"
-    repository = "patternfly-elements"
-    workflowId = "visual-regression.yml"
-
 [[redirects]]
   from = '/v1/*'
   to = 'https://release-v1--patternfly-elements.netlify.app/:splat'

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "husky": "^8.0.1",
         "leasot": "^13.2.0",
         "lerna": "^5.4.2",
-        "netlify-plugin-github-actions": "^0.0.2-next.0",
         "npm-merge-driver": "^2.3.6",
         "open": "^8.4.0",
         "prompts": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "husky": "^8.0.1",
     "leasot": "^13.2.0",
     "lerna": "^5.4.2",
-    "netlify-plugin-github-actions": "^0.0.2-next.0",
     "npm-merge-driver": "^2.3.6",
     "open": "^8.4.0",
     "prompts": "^2.4.2",


### PR DESCRIPTION
Previous attempts to fix the netlify build all failed. At this point the best thing to do is remove the visual-regression workflow trigger (which we're anyways not really using) so that we can deploy from main.