### PR TITLE
fix(core): remove submitter from requestSubmit call

### DIFF
--- a/.changeset/selfish-starfishes-smoke.md
+++ b/.changeset/selfish-starfishes-smoke.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+`InternalsController`: Removed the submitter argument from the `requestSubmit()`
+call.

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -12,7 +12,7 @@ export class InternalsController implements ReactiveController {
   hostConnected?(): void
 
   submit() {
-    this.#internals.form?.requestSubmit(this.host);
+    this.#internals.form?.requestSubmit();
   }
 
   reset() {


### PR DESCRIPTION
### What I did
remove submitter from requestSubmit call. This prevents the demo in rh-button from working properly. We may later revisit this as `InternalsController` development progresses.

> ```
> Uncaught TypeError: HTMLFormElement.requestSubmit: The submitter is not a submit button.
>     submit internals-controller.ts:15
>     w (index):37
>     handleEvent lit-html.ts:2003
>     _$AI lit-html.ts:1992
>     p lit-html.ts:1181
>     $ lit-html.ts:1538
>     _$AI lit-html.ts:1375
>     Z lit-html.ts:2169
>     update lit-element.ts:165
>     performUpdate reactive-element.ts:1327
>     scheduleUpdate reactive-element.ts:1259
>     _$Ej reactive-element.ts:1231
>     requestUpdate reactive-element.ts:1206
>     u reactive-element.ts:944
>     d reactive-element.ts:927
>     s lit-element.ts:115
>     s (index):67
>     RhButton rh-button.ts:11
>     e custom-element.ts:21
>     e custom-element.ts:64
>     __decorateClass rh-button.ts:7
>     <anonymous> rh-button.ts:11
> internals-controller.ts:15:40
> ```

Blocks https://github.com/RedHat-UX/red-hat-design-system/pull/550