### PR TITLE
fix(switch): making sure toggle isn't called when switch is disabled

### DIFF
--- a/.changeset/giant-spies-love.md
+++ b/.changeset/giant-spies-love.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/pfe-switch": patch
+---
+Prevented clicks and other interactions when the switch is disabled

--- a/elements/pfe-switch/BaseSwitch.scss
+++ b/elements/pfe-switch/BaseSwitch.scss
@@ -12,6 +12,7 @@ svg {
 
 :host(:disabled),
 :host([disabled]) {
+  pointer-events: none;
   cursor: not-allowed;
   #container {
     cursor: not-allowed;

--- a/elements/pfe-switch/BaseSwitch.ts
+++ b/elements/pfe-switch/BaseSwitch.ts
@@ -84,6 +84,10 @@ export abstract class BaseSwitch extends LitElement {
   }
 
   #toggle() {
+    if (this.disabled) {
+      return;
+    }
+
     this.checked = !this.checked;
     this.#updateLabels();
     this.dispatchEvent(new Event('change', { bubbles: true }));

--- a/elements/pfe-switch/README.md
+++ b/elements/pfe-switch/README.md
@@ -24,6 +24,9 @@ Then once installed, import it to your application:
 import '@patternfly/pfe-switch';
 ```
 
+### Note
+For `<pfe-switch>` to work in Safari, you'll need to load the [element-internals-polyfill](https://www.npmjs.com/package/element-internals-polyfill). Safari is in the process of [adding element internals to WebKit](https://bugs.webkit.org/show_bug.cgi?id=197960) so this polyfill should be temporary.
+
 ## Usage
 ```html
 <pfe-switch id="switch"></pfe-switch>


### PR DESCRIPTION
Fixes issue in Firefox where when `pfe-switch` is disabled, the switch can still be toggled. This PR exits the `#toggle` method if `pfe-switch` is disabled.

Fixes #2215.


### Related issues
- #2215

### Preview
- Go to https://deploy-preview-2221--patternfly-elements.netlify.app/components/switch/demo/#disabled in Firefox
- Try to click on the switch to make it toggle

