### PR TITLE
fix(accordion): :bug: updating the icon in BaseAccordionHeader

### DIFF
--- a/.changeset/odd-lamps-rescue.md
+++ b/.changeset/odd-lamps-rescue.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-accordion": patch
+---
+
+Updating pfe-accordion to match the new pfe-icon spec and include a customizable icon-set.

--- a/.changeset/odd-lamps-rescue.md
+++ b/.changeset/odd-lamps-rescue.md
@@ -2,4 +2,4 @@
 "@patternfly/pfe-accordion": patch
 ---
 
-Updating pfe-accordion to match the new pfe-icon spec and include a customizable icon-set.
+Uses latest version of `<pfe-icon>` internally.

--- a/elements/pfe-accordion/BaseAccordion.ts
+++ b/elements/pfe-accordion/BaseAccordion.ts
@@ -14,7 +14,6 @@ import {
 } from '@patternfly/pfe-core/decorators.js';
 
 import { NumberListConverter, ComposedEvent } from '@patternfly/pfe-core';
-import { deprecatedCustomEvent } from '@patternfly/pfe-core/functions/deprecatedCustomEvent.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
 import style from './BaseAccordion.scss';

--- a/elements/pfe-accordion/BaseAccordionHeader.ts
+++ b/elements/pfe-accordion/BaseAccordionHeader.ts
@@ -40,7 +40,9 @@ export abstract class BaseAccordionHeader extends LitElement {
 
   @property({ reflect: true }) bordered?: 'true'|'false';
 
-  @property({ reflect: true }) icon? = 'web-icon-caret-thin-right';
+  @property({ reflect: true }) icon? = 'angle-right';
+
+  @property({ reflect: true, attribute: 'icon-set' }) iconSet? = 'fas';
 
   @observed
   @property({ type: Boolean, reflect: true }) expanded = false;
@@ -114,6 +116,7 @@ export abstract class BaseAccordionHeader extends LitElement {
               icon="${ifDefined(this.icon)}"
               on-fail="collapse"
               part="icon"
+              set="${ifDefined(this.iconSet)}"
               class="icon"
               size="1x"
           ></pfe-icon>

--- a/elements/pfe-accordion/BaseAccordionHeader.ts
+++ b/elements/pfe-accordion/BaseAccordionHeader.ts
@@ -40,9 +40,9 @@ export abstract class BaseAccordionHeader extends LitElement {
 
   @property({ reflect: true }) bordered?: 'true'|'false';
 
-  @property({ reflect: true }) icon? = 'angle-right';
+  @property({ reflect: true }) icon?: string;
 
-  @property({ reflect: true, attribute: 'icon-set' }) iconSet? = 'fas';
+  @property({ reflect: true, attribute: 'icon-set' }) iconSet?: string;
 
   @observed
   @property({ type: Boolean, reflect: true }) expanded = false;
@@ -113,10 +113,9 @@ export abstract class BaseAccordionHeader extends LitElement {
             </span>
             `}
           <pfe-icon
-              icon="${ifDefined(this.icon)}"
-              on-fail="collapse"
+              icon="${this.icon ?? 'angle-right'}"
               part="icon"
-              set="${ifDefined(this.iconSet)}"
+              set="${this.iconSet ?? 'fas'}"
               class="icon"
               size="1x"
           ></pfe-icon>

--- a/elements/pfe-jump-links/demo/pfe-jump-links.js
+++ b/elements/pfe-jump-links/demo/pfe-jump-links.js
@@ -11,7 +11,7 @@ import { installRouter } from 'pwa-helpers/router.js';
  */
 async function route(location = window.location, event) {
   event?.preventDefault();
-  event?.stopPropagating();
+  event?.stopPropagation();
   if (location.hash) {
     root?.querySelector(location.hash)?.scrollIntoView({ behavior: 'smooth' });
   }


### PR DESCRIPTION
Updating the icon in BaseAccordionHeader as it was built for the previous pfe-icon spec and this will follow the new one with a customizable set attribute. 

### Related issues

- #2182

### What has changed and why

- Changed the default icon string that is used in BaseAccordionHeader along with adding an icon-set attribute to the component for compability with pfe-icon.
- Updated the pfe-jump-links.js because it is throwing an error currently in the console log that I noticed while testing.
