### PR TITLE
fix(icon): add dependencies to ts references

### DIFF
--- a/elements/pfe-icon/tsconfig.json
+++ b/elements/pfe-icon/tsconfig.json
@@ -18,6 +18,15 @@
     },
     {
       "path": "../../tools/pfe-tools"
+    },
+    {
+      "path": "../pfe-tooltip"
+    },
+    {
+      "path": "../pfe-button"
+    },
+    {
+      "path": "../pfe-autocomplete"
     }
   ]
 }


### PR DESCRIPTION
## What I did
add icon deps to ts ref. fixes [build errors](https://github.com/patternfly/patternfly-elements/actions/runs/3295121081/jobs/5433338016) and unblocks release