### PR TITLE
chore: build and release fixes

### DIFF
--- a/.changeset/breezy-steaks-melt.md
+++ b/.changeset/breezy-steaks-melt.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-label": patch
+---
+
+Fix label style loading

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,10 @@ jobs:
         id: build
         run: npm run build
 
+      - name: Release Dry Run
+        id: release-dry
+        run: npm run prepublishOnly -ws --if-present
+
       # Upload compiled assets to make them available for downstream jobs
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/elements/pfe-icon/demo/pfe-icon.js
+++ b/elements/pfe-icon/demo/pfe-icon.js
@@ -1,6 +1,8 @@
 import '@patternfly/pfe-icon';
 import '@patternfly/pfe-tooltip';
-import '@patternfly/pfe-button';
+// TS6202: Project references may not form a circular graph.
+// import '@patternfly/pfe-button';
+import('@patternfly' + '/' + 'pfe-button');
 import '@patternfly/pfe-autocomplete';
 import { iconSets } from '@patternfly/pfe-tools/environment.js';
 import { render, html } from 'lit';

--- a/elements/pfe-icon/pfe-icon.ts
+++ b/elements/pfe-icon/pfe-icon.ts
@@ -67,7 +67,7 @@ export class PfeIcon extends LitElement {
 
   private static getters = new Map<string, URLGetter>();
 
-  private static instances = new Set();
+  private static instances = new Set<PfeIcon>();
 
   /** Icon set */
   @property() set = PfeIcon.defaultIconSet;

--- a/elements/pfe-icon/tsconfig.json
+++ b/elements/pfe-icon/tsconfig.json
@@ -4,7 +4,11 @@
     "./**/*"
   ],
   "exclude": [
-    "./icons/**/*.js"
+    "./icons/**/*.js",
+    "./demo/pfe-icon.js",
+    "./demo/custom-icon-sets.js",
+    "./test/rh-icon*.js",
+    "./custom-elements-manifest.config.js"
   ],
   "compilerOptions": {
     "module": "esnext",
@@ -21,9 +25,6 @@
     },
     {
       "path": "../pfe-tooltip"
-    },
-    {
-      "path": "../pfe-button"
     },
     {
       "path": "../pfe-autocomplete"

--- a/elements/pfe-label/pfe-label.ts
+++ b/elements/pfe-label/pfe-label.ts
@@ -96,7 +96,7 @@ import styles from './pfe-label.scss';
 export class PfeLabel extends BaseLabel {
   static readonly version = '{{version}}';
 
-  static readonly styles = [BaseLabel.styles, styles];
+  static readonly styles = [...BaseLabel.styles, styles];
 
   static readonly shadowRootOptions: ShadowRootInit = { ...BaseLabel.shadowRootOptions, delegatesFocus: true };
 

--- a/elements/pfe-label/test/pfe-label.spec.ts
+++ b/elements/pfe-label/test/pfe-label.spec.ts
@@ -39,8 +39,8 @@ describe('<pfe-label>', function() {
     // replace the default built-in icon set resolveIconName function
     // with one that loads local icons.  we don't want tests dependent on
     // prod servers.
-    PfeIcon.addIconSet('rh', '', function(name: string) {
-      return `/elements/pfe-icon/test/${name.replace('rh', 'rh-icon')}.svg`;
+    PfeIcon.addIconSet('rh', function(name: string) {
+      return new URL(`/elements/pfe-icon/test/${name.replace('rh', 'rh-icon')}.svg`);
     });
   });
 


### PR DESCRIPTION
### What I did

- Fix typescript errors in pfe-icon
- Fix some runtime errors in pfe-label (would have been `static styles = [[basestyle], style]`)
- Add the release dry run step to PR checks