### PR TITLE
fix(badge)!: make state abstract

### DIFF
--- a/.changeset/proud-wombats-dress.md
+++ b/.changeset/proud-wombats-dress.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-badge": patch
+---
+
+Made `state` property on `BaseBadge` abstract.

--- a/elements/pfe-badge/BaseBadge.ts
+++ b/elements/pfe-badge/BaseBadge.ts
@@ -1,16 +1,11 @@
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
 
 import style from './BaseBadge.scss';
 
 export abstract class BaseBadge extends LitElement {
   static readonly styles = [style];
 
-  /**
-   * Denotes the state-of-affairs this badge represents
-   * Options include read and unread
-   */
-  @property({ reflect: true }) state?: 'unread'|'read';
+  abstract state?: string;
 
   /**
    * Sets a numeric value for a badge.
@@ -18,13 +13,13 @@ export abstract class BaseBadge extends LitElement {
    * You can pair it with `threshold` attribute to add a `+` sign
    * if the number exceeds the threshold value.
    */
-  @property({ reflect: true, type: Number }) number?: number;
+  abstract number?: number;
 
   /**
    * Sets a threshold for the numeric value and adds `+` sign if
    * the numeric value exceeds the threshold value.
    */
-  @property({ reflect: true, type: Number }) threshold?: number;
+  abstract threshold?: number;
 
   override render() {
     const { threshold, number, textContent } = this;

--- a/elements/pfe-badge/pfe-badge.ts
+++ b/elements/pfe-badge/pfe-badge.ts
@@ -1,4 +1,4 @@
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 import { BaseBadge } from './BaseBadge.js';
 
@@ -32,7 +32,18 @@ import styles from './pfe-badge.scss';
 @customElement('pfe-badge')
 export class PfeBadge extends BaseBadge {
   static readonly version = '{{version}}';
+
   static readonly styles = [...BaseBadge.styles, styles];
+
+  /**
+   * Denotes the state-of-affairs this badge represents
+   * Options include read and unread
+   */
+  @property({ reflect: true }) state?: 'unread'|'read';
+
+  @property({ reflect: true, type: Number }) number?: number;
+
+  @property({ reflect: true, type: Number }) threshold?: number;
 }
 
 declare global {


### PR DESCRIPTION
### What I did:
Make `state` property on `BaseBadge` abstract. Blocks https://github.com/RedHat-UX/red-hat-design-system/pull/599