### PR TITLE
fix(switch): adding repo and file list to package.json

### DIFF
--- a/elements/pfe-switch/package.json
+++ b/elements/pfe-switch/package.json
@@ -44,6 +44,24 @@
     "design systems",
     "web components"
   ],
+  "repository": {
+    "type": "git",
+    "url": "github:patternfly/patternfly-elements",
+    "directory": "elements/pfe-switch"
+  },
+  "files": [
+    "!*.ts",
+    "custom-elements.json",
+    "**/*.LEGAL.txt",
+    "**/*.css",
+    "**/*.d.ts",
+    "**/*.js",
+    "**/*.js.map",
+    "!custom-elements-manifest.config.js",
+    "!demo/*",
+    "!docs/*",
+    "!test/*"
+  ],
   "dependencies": {
     "@patternfly/pfe-core": "^2.0.0 || ^2.0.0-next.0",
     "lit": "^2.0.0"


### PR DESCRIPTION
Noticed an issue while working with the new pfe-switch where the published package included the .ts and .scss files.  Added those to ignore from package.json.  

Example on unpkg: https://unpkg.com/browse/@patternfly/pfe-switch@2.0.0-next.0/