### PR TITLE
fix(tabs): many refactors

### DIFF
--- a/core/pfe-core/functions/isElementInView.ts
+++ b/core/pfe-core/functions/isElementInView.ts
@@ -1,17 +1,18 @@
-/** This function returns whether or not an element is within the viewable area of a container. If partial is true,
+/**
+ * This function returns whether or not an element is within the viewable area of a container. If partial is true,
  * then this function will return true even if only part of the element is in view.
  *
- * @param {HTMLElement} container  The container to check if the element is in view of.
- * @param {HTMLElement} element    The element to check if it is view
- * @param {boolean} partial   true if partial view is allowed
- * @param {boolean} strict    true if strict mode is set, never consider the container width and element width
+ * @param container  The container to check if the element is in view of.
+ * @param element    The element to check if it is view
+ * @param partial   true if partial view is allowed
+ * @param strict    true if strict mode is set, never consider the container width and element width
  *
- * @returns { boolean } True if the component is in View.
+ * @returns True if the component is in View.
  */
 export function isElementInView(
   container: HTMLElement,
   element: HTMLElement,
-  partial: boolean,
+  partial = false,
   strict = false
 ): boolean {
   if (!container || !element) {
@@ -25,7 +26,9 @@ export function isElementInView(
   const elementBoundsRight = Math.floor(elementBounds.right);
 
   // Check if in view
-  const isTotallyInView = elementBoundsLeft >= containerBoundsLeft && elementBoundsRight <= containerBoundsRight;
+  const isTotallyInView =
+    elementBoundsLeft >= containerBoundsLeft &&
+    elementBoundsRight <= containerBoundsRight;
   const isPartiallyInView =
     (partial || (!strict && containerBounds.width < elementBounds.width)) &&
     ((elementBoundsLeft < containerBoundsLeft && elementBoundsRight > containerBoundsLeft) ||

--- a/elements/pfe-tabs/BaseTab.scss
+++ b/elements/pfe-tabs/BaseTab.scss
@@ -1,22 +1,6 @@
 :host {
   display: flex;
   flex: none;
-  scroll-snap-align: var(--pf-c-tabs__item--ScrollSnapAlign, end);
-}
-
-:host([active]) {
-  --pf-c-tabs__link--Color: var(--pf-c-tabs__item--m-current__link--Color,  var(--pf-global--Color--100, #151515));
-  --pf-c-tabs__link--after--BorderColor: var(--pf-c-tabs__item--m-current__link--after--BorderColor, var(--pf-global--active-color--100, #06c));
-  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__item--m-current__link--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
-}
-
-:host([box][active]) {
-  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
-  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--BackgroundColor, transparent);
-}
-
-:host(.first[box][active]) #current::before {
-  left: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
 }
 
 :host([vertical]) [part="text"] {
@@ -28,23 +12,11 @@ button {
   margin: 0;
   font-family: inherit;
   font-size: 100%;
-  line-height: var(--pf-global--LineHeight--md, 1.5);
-  color: var(--pf-global--Color--100, #151515);
   border: 0;
   position: relative;
   display: flex;
   flex: 1;
-  padding:
-    var(--pf-c-tabs__link--PaddingTop, var(--pf-global--spacer--sm, 0.5rem))
-    var(--pf-c-tabs__link--PaddingRight, var(--pf-global--spacer--md, 1rem))
-    var(--pf-c-tabs__link--PaddingBottom, var(--pf-global--spacer--sm, 0.5rem))
-    var(--pf-c-tabs__link--PaddingLeft, var(--pf-global--spacer--md, 1rem));
-  font-size: var(--pf-c-tabs__link--FontSize, var(--pf-global--FontSize--md, 1rem));
-  color: var(--pf-c-tabs__link--Color, var(--pf-global--Color--200, #6a6e73));
   text-decoration: none;
-  outline-offset: var(--pf-c-tabs__link--OutlineOffset, calc(-1 * 0.375rem));
-  --pf-c-tabs__link--after--BorderBottomWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
-  background-color: var(--pf-c-tabs__link--BackgroundColor, transparent);
   cursor: pointer;
 }
 
@@ -64,42 +36,6 @@ button::after {
 
 button::before {
   pointer-events: none;
-  border-block-start-width: var(--pf-c-tabs__link--before--BorderTopWidth, 0);
-  border-inline-end-width: var(--pf-c-tabs__link--before--BorderRightWidth, 0);
-  border-block-end-width: var(--pf-c-tabs__link--before--BorderBottomWidth, 0);
-  border-inline-start-width: var(--pf-c-tabs__link--before--BorderLeftWidth, 0);
-  border-block-start-color: var(--pf-c-tabs__link--before--BorderTopColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
-  border-inline-end-color: var(--pf-c-tabs__link--before--BorderRightColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
-  border-block-end-color: var(--pf-c-tabs__link--before--BorderBottomColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
-  border-inline-start-color: var(--pf-c-tabs__link--before--BorderLeftColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
-}
-
-
-
-button::after {
-  top: var(--pf-c-tabs__link--after--Top, auto);
-  right: var(--pf-c-tabs__link--after--Right, 0);
-  bottom: var(--pf-c-tabs__link--after--Bottom, 0);
-  left: var(--pf-c-tabs__link--before--Left, 0);
-  border-color: var(--pf-c-tabs__link--after--BorderColor, var(--pf-global--BorderColor--light-100, #b8bbbe));
-  border-block-start-width:  var(--pf-c-tabs__link--after--BorderTopWidth, 0);
-  border-inline-end-width: var(--pf-c-tabs__link--after--BorderRightWidth, 0);
-  border-block-end-width: var(--pf-c-tabs__link--after--BorderBottomWidth);
-  border-inline-start-width: var(--pf-c-tabs__link--after--BorderLeftWidth);
-}
-
-button:hover {
-  --pf-c-tabs__link-toggle-icon--Color: var(--pf-c-tabs__link--hover__toggle-icon--Color);
-  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--hover--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
-}
-
-button:focus,
-button:focus-visible {
-  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--focus--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
-}
-
-button:active {
-  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--active--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
 }
 
 :host([fill]) button {
@@ -107,62 +43,10 @@ button:active {
   justify-content: center;
 }
 
-:host([box]) button {
-  --pf-c-tabs__link--after--BorderTopWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
-}
-
-:host([box]) button,
-:host([vertical]) button {
-  --pf-c-tabs__link--after--BorderBottomWidth: 0;
-}
-
-:host([vertical]) button {
-  --pf-c-tabs__link--after--Bottom: 0;
-  --pf-c-tabs__link--after--BorderTopWidth: 0;
-  --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
-  max-width: 100%;
-  text-align: left;
-}
-
-:host([box][vertical]) button::after {
-  top: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
-}
-
-:host(.first[box][vertical]) button::after,
-:host([box][vertical][active]) button::after {
-  top: 0;
-}
-
-:host(.first[box][active]) button::before {
-  border-inline-start-width: var(--pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth,  var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-}
-
-:host(.last[box][active]) button::before {
-  border-inline-end-width: var(--pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-}
-
 :host(:disabled) button {
   pointer-events: none;
 }
 
-:host([disabled]) button,
-:host([aria-disabled="true"]) button {
-  --pf-c-tabs__link--Color: var(--pf-c-tabs__link--disabled--Color,  var(--pf-global--disabled-color--100, #6a6e73));
-  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__link--disabled--BackgroundColor, var(--pf-global--palette--black-150, #f5f5f5));
-  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 0);
-  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--disabled--before--BorderBottomWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-  --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--disabled--before--BorderLeftWidth, 0);
-  --pf-c-tabs__link--after--BorderWidth: 0;
-}
-
 :host([aria-disabled="true"]) button {
   cursor: default;
-}
-
-[part="icon"] {
-  margin-inline-end: var(--pf-c-tabs__link--child--MarginRight, var(--pf-global--spacer--md, 1rem));
-}
-
-[part="icon"]:last-child {
-  --pf-c-tabs__link--child--MarginRight: 0;
 }

--- a/elements/pfe-tabs/BaseTab.ts
+++ b/elements/pfe-tabs/BaseTab.ts
@@ -29,6 +29,15 @@ export abstract class BaseTab extends LitElement {
   @observed
   @property({ reflect: true, type: Boolean }) disabled = false;
 
+  #internals = this.attachInternals();
+
+  get ariaDisabled() {
+    return this.#internals.ariaDisabled;
+  }
+
+  get ariaSelected() {
+    return this.#internals.ariaSelected;
+  }
 
   connectedCallback() {
     super.connectedCallback();
@@ -52,7 +61,7 @@ export abstract class BaseTab extends LitElement {
   }
 
   #clickHandler() {
-    if (!this.disabled && this.ariaDisabled !== 'true') {
+    if (!this.disabled && this.#internals.ariaDisabled !== 'true') {
       this.active = true;
     }
   }
@@ -64,10 +73,10 @@ export abstract class BaseTab extends LitElement {
     }
     if (newVal && !this.disabled) {
       this.removeAttribute('tabindex');
-      this.ariaSelected = 'true';
+      this.#internals.ariaSelected = 'true';
     } else {
       this.tabIndex = -1;
-      this.ariaSelected = 'false';
+      this.#internals.ariaSelected = 'false';
     }
     this.dispatchEvent(new TabExpandEvent(newVal, this));
   }
@@ -81,11 +90,7 @@ export abstract class BaseTab extends LitElement {
     // if a tab is removed from disabled its not necessarily
     // not still aria-disabled so we don't remove the aria-disabled
     if (newVal === true) {
-      this.ariaDisabled = 'true';
+      this.#internals.ariaDisabled = 'true';
     }
-  }
-
-  setAriaControls(id: string): void {
-    this.setAttribute('aria-controls', id);
   }
 }

--- a/elements/pfe-tabs/BaseTab.ts
+++ b/elements/pfe-tabs/BaseTab.ts
@@ -12,7 +12,7 @@ export class TabExpandEvent extends ComposedEvent {
     public active: boolean,
     public tab: BaseTab,
   ) {
-    super('tab-expand');
+    super('expand');
   }
 }
 

--- a/elements/pfe-tabs/BaseTab.ts
+++ b/elements/pfe-tabs/BaseTab.ts
@@ -20,7 +20,8 @@ export abstract class BaseTab extends LitElement {
 
   static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
-  @queryAssignedElements({ slot: 'icon', flatten: true }) _icons!: Array<HTMLElement>;
+  @queryAssignedElements({ slot: 'icon', flatten: true })
+  private icons!: Array<HTMLElement>;
 
   @observed
   @property({ reflect: true, type: Boolean }) active = false;
@@ -28,19 +29,19 @@ export abstract class BaseTab extends LitElement {
   @observed
   @property({ reflect: true, type: Boolean }) disabled = false;
 
-  @state() _hasIcons = false;
-
-  #logger = new Logger(this);
 
   connectedCallback() {
     super.connectedCallback();
+    this.setAttribute('role', 'tab');
     this.addEventListener('click', this.#clickHandler);
   }
 
   render() {
     return html`
       <button part="button" role="tab">
-        <span part="icon" ?hidden="${this._hasIcons}">
+        <span part="icon"
+              ?hidden="${!this.icons.length}"
+              @slotchange="${() => this.requestUpdate()}">
           <slot name="icon"></slot>
         </span>
         <span part="text">
@@ -50,19 +51,10 @@ export abstract class BaseTab extends LitElement {
     `;
   }
 
-  firstUpdated(): void {
-    this.#updateAccessibility();
-    this._hasIcons = this._icons.length === 0;
-  }
-
   #clickHandler() {
     if (!this.disabled && this.ariaDisabled !== 'true') {
       this.active = true;
     }
-  }
-
-  #updateAccessibility(): void {
-    this.setAttribute('role', 'tab');
   }
 
   @bound

--- a/elements/pfe-tabs/BaseTab.ts
+++ b/elements/pfe-tabs/BaseTab.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property, query, queryAssignedElements, state } from 'lit/decorators.js';
 
-import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 import { ComposedEvent } from '@patternfly/pfe-core';
 import { bound, observed } from '@patternfly/pfe-core/decorators.js';
 
@@ -19,7 +18,7 @@ export class TabExpandEvent extends ComposedEvent {
 export abstract class BaseTab extends LitElement {
   static readonly styles = [style];
 
-  @query('button') _button!: HTMLButtonElement;
+  static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
   @queryAssignedElements({ slot: 'icon', flatten: true }) _icons!: Array<HTMLElement>;
 
@@ -96,9 +95,5 @@ export abstract class BaseTab extends LitElement {
 
   setAriaControls(id: string): void {
     this.setAttribute('aria-controls', id);
-  }
-
-  focusButton(): void {
-    this._button.focus();
   }
 }

--- a/elements/pfe-tabs/BaseTabPanel.scss
+++ b/elements/pfe-tabs/BaseTabPanel.scss
@@ -1,3 +1,7 @@
-:host([box="light"]) {
-  background-color: var(--pf-c-tab-content--m-light-300, var(--pf-global--BackgroundColor--light-300, #f0f0f0));
+:host {
+  display: block;
+}
+
+:host([hidden]) {
+  display: none;
 }

--- a/elements/pfe-tabs/BaseTabPanel.ts
+++ b/elements/pfe-tabs/BaseTabPanel.ts
@@ -17,17 +17,7 @@ export abstract class BaseTabPanel extends LitElement {
   }
 
   firstUpdated() {
-    this.#upgradeAccessibility();
-  }
-
-  #upgradeAccessibility(): void {
     this.setAttribute('role', 'tabpanel');
     this.tabIndex = 0;
-  }
-
-  setAriaLabelledBy(id: string): void {
-    if (!this.hasAttribute('aria-labelledby')) {
-      this.setAttribute('aria-labelledby', id);
-    }
   }
 }

--- a/elements/pfe-tabs/BaseTabPanel.ts
+++ b/elements/pfe-tabs/BaseTabPanel.ts
@@ -5,10 +5,7 @@ import style from './BaseTabPanel.scss';
 export abstract class BaseTabPanel extends LitElement {
   static readonly styles = [style];
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.hidden = true;
-  }
+  hidden = true;
 
   render() {
     return html`

--- a/elements/pfe-tabs/BaseTabs.scss
+++ b/elements/pfe-tabs/BaseTabs.scss
@@ -5,9 +5,6 @@
 [part="tabs-container"] {
   position: relative;
   display: flex;
-  width: var(--pf-c-tabs--Width, auto);
-  padding-inline-end: var(--pf-c-tabs--inset, 0);
-  padding-inline-start: var(--pf-c-tabs--inset, 0);
   overflow: hidden;
 }
 
@@ -16,12 +13,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  border-color: var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2));
   border-style: solid;
-  border-block-start-width: var(--pf-c-tabs--before--BorderTopWidth, 0);
-  border-inline-end-width: var(--pf-c-tabs--before--BorderRightWidth, 0);
-  border-block-end-width:  var(--pf-c-tabs--before--BorderBottomWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-  border-inline-start-width: var(--pf-c-tabs--before--BorderLeftWidth, 0);
 }
 
 :host([fill]) [part="tabs"] {
@@ -30,14 +22,6 @@
 
 :host([fill]) ::slotted(pfe-tab) {
   flex-grow: 1;
-}
-
-:host([fill]) ::slotted(pfe-tab:first-of-type) {
-  --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
-}
-
-:host([fill]) ::slotted(pfe-tab:last-of-type) {
-  --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: 0;
 }
 
 :host button {
@@ -54,117 +38,6 @@
   translate: 0 0;
 }
 
-// workaround to disable scroll right button when last tab is aria-disabled
-::slotted(pfe-tab[aria-disabled=true]:last-of-type) {
-  translate: calc(-1 * var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px)) 0;
-}
-// workaround to disable scroll left button when first tab is aria-disabled
-::slotted(pfe-tab[aria-disabled=true]:first-of-type) {
-  translate: var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px) 0;
-}
-
-:host([box]) [part="tabs-container"] {
-  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor, var(--pf-global--BackgroundColor--200, #f0f0f0));
-  --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-box__link--disabled--BackgroundColor, var(--pf-global--disabled-color--200, #d2d2d2));
-  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--after--Top: 0;
-  --pf-c-tabs__link--after--Bottom: auto;
-}
-
-:host([box]) ::slotted(pfe-tab:last-of-type) {
-  --pf-c-tabs__link--before--BorderRightWidth: 0;
-}
-
-:host([box]) button:nth-of-type(2)::before {
-  left: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
-}
-
-:host([box]) pfe-tab[aria-selected="true"] + pfe-tab {
-  --pf-c-tabs__link--before--Left: 0;
-}
-
-:host([box="light"]) [part="tabs-container"] {
-  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__link--BackgroundColor, transparent);
-  --pf-c-tabs__item--m-current__link--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--light-300, #f0f0f0));
-  --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__link--disabled--BackgroundColor, var(--pf-global--palette--black-150, #f5f5f5));
-}
-
-:host([vertical]) [part="tabs-container"] {
-  --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width, 100%);
-  --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset, var(--pf-global--spacer--lg, 1.5rem));
-  --pf-c-tabs--before--BorderBottomWidth: 0;  // *override user setting* border bottom should always be 0 for vertical tabs
-  --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop, var(--pf-global--spacer--md, 1rem));
-  --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom, var(--pf-global--spacer--md, 1rem));
-  --pf-c-tabs__link--before--Left: 0;
-  --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0; // *override user setting* border bottom for disabled should always be 0 for vertical tabs
-  --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--after--Top: 0;
-  --pf-c-tabs__link--after--Right: auto;
-
-  display: inline-flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 0;
-  overflow: visible;
-}
-
-:host([vertical]) [part="tabs"] {
-  position: relative;
-  flex-direction: column;
-  flex-grow: 1;
-  max-width: var(--pf-c-tabs--m-vertical--MaxWidth, 15.625rem);
-}
-
-:host([vertical]) [part="tabs"]::before {
-  position: absolute;
-  right: auto;
-  border-style: solid;
-  border-color: var(--pf-c-tabs--m-vertical__list--before--BorderColor, var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2)));
-  border-block-start-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth, 0);
-  border-inline-end-width: var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth, 0);
-  border-block-end-width: var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth, 0);
-  border-inline-start-width: var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-}
-
-:host([vertical]) ::slotted(pfe-tab:first-of-type) {
-  margin-block-start: var(--pf-c-tabs--inset, 0);
-}
-
-:host([vertical]) ::slotted(pfe-tab:last-of-type) {
-  margin-block-end: var(--pf-c-tabs--inset, 0);
-}
-
-:host([box][vertical]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset, var(--pf-global--spacer--xl, 2rem));
-  --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0; // *override user setting* border left should be 0 for vertical box;
-  --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  // --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0; // *override user setting* border left should be 0 for disabled ;
-}
-
-:host([box][vertical]) [part="tabs"]::before {
-  right: 0;
-  left: auto;
-}
-
-:host([box][vertical]) ::slotted(pfe-tab:last-of-type) {
-  --pf-c-tabs__link--before--BorderBottomWidth: 0;
-  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-}
-
-:host([box][vertical]) ::slotted(pfe-tab[aria-selected="true"]) {
-  --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
-  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2));
-  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-}
-
-:host([box][vertical]) ::slotted(pfe-tab[aria-selected="true"]:first-of-type) {
-  --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-}
-
 :host([overflow]) [part="tabs-container"] ,
 :host([overflow]) [part="tabs"] {
   overflow: visible;
@@ -173,7 +46,6 @@
 [part="tabs"] {
   scrollbar-width: none;
   position: relative;
-  display: var(--pf-c-tabs__list--Display, flex);
   max-width: 100%;
   overflow-x: auto;
 }
@@ -201,243 +73,23 @@ button,
 
 button {
   flex: none;
-  width: var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem));
   line-height: 1;
-  color: var(--pf-c-tabs__scroll-button--Color, var(--pf-global--Color--100, #151515));
-  background-color: var(--pf-c-tabs__scroll-button--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
-  outline-offset: var(--pf-c-tabs__scroll-button--OutlineOffset, calc(-1 * var(--pf-global--spacer--xs, 0.25rem)));
   opacity: 0;
-  transition:
-    margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin, .125s),
-    translate var(--pf-c-tabs__scroll-button--TransitionDuration--transform, .125s), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity, .125s);
-}
-
-button:hover {
-  --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--hover--Color, var(--pf-global--active-color--100, #06c));
 }
 
 button::before {
-  border-color: var(--pf-c-tabs__scroll-button--before--BorderColor, var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2)));
   border-block-start-width: 0;
-  border-inline-end-width: var(--pf-c-tabs__scroll-button--before--BorderRightWidth, 0);
-  border-block-end-width: var(--pf-c-tabs__scroll-button--before--BorderBottomWidth, var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
-  border-inline-start-width: var(--pf-c-tabs__scroll-button--before--BorderLeftWidth, 0);
 }
 
 button:nth-of-type(1) {
-  --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  margin-inline-end: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
   translate: -100% 0;
 }
 
 button:nth-of-type(2) {
-  --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
-  margin-inline-start: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
   translate: 100% 0;
 }
 
 button:disabled {
-  --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--disabled--Color, var(--pf-global--disabled-color--200, #d2d2d2));
   pointer-events: none;
 }
 
-:host(:not([inset], :not[vertical])) [part="tabs-container"] {
-  --pf-c-tabs--inset: 0;
-  --pf-c-tabs--m-vertical--inset: 0;
-  --pf-c-tabs--m-vertical--m-box--inset: 0;
-}
-
-:host([inset="sm"]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-}
-
-:host([inset="md"]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-}
-
-:host([inset="lg"]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-}
-
-:host([inset="xl"]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-}
-
-:host([inset="2xl"]) [part="tabs-container"] {
-  --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-}
-
-@media screen and (min-width: 576px) {
-  :host([inset="sm"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-  }
-
-  :host([inset="md"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-  }
-
-  :host([inset="lg"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-  }
-
-  :host([inset="xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-  }
-
-  :host([inset="2xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-  }
-}
-
-@media screen and (min-width: 768px) {
-  :host([inset="sm"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-  }
-
-  :host([inset="md"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-  }
-
-  :host([inset="lg"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-  }
-
-  :host([inset="xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-  }
-
-  :host([inset="2xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-  }
-}
-
-@media screen and (min-width: 992px) {
-  :host([inset="sm"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-  }
-
-  :host([inset="md"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-  }
-
-  :host([inset="lg"]) {
-    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-  }
-
-  :host([inset="xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-  }
-
-  :host([inset="2xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-  }
-}
-
-@media screen and (min-width: 1200px) {
-  [part="tabs-container"] {
-    --pf-c-tabs__scroll-button--Width: var(--pf-c-tabs__scroll-button--xl--Width, var(--pf-global--spacer--3xl, 4rem));
-    // --pf-c-tabs--m-page-insets--inset: var(--pf-c-tabs--m-page-insets--xl--inset);
-  }
-
-  :host([inset="sm"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-  }
-
-  :host([inset="md"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-  }
-
-  :host([inset="lg"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-  }
-
-  :host([inset="xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-  }
-
-  :host([inset="2xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-  }
-}
-
-@media (min-width: 1450px) {
-  :host([inset="sm"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
-  }
-
-  :host([inset="md"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
-  }
-
-  :host([inset="lg"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
-  }
-
-  :host([inset="xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
-  }
-
-  :host([inset="2xl"]) [part="tabs-container"] {
-    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
-    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
-  }
-}

--- a/elements/pfe-tabs/BaseTabs.scss
+++ b/elements/pfe-tabs/BaseTabs.scss
@@ -46,12 +46,21 @@
 
 :host button:nth-of-type(1) {
   margin-inline-end: 0;
-  transform: translateX(0);
+  translate: 0 0;
 }
 
 :host button:nth-of-type(2) {
   margin-inline-start: 0;
-  transform: translateX(0);
+  translate: 0 0;
+}
+
+// workaround to disable scroll right button when last tab is aria-disabled
+::slotted(pfe-tab[aria-disabled=true]:last-of-type) {
+  translate: calc(-1 * var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px)) 0;
+}
+// workaround to disable scroll left button when first tab is aria-disabled
+::slotted(pfe-tab[aria-disabled=true]:first-of-type) {
+  translate: var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px) 0;
 }
 
 :host([box]) [part="tabs-container"] {
@@ -198,7 +207,9 @@ button {
   background-color: var(--pf-c-tabs__scroll-button--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
   outline-offset: var(--pf-c-tabs__scroll-button--OutlineOffset, calc(-1 * var(--pf-global--spacer--xs, 0.25rem)));
   opacity: 0;
-  transition: margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin, .125s), transform var(--pf-c-tabs__scroll-button--TransitionDuration--transform, .125s), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity, .125s);
+  transition:
+    margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin, .125s),
+    translate var(--pf-c-tabs__scroll-button--TransitionDuration--transform, .125s), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity, .125s);
 }
 
 button:hover {
@@ -216,13 +227,13 @@ button::before {
 button:nth-of-type(1) {
   --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
   margin-inline-end: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
-  transform: translateX(-100%);
+  translate: -100% 0;
 }
 
 button:nth-of-type(2) {
   --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
   margin-inline-start: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
-  transform: translateX(100%);
+  translate: 100% 0;
 }
 
 button:disabled {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
 
+import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 import { isElementInView } from '@patternfly/pfe-core/functions/isElementInView.js';
 
@@ -67,6 +68,8 @@ export abstract class BaseTabs extends LitElement {
 
   #activeIndex = 0;
 
+  id: string = this.id || getRandomId(this.localName);
+
   @property({ attribute: false })
   get activeIndex() {
     return this.#activeIndex;
@@ -106,9 +109,8 @@ export abstract class BaseTabs extends LitElement {
   }
 
   private set allTabs(tabs: BaseTab[]) {
-    tabs = tabs.filter(tab => BaseTabs.isTab(tab));
-    this.#allTabs = tabs;
-    this.#focusableTabs = tabs.filter(tab => !tab.disabled);
+    this.#allTabs = tabs.filter(tab => (this.constructor as typeof BaseTabs).isTab(tab));
+    this.#focusableTabs = this.#allTabs.filter(tab => !tab.disabled);
   }
 
   private get allPanels() {
@@ -116,8 +118,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   private set allPanels(panels: BaseTabPanel[]) {
-    panels = panels.filter(panel => BaseTabs.isPanel(panel));
-    this.#allPanels = panels;
+    this.#allPanels = panels.filter(panel => (this.constructor as typeof BaseTabs).isPanel(panel));
   }
 
   private get focusableTabs() {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -125,9 +125,9 @@ export abstract class BaseTabs extends LitElement {
     this.#focusTab?.focusButton();
   }
 
-  connectedCallback() {
+  override connectedCallback() {
     super.connectedCallback();
-    this.addEventListener('tab-expand', this.#onTabExpand);
+    this.addEventListener('expand', this.#onTabExpand);
     this.addEventListener('keydown', this.#onKeydown);
     BaseTabs.#instances.add(this);
   }
@@ -195,7 +195,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #onTabExpand = (event: Event): void => {
-    if (this.allTabs.length === 0) {
+    if (!(event instanceof TabExpandEvent) || this.allTabs.length === 0) {
       return;
     }
 

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -130,7 +130,7 @@ export abstract class BaseTabs extends LitElement {
 
   private set focusTab(tab: BaseTab | undefined) {
     this.#focusTab = tab;
-    this.#focusTab?.focusButton();
+    this.#focusTab?.focus();
   }
 
   override connectedCallback() {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -12,8 +12,6 @@ import style from './BaseTab.scss';
 export abstract class BaseTabs extends LitElement {
   static readonly styles = [style];
 
-  static readonly delay = 100;
-
   static isTab(element: BaseTab): element is BaseTab {
     return element instanceof BaseTab;
   }
@@ -23,6 +21,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   @queryAssignedElements({ slot: 'tab' }) protected _tabs!: BaseTab[];
+  protected static readonly scrollTimeoutDelay = 0;
 
   @queryAssignedElements() protected _panels!: BaseTabPanel[];
 
@@ -314,11 +313,10 @@ export abstract class BaseTabs extends LitElement {
     }
   };
 
-  #onScroll = ():void => {
+  #onScroll = () => {
     clearTimeout(this.#scrollTimeout);
-    this.#scrollTimeout = setTimeout(() => {
-      this.#isOverflow();
-    }, BaseTabs.delay);
+    const { scrollTimeoutDelay } = (this.constructor as typeof BaseTabs);
+    this.#scrollTimeout = setTimeout(() => this.#setOverflowState(), scrollTimeoutDelay);
   };
 
   #firstLastClasses() {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -173,8 +173,7 @@ export abstract class BaseTabs extends LitElement {
     `;
   }
 
-  async firstUpdated() {
-    await this.updateComplete;
+  firstUpdated() {
     if (this.activeIndex === -1) {
       this.activeIndex = 0;
     }
@@ -211,9 +210,8 @@ export abstract class BaseTabs extends LitElement {
       return;
     }
 
-    const target = event as TabExpandEvent;
-    if (target.active) {
-      this.activeIndex = this.allTabs.findIndex(tab => tab === target.tab);
+    if (event.active) {
+      this.activeIndex = this.allTabs.findIndex(tab => tab === event.tab);
       // close all tabs that are not the activeIndex
       this.#deactivateExcept(this.activeIndex);
     } else {
@@ -226,14 +224,8 @@ export abstract class BaseTabs extends LitElement {
   };
 
   #deactivateExcept(index: number) {
-    const notActiveTabs = this.allTabs.filter((tab, i) => i !== index);
-    notActiveTabs.forEach(tab => {
-      tab.active = false;
-    });
-    const notActivePanels = this.allPanels.filter((panel, i) => i !== index);
-    notActivePanels.forEach(panel => {
-      panel.hidden = true;
-    });
+    this.allTabs.forEach((tab, i) => tab.active = i === index);
+    this.allPanels.forEach((panel, i) => panel.hidden = i !== index);
   }
 
   #firstFocusable(): BaseTab {
@@ -245,14 +237,13 @@ export abstract class BaseTabs extends LitElement {
     return this.focusableTabs[this.focusableTabs.length - 1];
   }
 
-  #firstTab(): BaseTab {
+  get #firstTab(): BaseTab {
     const [tab] = this.allTabs;
     return tab;
   }
 
-  #lastTab(): BaseTab {
-    const tab = this.allTabs[this.allTabs.length - 1];
-    return tab;
+  get #lastTab(): BaseTab {
+    return this.allTabs.at(-1) as BaseTab;
   }
 
   #next(): void {
@@ -349,8 +340,8 @@ export abstract class BaseTabs extends LitElement {
   };
 
   #firstLastClasses() {
-    this.#firstTab().classList.add('first');
-    this.#lastTab().classList.add('last');
+    this.#firstTab.classList.add('first');
+    this.#lastTab.classList.add('last');
   }
 
   #setOverflowState(): void {
@@ -365,8 +356,7 @@ export abstract class BaseTabs extends LitElement {
     const childrenArr = this.allTabs;
     let firstElementInView: BaseTab | undefined;
     let lastElementOutOfView: BaseTab | undefined;
-    let i;
-    for (i = 0; i < childrenArr.length && !firstElementInView; i++) {
+    for (let i = 0; i < childrenArr.length && !firstElementInView; i++) {
       if (isElementInView(container, childrenArr[i] as HTMLElement, false)) {
         firstElementInView = childrenArr[i];
         lastElementOutOfView = childrenArr[i - 1];

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -9,6 +9,11 @@ import { BaseTabPanel } from './BaseTabPanel.js';
 
 import style from './BaseTab.scss';
 
+/**
+ * @attr [label-scroll-left="Scroll left"] - accessible label for the tab panel's scroll left button.
+ * @attr [label-scroll-right="Scroll right"] - accessible label for the tab panel's scroll right button.
+ *
+ */
 export abstract class BaseTabs extends LitElement {
   static readonly styles = [style];
 
@@ -155,7 +160,7 @@ export abstract class BaseTabs extends LitElement {
             <slot name="tab" @slotchange="${this.onSlotchange}"></slot>
           </div>${!this.#showScrollButtons ? '' : html`
           <button id="nextTab"
-              aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll right'}"
+              aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
               ?disabled="${!this.#overflowOnRight}"
               @click="${this.#scrollRight}">
             <pfe-icon icon="${scrollIconRight}" set="${scrollIconSet}" loading="eager"></pfe-icon>

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -345,10 +345,16 @@ export abstract class BaseTabs extends LitElement {
     this.#lastTab.classList.add('last');
   }
 
+  /** override to prevent scroll buttons from showing */
+  protected get canShowScrollButtons() {
+    return true;
+  }
+
   #setOverflowState(): void {
-    this.#overflowOnLeft = !isElementInView(this.tabList, this.#firstTab);
-    this.#overflowOnRight = !isElementInView(this.tabList, this.#lastTab);
-    this.#showScrollButtons = (this.#overflowOnLeft || this.#overflowOnRight);
+    const { canShowScrollButtons } = this;
+    this.#overflowOnLeft = canShowScrollButtons && !isElementInView(this.tabList, this.#firstTab);
+    this.#overflowOnRight = canShowScrollButtons && !isElementInView(this.tabList, this.#lastTab);
+    this.#showScrollButtons = canShowScrollButtons && (this.#overflowOnLeft || this.#overflowOnRight);
     this.requestUpdate();
   }
 

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -81,24 +81,25 @@ export abstract class BaseTabs extends LitElement {
 
   set activeIndex(index: number) {
     const oldIndex = this.activeIndex;
-    let tab = this.allTabs[index];
-    if (tab === undefined || tab.disabled) {
-      if (tab === undefined) {
-        this.#logger.warn(`No active tab set, setting first focusable tab to active`);
-      } else {
-        this.#logger.warn(`Disabled tabs can not be set as active, setting first focusable tab to active`);
-      }
-      [tab] = this.#focusableTabs;
-      index = this.allTabs.findIndex(focusable => focusable === tab);
-      if (index === -1) {
-        this.#logger.warn(`No available tabs to activate`);
+    const tab = this.allTabs[index];
+    if (tab) {
+      if (tab.disabled) {
+        this.#logger.warn(`Disabled tabs can not be active, setting first focusable tab to active`);
+        this.#activate(this.#firstFocusable());
+        index = this.allTabs.findIndex(t => t === this.#firstFocusable());
+        return;
+      } else if (!tab.active) {
+        // if the activeIndex was set through the CLI e.g.`$0.activeIndex = 2`
+        tab.active = true;
         return;
       }
     }
-    tab.active = true;
-    this.allPanels[index].hidden = false;
-    this.#deactivateExcept(index);
-
+    if (index === -1) {
+      this.#logger.warn(`No active tab found, setting first focusable tab to active`);
+      this.#activate(this.#firstFocusable());
+      index = this.allTabs.findIndex(t => t === this.#firstFocusable());
+      return;
+    }
     this.#activeIndex = index;
     this.requestUpdate('activeIndex', oldIndex);
   }
@@ -174,10 +175,7 @@ export abstract class BaseTabs extends LitElement {
     `;
   }
 
-  firstUpdated() {
-    if (this.activeIndex === -1) {
-      this.activeIndex = 0;
-    }
+  async firstUpdated() {
     this.#onScroll();
     this.tabList.addEventListener('scroll', this.#onScroll);
   }
@@ -207,20 +205,17 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #onTabExpand = (event: Event): void => {
-    if (!(event instanceof TabExpandEvent) || this.allTabs.length === 0) {
+    if (!(event instanceof TabExpandEvent) ||
+        this.allTabs.length === 0 || this.allPanels.length === 0) {
       return;
     }
 
-    if (event.active) {
-      this.activeIndex = this.allTabs.findIndex(tab => tab === event.tab);
+    const target = event as TabExpandEvent;
+    if (target.active) {
+      this.activeIndex = this.allTabs.findIndex(tab => tab === target.tab);
+      this.allPanels[this.activeIndex].hidden = false;
       // close all tabs that are not the activeIndex
       this.#deactivateExcept(this.activeIndex);
-    } else {
-      if (this.activeTab === undefined) {
-        // if activeTab is invalid set to first focusable tab
-        const index = this.allTabs.findIndex(tab => tab === this.#firstFocusable());
-        this.activeIndex = index;
-      }
     }
   };
 
@@ -282,7 +277,7 @@ export abstract class BaseTabs extends LitElement {
   #currentIndex(): number {
     let current: BaseTab;
     // get current tab
-    if (this.focusTab?.ariaDisabled) {
+    if (this.focusTab?.ariaDisabled === 'true') {
       current = this.focusTab;
     } else {
       current = this.activeTab;
@@ -291,11 +286,14 @@ export abstract class BaseTabs extends LitElement {
     return index;
   }
 
-  #select(selectedTab: BaseTab): void {
-    if (!selectedTab.disabled) {
-      const index = this.#allTabs.findIndex(tab => tab === selectedTab);
-      this.activeIndex = index;
+  #activate(selectedTab: BaseTab): void {
+    if (selectedTab.ariaDisabled === null || selectedTab.ariaDisabled === 'false') {
+      selectedTab.active = true;
     }
+  }
+
+  #select(selectedTab: BaseTab): void {
+    this.#activate(selectedTab);
     this.focusTab = selectedTab;
   }
 
@@ -319,14 +317,12 @@ export abstract class BaseTabs extends LitElement {
 
       case 'Home':
         event.preventDefault();
-        this.activeIndex = this.allTabs.findIndex(tab => tab === this.#firstFocusable());
-        this.focusTab = this.#firstFocusable();
+        this.#select(this.#firstFocusable());
         break;
 
       case 'End':
         event.preventDefault();
-        this.activeIndex = this.allTabs.findIndex(tab => tab === this.#lastFocusable());
-        this.focusTab = this.#lastFocusable();
+        this.#select(this.#lastFocusable());
         break;
 
       default:

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -199,8 +199,10 @@ export abstract class BaseTabs extends LitElement {
   #updateAccessibility(): void {
     this.allTabs.forEach((tab, index) => {
       const panel = this.allPanels[index];
-      panel.setAriaLabelledBy(tab.id);
-      tab.setAriaControls(panel.id);
+      if (!panel.hasAttribute('aria-labelledby')) {
+        panel.setAttribute('aria-labelledby', tab.id);
+      }
+      tab.setAttribute('aria-controls', panel.id);
     });
   }
 

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -27,8 +27,17 @@ export abstract class BaseTabs extends LitElement {
   protected static readonly scrollIconSet = 'fas';
 
   @queryAssignedElements() protected _panels!: BaseTabPanel[];
+  static #instances = new Set<BaseTabs>();
 
   @query('[part="tabs"]') _tabList!: HTMLElement;
+  static {
+    // on resize check for overflows to add or remove scroll buttons
+    window.addEventListener('resize', () => {
+      for (const instance of this.#instances) {
+        instance.#onScroll();
+      }
+    }, { capture: false });
+  }
 
   @state() protected _showScrollButtons = false;
 
@@ -120,8 +129,12 @@ export abstract class BaseTabs extends LitElement {
     super.connectedCallback();
     this.addEventListener('tab-expand', this.#onTabExpand);
     this.addEventListener('keydown', this.#onKeydown);
-    // on resize check for overflows
-    window.addEventListener('resize', this.#onScroll, false);
+    BaseTabs.#instances.add(this);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    BaseTabs.#instances.delete(this);
   }
 
   override render() {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -22,6 +22,9 @@ export abstract class BaseTabs extends LitElement {
 
   @queryAssignedElements({ slot: 'tab' }) protected _tabs!: BaseTab[];
   protected static readonly scrollTimeoutDelay = 0;
+  protected static readonly scrollIconLeft = 'angle-left';
+  protected static readonly scrollIconRight = 'angle-right';
+  protected static readonly scrollIconSet = 'fas';
 
   @queryAssignedElements() protected _panels!: BaseTabPanel[];
 
@@ -122,22 +125,23 @@ export abstract class BaseTabs extends LitElement {
   }
 
   override render() {
+    const { scrollIconSet, scrollIconLeft, scrollIconRight } = this.constructor as typeof BaseTabs;
     return html`
       <div part="container">
         <div part="tabs-container">
           ${this._showScrollButtons ? html`
             <button id="previousTab" aria-label="Scroll left" ?disabled="${!this._overflowOnLeft}" @click="${this.#scrollLeft}">
-              <svg fill="currentColor" height="1em" width="1em" viewBox="0 0 256 512" aria-hidden="true" role="img" style="vertical-align: -0.125em;"><path d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"></path></svg>
             </button>`
           : html``}
+            <pfe-icon icon="${scrollIconLeft}" set="${scrollIconSet}" loading="eager"></pfe-icon>
           <div part="tabs" role="tablist">
             <slot name="tab" @slotchange="${this.onSlotchange}"></slot>
           </div>
           ${this._showScrollButtons ? html`
             <button id="nextTab" aria-label="Scroll right" ?disabled="${!this._overflowOnRight}" @click="${this.#scrollRight}">
-              <svg fill="currentColor" height="1em" width="1em" viewBox="0 0 256 512" aria-hidden="true" role="img" style="vertical-align: -0.125em;"><path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"></path></svg>
             </button>`
           : html``}
+            <pfe-icon icon="${scrollIconRight}" set="${scrollIconSet}" loading="eager"></pfe-icon>
         </div>
         <div part="panels">
           <slot @slotchange="${this.onSlotchange}"></slot>

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -20,16 +20,13 @@ export abstract class BaseTabs extends LitElement {
     return element instanceof BaseTabPanel;
   }
 
-  @queryAssignedElements({ slot: 'tab' }) protected _tabs!: BaseTab[];
   protected static readonly scrollTimeoutDelay = 0;
   protected static readonly scrollIconLeft = 'angle-left';
   protected static readonly scrollIconRight = 'angle-right';
   protected static readonly scrollIconSet = 'fas';
 
-  @queryAssignedElements() protected _panels!: BaseTabPanel[];
   static #instances = new Set<BaseTabs>();
 
-  @query('[part="tabs"]') _tabList!: HTMLElement;
   static {
     // on resize check for overflows to add or remove scroll buttons
     window.addEventListener('resize', () => {
@@ -40,10 +37,13 @@ export abstract class BaseTabs extends LitElement {
   }
 
   @state() protected _showScrollButtons = false;
+  @queryAssignedElements({ slot: 'tab' }) private tabs!: BaseTab[];
 
   @state() protected _overflowOnLeft = false;
+  @queryAssignedElements() private panels!: BaseTabPanel[];
 
   @state() protected _overflowOnRight = false;
+  @query('[part="tabs"]') private tabList!: HTMLElement;
 
   #logger = new Logger(this);
 
@@ -169,14 +169,14 @@ export abstract class BaseTabs extends LitElement {
       this.activeIndex = 0;
     }
     this.#onScroll();
-    this._tabList.addEventListener('scroll', this.#onScroll);
+    this.tabList.addEventListener('scroll', this.#onScroll);
   }
 
   protected onSlotchange(event: { target: { name: string; }; }) {
     if (event.target.name === 'tab') {
-      this.allTabs = this._tabs;
+      this.allTabs = this.tabs;
     } else {
-      this.allPanels = this._panels;
+      this.allPanels = this.panels;
     }
     if (this.allTabs.length === this.allPanels.length &&
       (this.allTabs.length !== 0 || this.allPanels.length !== 0)) {
@@ -348,7 +348,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #scrollLeft(): void {
-    const container = this._tabList;
+    const container = this.tabList;
     const childrenArr = this.allTabs;
     let firstElementInView: BaseTab | undefined;
     let lastElementOutOfView: BaseTab | undefined;
@@ -365,7 +365,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #scrollRight(): void {
-    const container = this._tabList;
+    const container = this.tabList;
     const childrenArr = this.allTabs;
     let lastElementInView: BaseTab | undefined;
     let firstElementOutOfView: BaseTab | undefined;

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -63,7 +63,7 @@ export abstract class BaseTabs extends LitElement {
 
   #focusTab?: BaseTab;
 
-  #scrollTimeout: ReturnType<typeof setTimeout> = setTimeout(() => '', 100);
+  #scrollTimeout?: ReturnType<typeof setTimeout>;
 
   #activeIndex = 0;
 

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -26,10 +26,14 @@ export abstract class BaseTabs extends LitElement {
     return element instanceof BaseTabPanel;
   }
 
-  protected static readonly scrollTimeoutDelay = 0;
-  protected static readonly scrollIconLeft = 'angle-left';
-  protected static readonly scrollIconRight = 'angle-right';
-  protected static readonly scrollIconSet = 'fas';
+  /** Time in milliseconds to debounce between scroll events and updating scroll button state */
+  protected static readonly scrollTimeoutDelay: number = 0;
+  /** Icon name to use for the scroll left button */
+  protected static readonly scrollIconLeft: string = 'angle-left';
+  /** Icon name to use for the scroll right button */
+  protected static readonly scrollIconRight: string = 'angle-right';
+  /** Icon set to use for the scroll buttons */
+  protected static readonly scrollIconSet: string = 'fas';
 
   static #instances = new Set<BaseTabs>();
 

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -88,7 +88,7 @@ export abstract class BaseTabs extends LitElement {
       } else {
         this.#logger.warn(`Disabled tabs can not be set as active, setting first focusable tab to active`);
       }
-      [tab] = this.focusableTabs;
+      [tab] = this.#focusableTabs;
       index = this.allTabs.findIndex(focusable => focusable === tab);
       if (index === -1) {
         this.#logger.warn(`No available tabs to activate`);
@@ -123,10 +123,6 @@ export abstract class BaseTabs extends LitElement {
 
   private set allPanels(panels: BaseTabPanel[]) {
     this.#allPanels = panels.filter(panel => (this.constructor as typeof BaseTabs).isPanel(panel));
-  }
-
-  private get focusableTabs() {
-    return this.#focusableTabs;
   }
 
   private get focusTab(): BaseTab | undefined {
@@ -234,12 +230,12 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #firstFocusable(): BaseTab {
-    const [firstTab] = this.focusableTabs;
+    const [firstTab] = this.#focusableTabs;
     return firstTab;
   }
 
   #lastFocusable(): BaseTab {
-    return this.focusableTabs[this.focusableTabs.length - 1];
+    return this.#focusableTabs.at(-1) as BaseTab;
   }
 
   get #firstTab(): BaseTab {
@@ -257,7 +253,7 @@ export abstract class BaseTabs extends LitElement {
     // increment focusable index and return focusable tab
     const nextFocusableIndex = currentIndex + 1;
     let nextTab: BaseTab;
-    if (nextFocusableIndex >= this.focusableTabs.length) {
+    if (nextFocusableIndex >= this.#focusableTabs.length) {
       // get the first focusable tab
       [nextTab] = this.#focusableTabs;
     } else {
@@ -291,12 +287,12 @@ export abstract class BaseTabs extends LitElement {
     } else {
       current = this.activeTab;
     }
-    const index = this.focusableTabs.findIndex(tab => tab === current);
+    const index = this.#focusableTabs.findIndex(tab => tab === current);
     return index;
   }
 
   #select(selectedTab: BaseTab): void {
-    if (selectedTab.ariaDisabled === null || selectedTab.ariaDisabled === 'false') {
+    if (!selectedTab.disabled) {
       const index = this.#allTabs.findIndex(tab => tab === selectedTab);
       this.activeIndex = index;
     }

--- a/elements/pfe-tabs/demo/pfe-tabs.html
+++ b/elements/pfe-tabs/demo/pfe-tabs.html
@@ -2,7 +2,7 @@
 <script type="module" src="./pfe-tabs.js"></script>
 
 <div class="example">
-  <h2 slot="header">Default</h2>
+  <h2>Default</h2>
   <pfe-tabs>
     <pfe-tab id="users" slot="tab">Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -18,7 +18,7 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Box</h2>
+  <h2>Box</h2>
   <pfe-tabs box="light">
     <pfe-tab slot="tab" active>Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -38,7 +38,7 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Default overflow</h2>
+  <h2>Default overflow</h2>
     <pfe-tabs id="overflow">
       <pfe-tab slot="tab">Users</pfe-tab>
       <pfe-tab-panel>Users</pfe-tab-panel>
@@ -60,7 +60,7 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Vertical</h2>
+  <h2>Vertical</h2>
   <pfe-tabs vertical>
     <pfe-tab slot="tab">Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -80,7 +80,7 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Inset</h2>
+  <h2>Inset</h2>
   <pfe-tabs inset="md">
     <pfe-tab slot="tab" active>Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -105,43 +105,25 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Icons and text</h2>
+  <h2>Icons and text</h2>
   <pfe-tabs>
-    <pfe-tab slot="tab">
-      <pfe-icon set="fas" icon="users" size="sm" loading="idle"></pfe-icon>
-      Users
-    </pfe-tab>
+    <pfe-tab slot="tab"> Users          <pfe-icon slot="icon" icon="users"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> Containers     <pfe-icon slot="icon" icon="box-open"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> Database       <pfe-icon slot="icon" icon="database"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> Server         <pfe-icon slot="icon" icon="server"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> System         <pfe-icon slot="icon" icon="laptop"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab" active> Network <pfe-icon slot="icon" icon="network-wired"></pfe-icon></pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img"><path d="M509.5 184.6L458.9 32.8C452.4 13.2 434.1 0 413.4 0H272v192h238.7c-.4-2.5-.4-5-1.2-7.4zM240 0H98.6c-20.7 0-39 13.2-45.5 32.8L2.5 184.6c-.8 2.4-.8 4.9-1.2 7.4H240V0zM0 224v240c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V224H0z"></path></svg>
-      Containers
-    </pfe-tab>
     <pfe-tab-panel>Containers</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 448 512" aria-hidden="true" role="img"><path d="M448 73.143v45.714C448 159.143 347.667 192 224 192S0 159.143 0 118.857V73.143C0 32.857 100.333 0 224 0s224 32.857 224 73.143zM448 176v102.857C448 319.143 347.667 352 224 352S0 319.143 0 278.857V176c48.125 33.143 136.208 48.572 224 48.572S399.874 209.143 448 176zm0 160v102.857C448 479.143 347.667 512 224 512S0 479.143 0 438.857V336c48.125 33.143 136.208 48.572 224 48.572S399.874 369.143 448 336z"></path></svg>
-      Database
-    </pfe-tab>
     <pfe-tab-panel>Database</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img"><path d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"></path></svg>
-      Server
-    </pfe-tab>
     <pfe-tab-panel>Server</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 640 512" aria-hidden="true" role="img"><path d="M624 416H381.54c-.74 19.81-14.71 32-32.74 32H288c-18.69 0-33.02-17.47-32.77-32H16c-8.8 0-16 7.2-16 16v16c0 35.2 28.8 64 64 64h512c35.2 0 64-28.8 64-64v-16c0-8.8-7.2-16-16-16zM576 48c0-26.4-21.6-48-48-48H112C85.6 0 64 21.6 64 48v336h512V48zm-64 272H128V64h384v256z"></path></svg>
-      System
-    </pfe-tab>
     <pfe-tab-panel>System</pfe-tab-panel>
-    <pfe-tab slot="tab" active>
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 640 512" aria-hidden="true" role="img"><path d="M384 320H256c-17.67 0-32 14.33-32 32v128c0 17.67 14.33 32 32 32h128c17.67 0 32-14.33 32-32V352c0-17.67-14.33-32-32-32zM192 32c0-17.67-14.33-32-32-32H32C14.33 0 0 14.33 0 32v128c0 17.67 14.33 32 32 32h95.72l73.16 128.04C211.98 300.98 232.4 288 256 288h.28L192 175.51V128h224V64H192V32zM608 0H480c-17.67 0-32 14.33-32 32v128c0 17.67 14.33 32 32 32h128c17.67 0 32-14.33 32-32V32c0-17.67-14.33-32-32-32z"></path></svg>
-      Network
-    </pfe-tab>
     <pfe-tab-panel>Network</pfe-tab-panel>
   </pfe-tabs>
 </div>
 
 <div class="example">
-  <h2 slot="header">Filled</h2>
+  <h2>Filled</h2>
   <pfe-tabs fill>
     <pfe-tab slot="tab">Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -153,28 +135,19 @@
 </div>
 
 <div class="example">
-  <h2 slot="header">Filled with icons</h2>
+  <h2>Filled with icons</h2>
   <pfe-tabs fill>
-    <pfe-tab slot="tab" active>
-      <svg slot="icon" slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 640 512" aria-hidden="true" role="img"><path d="M96 224c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm448 0c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm32 32h-64c-17.6 0-33.5 7.1-45.1 18.6 40.3 22.1 68.9 62 75.1 109.4h66c17.7 0 32-14.3 32-32v-32c0-35.3-28.7-64-64-64zm-256 0c61.9 0 112-50.1 112-112S381.9 32 320 32 208 82.1 208 144s50.1 112 112 112zm76.8 32h-8.3c-20.8 10-43.9 16-68.5 16s-47.6-6-68.5-16h-8.3C179.6 288 128 339.6 128 403.2V432c0 26.5 21.5 48 48 48h288c26.5 0 48-21.5 48-48v-28.8c0-63.6-51.6-115.2-115.2-115.2zm-223.7-13.4C161.5 263.1 145.6 256 128 256H64c-35.3 0-64 28.7-64 64v32c0 17.7 14.3 32 32 32h65.9c6.3-47.4 34.9-87.3 75.2-109.4z"></path></svg>
-      Users
-    </pfe-tab>
+    <pfe-tab slot="tab"> Users      <pfe-icon slot="icon" icon="users"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> Containers <pfe-icon slot="icon" icon="box-open"></pfe-icon></pfe-tab>
+    <pfe-tab slot="tab"> Database   <pfe-icon slot="icon" icon="database"></pfe-icon></pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img"><path d="M509.5 184.6L458.9 32.8C452.4 13.2 434.1 0 413.4 0H272v192h238.7c-.4-2.5-.4-5-1.2-7.4zM240 0H98.6c-20.7 0-39 13.2-45.5 32.8L2.5 184.6c-.8 2.4-.8 4.9-1.2 7.4H240V0zM0 224v240c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V224H0z"></path></svg>
-      Containers
-    </pfe-tab>
     <pfe-tab-panel>Containers</pfe-tab-panel>
-    <pfe-tab slot="tab">
-      <svg slot="icon" style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 448 512" aria-hidden="true" role="img"><path d="M448 73.143v45.714C448 159.143 347.667 192 224 192S0 159.143 0 118.857V73.143C0 32.857 100.333 0 224 0s224 32.857 224 73.143zM448 176v102.857C448 319.143 347.667 352 224 352S0 319.143 0 278.857V176c48.125 33.143 136.208 48.572 224 48.572S399.874 209.143 448 176zm0 160v102.857C448 479.143 347.667 512 224 512S0 479.143 0 438.857V336c48.125 33.143 136.208 48.572 224 48.572S399.874 369.143 448 336z"></path></svg>
-      Database
-    </pfe-tab>
     <pfe-tab-panel>Database</pfe-tab-panel>
   </pfe-tabs>
 </div>
 
 <div class="example">
-  <h2 slot="header">Active Key is Disabled</h2>
+  <h2>Active Key is Disabled</h2>
   <pfe-tabs id="disabledExample">
     <pfe-tab slot="tab">Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>
@@ -186,5 +159,38 @@
     <pfe-tab-panel>Disabled</pfe-tab-panel>
     <pfe-tab slot="tab" aria-disabled="true">Aria Disabled</pfe-tab>
     <pfe-tab-panel>Aria Disabled</pfe-tab-panel>
+  </pfe-tabs>
+</div>
+
+<div class="example">
+  <h2>Tabs first in markup</h2>
+  <pfe-tabs id="tabs-first">
+    <pfe-tab slot="tab">Users</pfe-tab>
+    <pfe-tab slot="tab">Containers</pfe-tab>
+    <pfe-tab slot="tab">Database</pfe-tab>
+    <pfe-tab slot="tab" disabled active>Disabled</pfe-tab>
+    <pfe-tab slot="tab" aria-disabled="true">Aria Disabled</pfe-tab>
+    <pfe-tab-panel>Users</pfe-tab-panel>
+    <pfe-tab-panel>Containers</pfe-tab-panel>
+    <pfe-tab-panel>Database</pfe-tab-panel>
+    <pfe-tab-panel>Disabled</pfe-tab-panel>
+    <pfe-tab-panel>Aria Disabled</pfe-tab-panel>
+  </pfe-tabs>
+</div>
+
+<div class="example">
+  <h2>Tabs with explicit relationships</h2>
+  <pfe-tabs id="explicit">
+    <pfe-tab slot="tab" aria-controls="panel-1">1</pfe-tab>
+    <pfe-tab slot="tab" aria-controls="panel-2">2</pfe-tab>
+    <pfe-tab slot="tab" aria-controls="panel-3">3</pfe-tab>
+    <pfe-tab slot="tab" aria-controls="panel-4">4</pfe-tab>
+    <pfe-tab slot="tab" aria-controls="panel-5">5</pfe-tab>
+
+    <pfe-tab-panel id="panel-5">5</pfe-tab-panel>
+    <pfe-tab-panel id="panel-4">4</pfe-tab-panel>
+    <pfe-tab-panel id="panel-3">3</pfe-tab-panel>
+    <pfe-tab-panel id="panel-2">2</pfe-tab-panel>
+    <pfe-tab-panel id="panel-1">1</pfe-tab-panel>
   </pfe-tabs>
 </div>

--- a/elements/pfe-tabs/demo/pfe-tabs.html
+++ b/elements/pfe-tabs/demo/pfe-tabs.html
@@ -147,7 +147,7 @@
 </div>
 
 <div class="example">
-  <h2>Active Key is Disabled</h2>
+  <h2 slot="header">Active Tab is Disabled</h2>
   <pfe-tabs id="disabledExample">
     <pfe-tab slot="tab">Users</pfe-tab>
     <pfe-tab-panel>Users</pfe-tab-panel>

--- a/elements/pfe-tabs/pfe-tab-panel.scss
+++ b/elements/pfe-tabs/pfe-tab-panel.scss
@@ -1,7 +1,3 @@
-:host {
-  display: block;
-}
-
-:host([hidden]) {
-  display: none;
+:host([box="light"]) {
+  background-color: var(--pf-c-tab-content--m-light-300, var(--pf-global--BackgroundColor--light-300, #f0f0f0));
 }

--- a/elements/pfe-tabs/pfe-tab.scss
+++ b/elements/pfe-tabs/pfe-tab.scss
@@ -1,3 +1,126 @@
+:host {
+  scroll-snap-align: var(--pf-c-tabs__item--ScrollSnapAlign, end);
+}
+
+:host([active]) {
+  --pf-c-tabs__link--Color: var(--pf-c-tabs__item--m-current__link--Color,  var(--pf-global--Color--100, #151515));
+  --pf-c-tabs__link--after--BorderColor: var(--pf-c-tabs__item--m-current__link--after--BorderColor, var(--pf-global--active-color--100, #06c));
+  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__item--m-current__link--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
+}
+
+:host([box][active]) {
+  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
+  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--BackgroundColor, transparent);
+}
+
+:host(.first[box][active]) #current::before {
+  left: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
+}
+
+button {
+  line-height: var(--pf-global--LineHeight--md, 1.5);
+  color: var(--pf-global--Color--100, #151515);
+  padding:
+    var(--pf-c-tabs__link--PaddingTop, var(--pf-global--spacer--sm, 0.5rem))
+    var(--pf-c-tabs__link--PaddingRight, var(--pf-global--spacer--md, 1rem))
+    var(--pf-c-tabs__link--PaddingBottom, var(--pf-global--spacer--sm, 0.5rem))
+    var(--pf-c-tabs__link--PaddingLeft, var(--pf-global--spacer--md, 1rem));
+  font-size: var(--pf-c-tabs__link--FontSize, var(--pf-global--FontSize--md, 1rem));
+  color: var(--pf-c-tabs__link--Color, var(--pf-global--Color--200, #6a6e73));
+  outline-offset: var(--pf-c-tabs__link--OutlineOffset, calc(-1 * 0.375rem));
+  --pf-c-tabs__link--after--BorderBottomWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
+  background-color: var(--pf-c-tabs__link--BackgroundColor, transparent);
+}
+
+button::before {
+  border-block-start-width: var(--pf-c-tabs__link--before--BorderTopWidth, 0);
+  border-inline-end-width: var(--pf-c-tabs__link--before--BorderRightWidth, 0);
+  border-block-end-width: var(--pf-c-tabs__link--before--BorderBottomWidth, 0);
+  border-inline-start-width: var(--pf-c-tabs__link--before--BorderLeftWidth, 0);
+  border-block-start-color: var(--pf-c-tabs__link--before--BorderTopColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
+  border-inline-end-color: var(--pf-c-tabs__link--before--BorderRightColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
+  border-block-end-color: var(--pf-c-tabs__link--before--BorderBottomColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
+  border-inline-start-color: var(--pf-c-tabs__link--before--BorderLeftColor,  var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2)));
+}
+
+button::after {
+  top: var(--pf-c-tabs__link--after--Top, auto);
+  right: var(--pf-c-tabs__link--after--Right, 0);
+  bottom: var(--pf-c-tabs__link--after--Bottom, 0);
+  left: var(--pf-c-tabs__link--before--Left, 0);
+  border-color: var(--pf-c-tabs__link--after--BorderColor, var(--pf-global--BorderColor--light-100, #b8bbbe));
+  border-block-start-width:  var(--pf-c-tabs__link--after--BorderTopWidth, 0);
+  border-inline-end-width: var(--pf-c-tabs__link--after--BorderRightWidth, 0);
+  border-block-end-width: var(--pf-c-tabs__link--after--BorderBottomWidth);
+  border-inline-start-width: var(--pf-c-tabs__link--after--BorderLeftWidth);
+}
+
+button:hover {
+  --pf-c-tabs__link-toggle-icon--Color: var(--pf-c-tabs__link--hover__toggle-icon--Color);
+  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--hover--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
+}
+
+button:focus,
+button:focus-visible {
+  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--focus--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
+}
+
+button:active {
+  --pf-c-tabs__link--after--BorderWidth: var(--pf-c-tabs__link--active--after--BorderWidth, var(--pf-global--BorderWidth--lg, 3px));
+}
+
+:host([box]) button {
+  --pf-c-tabs__link--after--BorderTopWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
+}
+
+:host([box]) button,
+:host([vertical]) button {
+  --pf-c-tabs__link--after--BorderBottomWidth: 0;
+}
+
+:host([vertical]) button {
+  --pf-c-tabs__link--after--Bottom: 0;
+  --pf-c-tabs__link--after--BorderTopWidth: 0;
+  --pf-c-tabs__link--after--BorderLeftWidth: var(--pf-c-tabs__link--after--BorderWidth, 0);
+  max-width: 100%;
+  text-align: left;
+}
+
+:host([box][vertical]) button::after {
+  top: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
+}
+
+:host(.first[box][vertical]) button::after,
+:host([box][vertical][active]) button::after {
+  top: 0;
+}
+
+:host(.first[box][active]) button::before {
+  border-inline-start-width: var(--pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth,  var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+}
+
+:host(.last[box][active]) button::before {
+  border-inline-end-width: var(--pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+}
+
+:host([disabled]) button,
+:host([aria-disabled="true"]) button {
+  --pf-c-tabs__link--Color: var(--pf-c-tabs__link--disabled--Color,  var(--pf-global--disabled-color--100, #6a6e73));
+  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs__link--disabled--BackgroundColor, var(--pf-global--palette--black-150, #f5f5f5));
+  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 0);
+  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--disabled--before--BorderBottomWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+  --pf-c-tabs__link--before--BorderLeftWidth: var(--pf-c-tabs__link--disabled--before--BorderLeftWidth, 0);
+  --pf-c-tabs__link--after--BorderWidth: 0;
+}
+
+[part="icon"] {
+  margin-inline-end: var(--pf-c-tabs__link--child--MarginRight, var(--pf-global--spacer--md, 1rem));
+}
+
+[part="icon"]:last-child {
+  --pf-c-tabs__link--child--MarginRight: 0;
+}
+
 :host([disabled][border-bottom="false"]) button,
 :host([aria-disabled="true"][border-bottom="false"]) button {
   --pf-c-tabs__link--before--BorderBottomWidth: 0;

--- a/elements/pfe-tabs/pfe-tabs.scss
+++ b/elements/pfe-tabs/pfe-tabs.scss
@@ -1,3 +1,379 @@
+[part="tabs-container"] {
+  width: var(--pf-c-tabs--Width, auto);
+  padding-inline-end: var(--pf-c-tabs--inset, 0);
+  padding-inline-start: var(--pf-c-tabs--inset, 0);
+}
+
+[part="tabs-container"]::before {
+  border-color: var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2));
+  border-block-start-width: var(--pf-c-tabs--before--BorderTopWidth, 0);
+  border-inline-end-width: var(--pf-c-tabs--before--BorderRightWidth, 0);
+  border-block-end-width:  var(--pf-c-tabs--before--BorderBottomWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+  border-inline-start-width: var(--pf-c-tabs--before--BorderLeftWidth, 0);
+}
+
+// workaround to disable scroll right button when last tab is aria-disabled
+::slotted(pfe-tab[aria-disabled=true]:last-of-type) {
+  translate: calc(-1 * var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px)) 0;
+}
+// workaround to disable scroll left button when first tab is aria-disabled
+::slotted(pfe-tab[aria-disabled=true]:first-of-type) {
+  translate: var(--pf-c-tabs__link--disabled--before--BorderRightWidth, 1px) 0;
+}
+
+:host([box]) [part="tabs-container"] {
+  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-box__link--BackgroundColor, var(--pf-global--BackgroundColor--200, #f0f0f0));
+  --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-box__link--disabled--BackgroundColor, var(--pf-global--disabled-color--200, #d2d2d2));
+  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--after--Top: 0;
+  --pf-c-tabs__link--after--Bottom: auto;
+}
+
+:host([box]) ::slotted(pfe-tab:last-of-type) {
+  --pf-c-tabs__link--before--BorderRightWidth: 0;
+}
+
+:host([box]) button:nth-of-type(2)::before {
+  left: calc(var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)) * -1);
+}
+
+:host([box]) pfe-tab[aria-selected="true"] + pfe-tab {
+  --pf-c-tabs__link--before--Left: 0;
+}
+
+:host([box="light"]) [part="tabs-container"] {
+  --pf-c-tabs__link--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__link--BackgroundColor, transparent);
+  --pf-c-tabs__item--m-current__link--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--light-300, #f0f0f0));
+  --pf-c-tabs__link--disabled--BackgroundColor: var(--pf-c-tabs--m-color-scheme--light-300__link--disabled--BackgroundColor, var(--pf-global--palette--black-150, #f5f5f5));
+}
+
+:host([vertical]) [part="tabs-container"] {
+  --pf-c-tabs--Width: var(--pf-c-tabs--m-vertical--Width, 100%);
+  --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--inset, var(--pf-global--spacer--lg, 1.5rem));
+  --pf-c-tabs--before--BorderBottomWidth: 0;  // *override user setting* border bottom should always be 0 for vertical tabs
+  --pf-c-tabs__link--PaddingTop: var(--pf-c-tabs--m-vertical__link--PaddingTop, var(--pf-global--spacer--md, 1rem));
+  --pf-c-tabs__link--PaddingBottom: var(--pf-c-tabs--m-vertical__link--PaddingBottom, var(--pf-global--spacer--md, 1rem));
+  --pf-c-tabs__link--before--Left: 0;
+  --pf-c-tabs__link--disabled--before--BorderBottomWidth: 0; // *override user setting* border bottom for disabled should always be 0 for vertical tabs
+  --pf-c-tabs__link--disabled--before--BorderLeftWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--after--Top: 0;
+  --pf-c-tabs__link--after--Right: auto;
+
+  display: inline-flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+  overflow: visible;
+}
+
+:host([vertical]) [part="tabs"] {
+  position: relative;
+  flex-direction: column;
+  flex-grow: 1;
+  max-width: var(--pf-c-tabs--m-vertical--MaxWidth, 15.625rem);
+}
+
+:host([vertical]) [part="tabs"]::before {
+  position: absolute;
+  right: auto;
+  border-style: solid;
+  border-color: var(--pf-c-tabs--m-vertical__list--before--BorderColor, var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2)));
+  border-block-start-width: var(--pf-c-tabs--m-vertical__list--before--BorderTopWidth, 0);
+  border-inline-end-width: var(--pf-c-tabs--m-vertical__list--before--BorderRightWidth, 0);
+  border-block-end-width: var(--pf-c-tabs--m-vertical__list--before--BorderBottomWidth, 0);
+  border-inline-start-width: var(--pf-c-tabs--m-vertical__list--before--BorderLeftWidth, var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+}
+
+:host([vertical]) ::slotted(pfe-tab:first-of-type) {
+  margin-block-start: var(--pf-c-tabs--inset, 0);
+}
+
+:host([vertical]) ::slotted(pfe-tab:last-of-type) {
+  margin-block-end: var(--pf-c-tabs--inset, 0);
+}
+
+:host([box][vertical]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-c-tabs--m-vertical--m-box--inset, var(--pf-global--spacer--xl, 2rem));
+  --pf-c-tabs--m-vertical__list--before--BorderLeftWidth: 0; // *override user setting* border left should be 0 for vertical box;
+  --pf-c-tabs--m-vertical__list--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--disabled--before--BorderRightWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  // --pf-c-tabs__link--disabled--before--BorderBottomWidth: var(--pf-c-tabs--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  --pf-c-tabs__link--disabled--before--BorderLeftWidth: 0; // *override user setting* border left should be 0 for disabled ;
+}
+
+:host([box][vertical]) [part="tabs"]::before {
+  right: 0;
+  left: auto;
+}
+
+:host([box][vertical]) ::slotted(pfe-tab:last-of-type) {
+  --pf-c-tabs__link--before--BorderBottomWidth: 0;
+  --pf-c-tabs__link--before--BorderRightWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+}
+
+:host([box][vertical]) ::slotted(pfe-tab[aria-selected="true"]) {
+  --pf-c-tabs__link--before--BorderRightColor: var(--pf-c-tabs__item--m-current__link--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
+  --pf-c-tabs__link--before--BorderBottomColor: var(--pf-c-tabs__link--before--border-color--base, var(--pf-global--BorderColor--100, #d2d2d2));
+  --pf-c-tabs__link--before--BorderBottomWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+}
+
+:host([box][vertical]) ::slotted(pfe-tab[aria-selected="true"]:first-of-type) {
+  --pf-c-tabs__link--before--BorderTopWidth: var(--pf-c-tabs__link--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+}
+
+[part="tabs"] {
+  display: var(--pf-c-tabs__list--Display, flex);
+}
+
+
+button {
+  width: var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem));
+  color: var(--pf-c-tabs__scroll-button--Color, var(--pf-global--Color--100, #151515));
+  background-color: var(--pf-c-tabs__scroll-button--BackgroundColor, var(--pf-global--BackgroundColor--100, #ffffff));
+  outline-offset: var(--pf-c-tabs__scroll-button--OutlineOffset, calc(-1 * var(--pf-global--spacer--xs, 0.25rem)));
+  transition:
+    margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin, .125s),
+    translate var(--pf-c-tabs__scroll-button--TransitionDuration--transform, .125s), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity, .125s);
+}
+
+button:hover {
+  --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--hover--Color, var(--pf-global--active-color--100, #06c));
+}
+
+button::before {
+  border-color: var(--pf-c-tabs__scroll-button--before--BorderColor, var(--pf-c-tabs--before--BorderColor, var(--pf-global--BorderColor--100, #d2d2d2)));
+  border-inline-end-width: var(--pf-c-tabs__scroll-button--before--BorderRightWidth, 0);
+  border-block-end-width: var(--pf-c-tabs__scroll-button--before--BorderBottomWidth, var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px)));
+  border-inline-start-width: var(--pf-c-tabs__scroll-button--before--BorderLeftWidth, 0);
+}
+
+button:nth-of-type(1) {
+  --pf-c-tabs__scroll-button--before--BorderRightWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  margin-inline-end: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
+}
+
+button:nth-of-type(2) {
+  --pf-c-tabs__scroll-button--before--BorderLeftWidth: var(--pf-c-tabs__scroll-button--before--border-width--base, var(--pf-global--BorderWidth--sm, 1px));
+  margin-inline-start: calc(var(--pf-c-tabs__scroll-button--Width, var(--pf-global--spacer--2xl, 3rem)) * -1);
+}
+
+button:disabled {
+  --pf-c-tabs__scroll-button--Color: var(--pf-c-tabs__scroll-button--disabled--Color, var(--pf-global--disabled-color--200, #d2d2d2));
+}
+
+:host(:not([inset], :not[vertical])) [part="tabs-container"] {
+  --pf-c-tabs--inset: 0;
+  --pf-c-tabs--m-vertical--inset: 0;
+  --pf-c-tabs--m-vertical--m-box--inset: 0;
+}
+
+:host([inset="sm"]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+}
+
+:host([inset="md"]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+}
+
+:host([inset="lg"]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+}
+
+:host([inset="xl"]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+}
+
+:host([inset="2xl"]) [part="tabs-container"] {
+  --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+  --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+  --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+}
+
+@media screen and (min-width: 576px) {
+  :host([inset="sm"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+  }
+
+  :host([inset="md"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+  }
+
+  :host([inset="lg"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+  }
+
+  :host([inset="xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+  }
+
+  :host([inset="2xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+  }
+}
+
+@media screen and (min-width: 768px) {
+  :host([inset="sm"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+  }
+
+  :host([inset="md"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+  }
+
+  :host([inset="lg"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+  }
+
+  :host([inset="xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+  }
+
+  :host([inset="2xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+  }
+}
+
+@media screen and (min-width: 992px) {
+  :host([inset="sm"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+  }
+
+  :host([inset="md"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+  }
+
+  :host([inset="lg"]) {
+    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+  }
+
+  :host([inset="xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+  }
+
+  :host([inset="2xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  [part="tabs-container"] {
+    --pf-c-tabs__scroll-button--Width: var(--pf-c-tabs__scroll-button--xl--Width, var(--pf-global--spacer--3xl, 4rem));
+    // --pf-c-tabs--m-page-insets--inset: var(--pf-c-tabs--m-page-insets--xl--inset);
+  }
+
+  :host([inset="sm"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+  }
+
+  :host([inset="md"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+  }
+
+  :host([inset="lg"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+  }
+
+  :host([inset="xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+  }
+
+  :host([inset="2xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+  }
+}
+
+@media (min-width: 1450px) {
+  :host([inset="sm"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--sm, 0.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--sm, 0.5rem);
+  }
+
+  :host([inset="md"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--md, 1rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--md, 1rem);
+  }
+
+  :host([inset="lg"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--lg, 1.5rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--lg, 1.5rem);
+  }
+
+  :host([inset="xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--xl, 2rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--xl, 2rem);
+  }
+
+  :host([inset="2xl"]) [part="tabs-container"] {
+    --pf-c-tabs--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--inset: var(--pf-global--spacer--2xl, 3rem);
+    --pf-c-tabs--m-vertical--m-box--inset: var(--pf-global--spacer--2xl, 3rem);
+  }
+}
+
+
+
+
+:host([fill]) ::slotted(pfe-tab:first-of-type) {
+  --pf-c-tabs--m-box__item--m-current--first-child__link--before--BorderLeftWidth: 0;
+}
+
+:host([fill]) ::slotted(pfe-tab:last-of-type) {
+  --pf-c-tabs--m-box__item--m-current--last-child__link--before--BorderRightWidth: 0;
+}
 
 :host([border-bottom="false"]) [part="tabs-container"] {
   --pf-c-tabs--before--BorderBottomWidth: 0; // *override user setting* when border-bottom is false border bottom styles should be 0;

--- a/elements/pfe-tabs/pfe-tabs.ts
+++ b/elements/pfe-tabs/pfe-tabs.ts
@@ -68,6 +68,8 @@ export class PfeTabs extends BaseTabs {
 
   static readonly styles = [style, pfeStyle];
 
+  protected static readonly scrollTimeoutDelay = 150;
+
   static isTab(element: HTMLElement): element is PfeTab {
     return element instanceof PfeTab;
   }

--- a/elements/pfe-tabs/pfe-tabs.ts
+++ b/elements/pfe-tabs/pfe-tabs.ts
@@ -96,12 +96,12 @@ export class PfeTabs extends BaseTabs {
   }
 
   protected _allTabs(): PfeTab[] {
-    const tabs = this._tabs as PfeTab[];
+    const tabs = this.tabs as PfeTab[];
     return tabs.filter(tab => PfeTabs.isTab(tab));
   }
 
   protected _allPanels(): PfeTabPanel[] {
-    const panels = this._panels as PfeTabPanel[];
+    const panels = this.panels as PfeTabPanel[];
     return panels.filter(panel => PfeTabs.isPanel(panel));
   }
 }

--- a/elements/pfe-tabs/pfe-tabs.ts
+++ b/elements/pfe-tabs/pfe-tabs.ts
@@ -1,7 +1,6 @@
 import { customElement, property } from 'lit/decorators.js';
 
 import { cascades } from '@patternfly/pfe-core/decorators.js';
-import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
 import { BaseTabs } from './BaseTabs.js';
 import { PfeTab } from './pfe-tab.js';
@@ -90,19 +89,6 @@ export class PfeTabs extends BaseTabs {
   @cascades('pfe-tab')
   @property({ attribute: 'border-bottom' }) borderBottom: 'true' | 'false' = 'true';
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.id ||= getRandomId('pfe-tabs');
-  }
-
-  protected _allTabs(): PfeTab[] {
-    const tabs = this.tabs as PfeTab[];
-    return tabs.filter(tab => PfeTabs.isTab(tab));
-  }
-
-  protected _allPanels(): PfeTabPanel[] {
-    const panels = this.panels as PfeTabPanel[];
-    return panels.filter(panel => PfeTabs.isPanel(panel));
   }
 }
 

--- a/elements/pfe-tabs/pfe-tabs.ts
+++ b/elements/pfe-tabs/pfe-tabs.ts
@@ -89,6 +89,8 @@ export class PfeTabs extends BaseTabs {
   @cascades('pfe-tab')
   @property({ attribute: 'border-bottom' }) borderBottom: 'true' | 'false' = 'true';
 
+  protected get canShowScrollButtons(): boolean {
+    return !this.vertical;
   }
 }
 

--- a/elements/pfe-tabs/test/pfe-tabs.spec.ts
+++ b/elements/pfe-tabs/test/pfe-tabs.spec.ts
@@ -163,7 +163,7 @@ describe('<pfe-tabs>', function() {
 
     it('should have visible scroll buttons if overflowed', async function() {
       const el = await createFixture<PfeTabs>(TEMPLATE);
-      await aTimeout(BaseTabs.delay);
+      await aTimeout(BaseTabs.scrollTimeoutDelay);
       const previousTab = el.shadowRoot!.querySelector('#previousTab')!;
       const nextTab = el.shadowRoot!.querySelector('#nextTab')!;
       const prevDisplayStyle = getComputedStyle(previousTab).display;

--- a/elements/pfe-tabs/test/pfe-tabs.spec.ts
+++ b/elements/pfe-tabs/test/pfe-tabs.spec.ts
@@ -77,7 +77,7 @@ describe('<pfe-tabs>', function() {
     tab!.setAttribute('active', '');
     await nextFrame();
     expect(tab!.hasAttribute('active')).to.equal(true);
-    expect(tab!.getAttribute('aria-selected')).to.equal('true');
+    expect(tab!.ariaSelected).to.equal('true');
   });
 
   it('should activate tab when activeIndex property is changed', async function() {
@@ -88,7 +88,7 @@ describe('<pfe-tabs>', function() {
     await nextFrame();
     const tab = el.querySelector('pfe-tab:first-of-type');
     expect(tab!.hasAttribute('active')).to.equal(true);
-    expect(tab!.getAttribute('aria-selected')).to.equal('true');
+    expect(tab!.ariaSelected).to.equal('true');
   });
 
   it('should open panel at same index of selected tab', async function() {
@@ -119,16 +119,16 @@ describe('<pfe-tabs>', function() {
       await setViewport({ width: 320, height: 640 });
     });
 
-    it('should aria-disable the tab', async function() {
+    it('should aria-disable the tab if disabled', async function() {
       const el = await createFixture<PfeTabs>(TEMPLATE);
       const disabledTab = el.querySelector('pfe-tab:nth-of-type(2)')! as BaseTab;
       disabledTab.disabled = true;
       await nextFrame();
-      const ariaDisabled = disabledTab!.hasAttribute('aria-disabled');
-      expect(ariaDisabled).to.equal(true);
+      const { ariaDisabled } = disabledTab!;
+      expect(ariaDisabled).to.equal('true');
     });
 
-    it('should have disabled styles', async function() {
+    it('should have disabled css styles if disabled', async function() {
       const el = await createFixture<PfeTabs>(TEMPLATE);
       const disabledTab = el.querySelector('pfe-tab:first-of-type')!;
       disabledTab.setAttribute('disabled', 'disabled');
@@ -138,7 +138,7 @@ describe('<pfe-tabs>', function() {
       expect(disabledStyles).to.equal('rgb(245, 245, 245)');
     });
 
-    it('should have disabled styles if aria-disabled attribute is true', async function() {
+    it('should have disabled css styles if aria-disabled attribute is true', async function() {
       const el = await createFixture<PfeTabs>(TEMPLATE);
       const disabledTab = el.querySelector('pfe-tab:first-of-type')!;
       disabledTab.setAttribute('aria-disabled', 'true');
@@ -163,7 +163,9 @@ describe('<pfe-tabs>', function() {
 
     it('should have visible scroll buttons if overflowed', async function() {
       const el = await createFixture<PfeTabs>(TEMPLATE);
-      await aTimeout(BaseTabs.scrollTimeoutDelay);
+      // Property 'scrollTimeoutDelay' is protected and only accessible within class 'PfeTabs' and its subclasses.
+      // using 150 as a static representation.
+      await aTimeout(150);
       const previousTab = el.shadowRoot!.querySelector('#previousTab')!;
       const nextTab = el.shadowRoot!.querySelector('#nextTab')!;
       const prevDisplayStyle = getComputedStyle(previousTab).display;


### PR DESCRIPTION
### What I did
- use ElementInternals
- many refactors (see commit messages)
- some perf improvements (i.e. use a single listener on window)
- rename `tab-expand` to `expand`
- move all the pf css to the pfe-*.scss files
- add attrs to customize the aria-label for scroll buttons
- remove some dependencies
- use pfe-icon