### PR TITLE
fix(tools): update element internals polyfill

### DIFF
--- a/.changeset/breezy-melons-sell.md
+++ b/.changeset/breezy-melons-sell.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Update element internals polyfill, fixes clicking on label in safari

--- a/docs/_includes/_head.njk
+++ b/docs/_includes/_head.njk
@@ -22,9 +22,10 @@
   <link rel="stylesheet" href="{{ '/core/styles/pfe-layouts.min.css' | url }}">
   <link rel="stylesheet" href="{{ '/main.css' | url }}">
 
+  <script type="module" src="{{ '/element-internals-polyfill/dist/index.js' | url }}"></script>
   <script type="module">
-    // Workaround for bundled pfe-icon: make icon imports absolute, instead of relative to the bundle
     import * as Bundle from '/pfe.min.js';
+    // Workaround for bundled pfe-icon: make icon imports absolute, instead of relative to the bundle
     Bundle.PfeIcon.getIconUrl = (set, icon) =>
       new URL(`/components/icon/icons/${set}/${icon}.js`, import.meta.url);
   </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11299,9 +11299,9 @@
       "dev": true
     },
     "node_modules/element-internals-polyfill": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.1.15.tgz",
-      "integrity": "sha512-LwCoE6/Q2TEWo0ohm1v+hLeH4J72c7RlOO0U+pik1LIkeosrMB9qA9JZx6WkGcJcAsq/JnxhiWpd2ykwJH+uKA=="
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.1.16.tgz",
+      "integrity": "sha512-dkH7+GgrFAXaAeNaYQXJjBhE7tLypRljnknkfDIkappmpIe61PPvyA3q7/QXtbhGWmCM9dfU4KZ1szU6Iu7x1A=="
     },
     "node_modules/eleventy-plugin-toc": {
       "version": "1.1.5",
@@ -28908,7 +28908,7 @@
         "custom-elements-manifest": "^2.0.0",
         "dedent": "^0.7.0",
         "dotenv": "^16.0.3",
-        "element-internals-polyfill": "^1.1.15",
+        "element-internals-polyfill": "^1.1.16",
         "eleventy-plugin-toc": "^1.1.5",
         "esbuild": "^0.15.12",
         "esbuild-node-externals": "^1.5.0",
@@ -33455,7 +33455,7 @@
         "custom-elements-manifest": "^2.0.0",
         "dedent": "^0.7.0",
         "dotenv": "^16.0.3",
-        "element-internals-polyfill": "^1.1.15",
+        "element-internals-polyfill": "^1.1.16",
         "eleventy-plugin-toc": "^1.1.5",
         "esbuild": "^0.15.12",
         "esbuild-node-externals": "^1.5.0",
@@ -38032,9 +38032,9 @@
       "dev": true
     },
     "element-internals-polyfill": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.1.15.tgz",
-      "integrity": "sha512-LwCoE6/Q2TEWo0ohm1v+hLeH4J72c7RlOO0U+pik1LIkeosrMB9qA9JZx6WkGcJcAsq/JnxhiWpd2ykwJH+uKA=="
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.1.16.tgz",
+      "integrity": "sha512-dkH7+GgrFAXaAeNaYQXJjBhE7tLypRljnknkfDIkappmpIe61PPvyA3q7/QXtbhGWmCM9dfU4KZ1szU6Iu7x1A=="
     },
     "eleventy-plugin-toc": {
       "version": "1.1.5",

--- a/tools/pfe-tools/11ty/plugins/pfe-assets.cjs
+++ b/tools/pfe-tools/11ty/plugins/pfe-assets.cjs
@@ -19,7 +19,9 @@ function getFilesToCopy(options) {
     return null;
   }
 
-  const files = {};
+  const files = {
+    [path.join(repoRoot, 'node_modules/element-internals-polyfill')]: 'element-internals-polyfill',
+  };
 
   // Copy all component and core files to _site
   if (hasElements) {

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -95,7 +95,7 @@
     "custom-elements-manifest": "^2.0.0",
     "dedent": "^0.7.0",
     "dotenv": "^16.0.3",
-    "element-internals-polyfill": "^1.1.15",
+    "element-internals-polyfill": "^1.1.16",
     "eleventy-plugin-toc": "^1.1.5",
     "esbuild": "^0.15.12",
     "esbuild-node-externals": "^1.5.0",


### PR DESCRIPTION
## What I did
- update the element internals polyfill to a version which fixes click-on-label 
- copy the polyfill to the web root when building 11ty
- load the polyfill on all docs pages

fixes #2214 

## Testing instructions 
load /components/switch in safari

## Notes to reviewers
I'm loading the polyfill on all pages, this could be more carefully scoped by examining the page data in _head.njk, but that seemed excessively precious to me.