### PR TITLE
docs(switch): fixing issue with duplicate ids on demo and docs

### DIFF
--- a/elements/pfe-switch/demo/pfe-switch.html
+++ b/elements/pfe-switch/demo/pfe-switch.html
@@ -93,9 +93,9 @@
     <label for="checked-disabled" data-state="off">Message when off</label>
   </fieldset>
   <fieldset>
-    <pfe-switch id="disabled" disabled></pfe-switch>
-    <label for="disabled" data-state="on">Message when on</label>
-    <label for="disabled" data-state="off">Message when off</label>
+    <pfe-switch id="default-disabled" disabled></pfe-switch>
+    <label for="default-disabled" data-state="on">Message when on</label>
+    <label for="default-disabled" data-state="off">Message when off</label>
   </fieldset>
 </form>
 </section>

--- a/elements/pfe-switch/docs/pfe-switch.md
+++ b/elements/pfe-switch/docs/pfe-switch.md
@@ -1,42 +1,12 @@
 {% renderOverview %}
 A switch toggles the state of a setting (between on and off). Switches provide a more explicit, visible representation on a setting.
 
-<pfe-switch id="overview-switch" checked></pfe-switch>
-<label for="overview-switch" data-state="on">Message when on</label>
-<label for="overview-switch" data-state="off" hidden>Message when off</label>
+
 {% endrenderOverview %}
 
 {% band header="Usage" %}
 
 ### Basic
-<pfe-switch id="color-scheme-toggle" checked></pfe-switch>
-<label for="color-scheme-toggle" data-state="on">Message when on</label>
-<label for="color-scheme-toggle" data-state="off" hidden>Message when off</label>
-
-```html
-<pfe-switch id="color-scheme-toggle"></pfe-switch>
-<label for="color-scheme-toggle" data-state="on">Message when on</label>
-<label for="color-scheme-toggle" data-state="off" hidden>Message when off</label>
-```
-
-
-### Without label
-<pfe-switch checked></pfe-switch>
-
-```html
-<pfe-switch></pfe-switch>
-```
-
-### Checked with label
-<pfe-switch id="checked" checked show-check-icon></pfe-switch>
-<label for="checked" data-state="on">Message when on</label>
-<label for="checked" data-state="off">Message when off</label>
-
-```html
-<pfe-switch id="checked" checked show-check-icon></pfe-switch>
-<label for="checked" data-state="on">Message when on</label>
-<label for="checked" data-state="off">Message when off</label>
-```
 
 ### Disabled
 <form>
@@ -47,28 +17,13 @@ A switch toggles the state of a setting (between on and off). Switches provide a
     <label for="checked-disabled" data-state="off">Message when off</label>
   </fieldset>
   <fieldset>
-    <pfe-switch id="disabled" disabled></pfe-switch>
-    <label for="disabled" data-state="on">Message when on</label>
-    <label for="disabled" data-state="off">Message when off</label>
+    <pfe-switch id="default-disabled" disabled></pfe-switch>
+    <label for="default-disabled" data-state="on">Message when on</label>
+    <label for="default-disabled" data-state="off">Message when off</label>
   </fieldset>
 </form>
 
-```html
-<form>
-  <fieldset>
-    <legend>Checked and Disabled</legend>
-    <pfe-switch id="checked-disabled" checked disabled></pfe-switch>
-    <label for="checked-disabled" data-state="on">Message when on</label>
-    <label for="checked-disabled" data-state="off">Message when off</label>
-  </fieldset>
 
-  <fieldset>
-    <pfe-switch id="disabled" disabled></pfe-switch>
-    <label for="disabled" data-state="on">Message when on</label>
-    <label for="disabled" data-state="off">Message when off</label>
-  </fieldset>
-</form>
-```
 {% endband %}
 
 {% renderSlots %}{% endrenderSlots %}

--- a/elements/pfe-switch/docs/pfe-switch.md
+++ b/elements/pfe-switch/docs/pfe-switch.md
@@ -1,12 +1,42 @@
 {% renderOverview %}
 A switch toggles the state of a setting (between on and off). Switches provide a more explicit, visible representation on a setting.
 
-
+<pfe-switch id="overview-switch" checked></pfe-switch>
+<label for="overview-switch" data-state="on">Message when on</label>
+<label for="overview-switch" data-state="off" hidden>Message when off</label>
 {% endrenderOverview %}
 
 {% band header="Usage" %}
 
 ### Basic
+<pfe-switch id="color-scheme-toggle" checked></pfe-switch>
+<label for="color-scheme-toggle" data-state="on">Message when on</label>
+<label for="color-scheme-toggle" data-state="off" hidden>Message when off</label>
+
+```html
+<pfe-switch id="color-scheme-toggle"></pfe-switch>
+<label for="color-scheme-toggle" data-state="on">Message when on</label>
+<label for="color-scheme-toggle" data-state="off" hidden>Message when off</label>
+```
+
+
+### Without label
+<pfe-switch checked></pfe-switch>
+
+```html
+<pfe-switch></pfe-switch>
+```
+
+### Checked with label
+<pfe-switch id="checked" checked show-check-icon></pfe-switch>
+<label for="checked" data-state="on">Message when on</label>
+<label for="checked" data-state="off">Message when off</label>
+
+```html
+<pfe-switch id="checked" checked show-check-icon></pfe-switch>
+<label for="checked" data-state="on">Message when on</label>
+<label for="checked" data-state="off">Message when off</label>
+```
 
 ### Disabled
 <form>
@@ -17,13 +47,28 @@ A switch toggles the state of a setting (between on and off). Switches provide a
     <label for="checked-disabled" data-state="off">Message when off</label>
   </fieldset>
   <fieldset>
+    <pfe-switch id="disabled" disabled></pfe-switch>
+    <label for="disabled" data-state="on">Message when on</label>
+    <label for="disabled" data-state="off">Message when off</label>
+  </fieldset>
+</form>
+
+```html
+<form>
+  <fieldset>
+    <legend>Checked and Disabled</legend>
+    <pfe-switch id="checked-disabled" checked disabled></pfe-switch>
+    <label for="checked-disabled" data-state="on">Message when on</label>
+    <label for="checked-disabled" data-state="off">Message when off</label>
+  </fieldset>
+
+  <fieldset>
     <pfe-switch id="default-disabled" disabled></pfe-switch>
     <label for="default-disabled" data-state="on">Message when on</label>
     <label for="default-disabled" data-state="off">Message when off</label>
   </fieldset>
 </form>
-
-
+```
 {% endband %}
 
 {% renderSlots %}{% endrenderSlots %}

--- a/elements/pfe-switch/docs/pfe-switch.md
+++ b/elements/pfe-switch/docs/pfe-switch.md
@@ -47,9 +47,9 @@ A switch toggles the state of a setting (between on and off). Switches provide a
     <label for="checked-disabled" data-state="off">Message when off</label>
   </fieldset>
   <fieldset>
-    <pfe-switch id="disabled" disabled></pfe-switch>
-    <label for="disabled" data-state="on">Message when on</label>
-    <label for="disabled" data-state="off">Message when off</label>
+    <pfe-switch id="default-disabled" disabled></pfe-switch>
+    <label for="default-disabled" data-state="on">Message when on</label>
+    <label for="default-disabled" data-state="off">Message when off</label>
   </fieldset>
 </form>
 


### PR DESCRIPTION
Removes duplicate `disabled` id from docs and demo pages.

Fixes #2224 