### PR TITLE
fix(tabs): correct typo and made imports uniform

### DIFF
--- a/.changeset/giant-goats-swim.md
+++ b/.changeset/giant-goats-swim.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tabs": patch
+---
+
+Fixed `<pfe-tabs>` CSS imports, typo caused issue with child repository having incorrect styles

--- a/.changeset/giant-goats-swim.md
+++ b/.changeset/giant-goats-swim.md
@@ -2,4 +2,4 @@
 "@patternfly/pfe-tabs": patch
 ---
 
-Fixed `<pfe-tabs>` CSS imports, typo caused issue with child repository having incorrect styles
+Fixed `<pfe-tabs>` CSS imports and a typo that caused an issue with the child repository having incorrect styles

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -8,7 +8,7 @@ import { isElementInView } from '@patternfly/pfe-core/functions/isElementInView.
 import { BaseTab, TabExpandEvent } from './BaseTab.js';
 import { BaseTabPanel } from './BaseTabPanel.js';
 
-import style from './BaseTab.scss';
+import styles from './BaseTabs.scss';
 
 /**
  * @attr [label-scroll-left="Scroll left"] - accessible label for the tab panel's scroll left button.
@@ -16,7 +16,7 @@ import style from './BaseTab.scss';
  *
  */
 export abstract class BaseTabs extends LitElement {
-  static readonly styles = [style];
+  static readonly styles = [styles];
 
   static isTab(element: BaseTab): element is BaseTab {
     return element instanceof BaseTab;

--- a/elements/pfe-tabs/pfe-tab-panel.ts
+++ b/elements/pfe-tabs/pfe-tab-panel.ts
@@ -2,8 +2,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
-import style from './BaseTabPanel.scss';
-import pfeStyle from './pfe-tab-panel.scss';
+import styles from './pfe-tab-panel.scss';
 
 import { BaseTabPanel } from './BaseTabPanel';
 
@@ -16,7 +15,7 @@ import { BaseTabPanel } from './BaseTabPanel';
  */
 @customElement('pfe-tab-panel')
 export class PfeTabPanel extends BaseTabPanel {
-  static readonly styles = [style, pfeStyle];
+  static readonly styles = [...BaseTabPanel.styles, styles];
 
   connectedCallback() {
     super.connectedCallback();

--- a/elements/pfe-tabs/pfe-tab.ts
+++ b/elements/pfe-tabs/pfe-tab.ts
@@ -2,8 +2,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { BaseTab } from './BaseTab.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 
-import style from './BaseTab.scss';
-import pfeStyle from './pfe-tab.scss';
+import styles from './pfe-tab.scss';
 
 /**
  * PfeTab
@@ -67,7 +66,7 @@ import pfeStyle from './pfe-tab.scss';
  */
 @customElement('pfe-tab')
 export class PfeTab extends BaseTab {
-  static readonly styles = [style, pfeStyle];
+  static readonly styles = [...BaseTab.styles, styles];
 
   connectedCallback() {
     super.connectedCallback();

--- a/elements/pfe-tabs/pfe-tabs.ts
+++ b/elements/pfe-tabs/pfe-tabs.ts
@@ -6,8 +6,7 @@ import { BaseTabs } from './BaseTabs.js';
 import { PfeTab } from './pfe-tab.js';
 import { PfeTabPanel } from './pfe-tab-panel.js';
 
-import style from './BaseTabs.scss';
-import pfeStyle from './pfe-tabs.scss';
+import styles from './pfe-tabs.scss';
 
 /**
  * Tabs allow users to navigate between views within the same page or context. Variants include
@@ -65,7 +64,7 @@ import pfeStyle from './pfe-tabs.scss';
 export class PfeTabs extends BaseTabs {
   static readonly version = '{{version}}';
 
-  static readonly styles = [style, pfeStyle];
+  static readonly styles = [...BaseTabs.styles, styles];
 
   protected static readonly scrollTimeoutDelay = 150;
 


### PR DESCRIPTION
## What I did

 - Fixed `<pfe-tabs>` CSS imports and a typo that caused an issue with the child repository having incorrect styles