### PR TITLE
feat(core): internals controller improvements

### DIFF
--- a/.changeset/little-timers-repeat.md
+++ b/.changeset/little-timers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-button": patch
+---
+
+Allowed button to be disabled by its form without sprouting a disabled attr

--- a/.changeset/modern-readers-joke.md
+++ b/.changeset/modern-readers-joke.md
@@ -1,0 +1,11 @@
+---
+"@patternfly/pfe-core": minor
+---
+
+Added options to `InternalsController`. Use them to initialize `ARIA`
+properties.
+
+```ts
+  role: 'listbox',
+});
+```

--- a/.changeset/shy-knives-walk.md
+++ b/.changeset/shy-knives-walk.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Added constructible stylesheets polyfill to dev server

--- a/.changeset/spicy-pans-draw.md
+++ b/.changeset/spicy-pans-draw.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": minor
+---
+
+`InternalsController`: hook into host's `formDisabledCallback`

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -3,10 +3,25 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 export class InternalsController implements ReactiveController {
   #internals: ElementInternals;
 
+  disabled = false;
+
   constructor(
     public host: ReactiveControllerHost & HTMLElement,
   ) {
     this.#internals = host.attachInternals();
+    const { formDisabledCallback } = host;
+    Object.defineProperty(Object.getPrototypeOf(host), 'formDisabledCallback', {
+      configurable: true,
+      value: (disabled: boolean) => {
+        formDisabledCallback?.call(host, disabled);
+        this.formDisabledCallback(disabled);
+      }
+    });
+  }
+
+  formDisabledCallback(disabled: boolean) {
+    this.disabled = disabled;
+    this.host.requestUpdate();
   }
 
   hostConnected?(): void

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -1,9 +1,50 @@
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
-export class InternalsController implements ReactiveController {
+export class InternalsController implements ReactiveController, ARIAMixin {
   #internals: ElementInternals;
 
   disabled = false;
+
+  declare role: ARIAMixin['role'];
+  declare ariaAtomic: ARIAMixin['ariaAtomic'];
+  declare ariaAutoComplete: ARIAMixin['ariaAutoComplete'];
+  declare ariaBusy: ARIAMixin['ariaBusy'];
+  declare ariaChecked: ARIAMixin['ariaChecked'];
+  declare ariaColCount: ARIAMixin['ariaColCount'];
+  declare ariaColIndex: ARIAMixin['ariaColIndex'];
+  declare ariaColIndexText: ARIAMixin['ariaColIndexText'];
+  declare ariaColSpan: ARIAMixin['ariaColSpan'];
+  declare ariaCurrent: ARIAMixin['ariaCurrent'];
+  declare ariaDisabled: ARIAMixin['ariaDisabled'];
+  declare ariaExpanded: ARIAMixin['ariaExpanded'];
+  declare ariaHasPopup: ARIAMixin['ariaHasPopup'];
+  declare ariaHidden: ARIAMixin['ariaHidden'];
+  declare ariaInvalid: ARIAMixin['ariaInvalid'];
+  declare ariaKeyShortcuts: ARIAMixin['ariaKeyShortcuts'];
+  declare ariaLabel: ARIAMixin['ariaLabel'];
+  declare ariaLevel: ARIAMixin['ariaLevel'];
+  declare ariaLive: ARIAMixin['ariaLive'];
+  declare ariaModal: ARIAMixin['ariaModal'];
+  declare ariaMultiLine: ARIAMixin['ariaMultiLine'];
+  declare ariaMultiSelectable: ARIAMixin['ariaMultiSelectable'];
+  declare ariaOrientation: ARIAMixin['ariaOrientation'];
+  declare ariaPlaceholder: ARIAMixin['ariaPlaceholder'];
+  declare ariaPosInSet: ARIAMixin['ariaPosInSet'];
+  declare ariaPressed: ARIAMixin['ariaPressed'];
+  declare ariaReadOnly: ARIAMixin['ariaReadOnly'];
+  declare ariaRequired: ARIAMixin['ariaRequired'];
+  declare ariaRoleDescription: ARIAMixin['ariaRoleDescription'];
+  declare ariaRowCount: ARIAMixin['ariaRowCount'];
+  declare ariaRowIndex: ARIAMixin['ariaRowIndex'];
+  declare ariaRowIndexText: ARIAMixin['ariaRowIndexText'];
+  declare ariaRowSpan: ARIAMixin['ariaRowSpan'];
+  declare ariaSelected: ARIAMixin['ariaSelected'];
+  declare ariaSetSize: ARIAMixin['ariaSetSize'];
+  declare ariaSort: ARIAMixin['ariaSort'];
+  declare ariaValueMax: ARIAMixin['ariaValueMax'];
+  declare ariaValueMin: ARIAMixin['ariaValueMin'];
+  declare ariaValueNow: ARIAMixin['ariaValueNow'];
+  declare ariaValueText: ARIAMixin['ariaValueText'];
 
   constructor(
     public host: ReactiveControllerHost & HTMLElement,
@@ -22,6 +63,16 @@ export class InternalsController implements ReactiveController {
   formDisabledCallback(disabled: boolean) {
     this.disabled = disabled;
     this.host.requestUpdate();
+    for (const key of Object.keys(Object.getPrototypeOf(this.#internals))) {
+      Object.defineProperty(this, key, {
+        get() {
+          return this.#internals[key];
+        },
+        set(value) {
+          this.#internals[key] = value;
+        }
+      });
+    }
   }
 
   hostConnected?(): void

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -61,7 +61,7 @@ export class InternalsController implements ReactiveController, ARIAMixin {
   ) {
     this.#internals = host.attachInternals();
     // proxy the internals object's aria prototype
-    for (const key of Object.keys(this.#internals)) {
+    for (const key of Object.keys(Object.getPrototypeOf(this.#internals))) {
       if (isARIAMixinProp(key)) {
         Object.defineProperty(this, key, {
           get() {

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -44,9 +44,9 @@ export class InternalsController implements ReactiveController, ARIAMixin {
 
   #internals: ElementInternals;
 
-  /** True when the control is disabled via it's containing fieldset element */
   #formDisabled = false;
 
+  /** True when the control is disabled via it's containing fieldset element */
   get formDisabled() {
     return this.#formDisabled;
   }
@@ -80,6 +80,7 @@ export class InternalsController implements ReactiveController, ARIAMixin {
           },
           set(value) {
             this.#internals[key] = value;
+            this.host.requestUpdate();
           }
         });
       }

--- a/elements/pfe-button/BaseButton.ts
+++ b/elements/pfe-button/BaseButton.ts
@@ -36,6 +36,9 @@ export abstract class BaseButton extends LitElement {
 
   @property() name?: string;
 
+  /** Shorthand for the `icon` slot, the value is icon name */
+  @property() icon?: string;
+
   /** Changes the size of the button. */
   abstract size?: string;
 
@@ -45,9 +48,6 @@ export abstract class BaseButton extends LitElement {
    * user data.
    */
   abstract danger: unknown;
-
-  /** Shorthand for the `icon` slot, the value is icon name */
-  @property() icon?: string;
 
   #internals = new InternalsController(this);
 

--- a/elements/pfe-button/BaseButton.ts
+++ b/elements/pfe-button/BaseButton.ts
@@ -5,7 +5,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { InternalsController } from '@patternfly/pfe-core/controllers/internals-controller.js';
-
 import styles from './BaseButton.scss';
 
 /**
@@ -51,18 +50,8 @@ export abstract class BaseButton extends LitElement {
 
   #internals = new InternalsController(this);
 
-  #initiallyDisabled = this.hasAttribute('disabled');
-
   protected get hasIcon() {
     return !!this.icon;
-  }
-
-  formDisabledCallback(disabled: boolean) {
-    this.disabled = disabled;
-  }
-
-  formResetCallback() {
-    this.disabled = this.#initiallyDisabled;
   }
 
   override render() {
@@ -73,11 +62,16 @@ export abstract class BaseButton extends LitElement {
               value="${ifDefined(this.value)}"
               aria-label="${ifDefined(this.label)}"
               @click="${this.#onClick}"
-              ?disabled="${this.disabled}">
+              ?disabled="${this.disabled || this.#internals.formDisabled}">
         <slot id="icon" part="icon" aria-hidden="true" name="icon">${this.renderDefaultIcon()}</slot>
         <slot id="text" aria-hidden=${String(!!this.label) as 'true'|'false'}></slot>
       </button>
     `;
+  }
+
+  protected async formDisabledCallback() {
+    await this.updateComplete;
+    this.requestUpdate();
   }
 
   #onClick() {

--- a/elements/pfe-button/demo/form-control.html
+++ b/elements/pfe-button/demo/form-control.html
@@ -1,0 +1,37 @@
+<script type="module" src="../form-control.js"></script>
+
+<form>
+  <h2>Nothing disabled</h2>
+  <fieldset>
+    <pfe-button>Ok</pfe-button>
+  </fieldset>
+  <label>Fieldset Disabled <pfe-switch name="fieldset"></pfe-switch> </label>
+  <label>Button Disabled <pfe-switch name="button"></pfe-switch> </label>
+</form>
+
+<form>
+  <h2>fieldset disabled</h2>
+  <fieldset disabled>
+    <pfe-button>Ok</pfe-button>
+  </fieldset>
+  <label>Fieldset Disabled <pfe-switch name="fieldset" checked></pfe-switch> </label>
+  <label>Button Disabled <pfe-switch name="button"></pfe-switch> </label>
+</form>
+
+<form>
+  <h2>Button disabled</h2>
+  <fieldset>
+    <pfe-button disabled>Ok</pfe-button>
+  </fieldset>
+  <label>Fieldset Disabled <pfe-switch name="fieldset"></pfe-switch> </label>
+  <label>Button Disabled <pfe-switch name="button" checked></pfe-switch> </label>
+</form>
+
+<form>
+  <h2>Both disabled</h2>
+  <fieldset disabled>
+    <pfe-button disabled>Ok</pfe-button>
+  </fieldset>
+  <label>Fieldset Disabled <pfe-switch name="fieldset" checked></pfe-switch> </label>
+  <label>Button Disabled <pfe-switch name="button" checked></pfe-switch> </label>
+</form>

--- a/elements/pfe-button/demo/form-control.js
+++ b/elements/pfe-button/demo/form-control.js
@@ -1,0 +1,14 @@
+import '@patternfly/pfe-switch';
+import '@patternfly/pfe-button';
+
+for (const form of document.querySelectorAll('form')) {
+  form.addEventListener('submit', e=>e.preventDefault());
+  form.addEventListener('change', sync);
+  sync.call(form);
+}
+
+/** @this{HTMLFormElement}*/
+function sync() {
+  this.querySelector('fieldset').disabled = this.fieldset.checked;
+  this.querySelector('pfe-button').disabled = this.button.checked;
+}

--- a/elements/pfe-button/test/pfe-button.spec.ts
+++ b/elements/pfe-button/test/pfe-button.spec.ts
@@ -16,7 +16,7 @@ describe('<pfe-button>', function() {
   describe('in a fieldset', function() {
     let element: PfeButton;
     let fieldset: HTMLFieldSetElement;
-    let form: HTMLFormSetElement;
+    let form: HTMLFormElement;
 
     beforeEach(async function() {
       form = await createFixture(html`
@@ -28,9 +28,9 @@ describe('<pfe-button>', function() {
           <input id="post">
         </form>
       `);
-      fieldset = form.querySelector('fieldset');
-      element = form.querySelector('pfe-button');
-      form.querySelector('input').focus();
+      fieldset = form.querySelector('fieldset')!;
+      element = form.querySelector('pfe-button')!;
+      form.querySelector('input')?.focus();
       await element.updateComplete;
     });
 

--- a/elements/pfe-button/test/pfe-button.spec.ts
+++ b/elements/pfe-button/test/pfe-button.spec.ts
@@ -1,6 +1,7 @@
 import { expect, html } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 import { PfeButton } from '@patternfly/pfe-button';
+import { sendKeys } from '@web/test-runner-commands';
 
 import '@patternfly/pfe-tools/test/stub-logger.js';
 
@@ -11,5 +12,87 @@ describe('<pfe-button>', function() {
       .to.be.an.instanceOf(customElements.get('pfe-button'))
       .and
       .to.be.an.instanceOf(PfeButton);
+  });
+  describe('in a fieldset', function() {
+    let element: PfeButton;
+    let fieldset: HTMLFieldSetElement;
+    let form: HTMLFormSetElement;
+
+    beforeEach(async function() {
+      form = await createFixture(html`
+        <form>
+          <input id="pre">
+          <fieldset>
+            <pfe-button>OK</pfe-button>
+          </fieldset>
+          <input id="post">
+        </form>
+      `);
+      fieldset = form.querySelector('fieldset');
+      element = form.querySelector('pfe-button');
+      form.querySelector('input').focus();
+      await element.updateComplete;
+    });
+
+    describe('tabbing through', function() {
+      beforeEach(async function() {
+        await sendKeys({ press: 'Tab' });
+      });
+      it('does focus the button', function() {
+        expect(document.activeElement)
+          .to
+          .be.an.instanceof(PfeButton);
+      });
+    });
+
+    describe('disabling the fieldset', function() {
+      beforeEach(async function() {
+        fieldset.disabled = true;
+        await element.updateComplete;
+      });
+      it('disables the button', function() {
+        expect(element.matches(':disabled'), 'matches :disabled').to.be.true;
+      });
+      describe('tabbing through', function() {
+        beforeEach(async function() {
+          await sendKeys({ press: 'Tab' });
+        });
+        it('does not focus the button', function() {
+          expect(document.activeElement)
+            .to
+            .not
+            .be.an.instanceof(PfeButton);
+        });
+      });
+      // this was a regression spotted by @brianferry
+      describe('then disabling the button', function() {
+        beforeEach(async function() {
+          element.disabled = true;
+          await element.updateComplete;
+        });
+        describe('then enabling the button', function() {
+          beforeEach(async function() {
+            element.disabled = false;
+            await element.updateComplete;
+          });
+          describe('then enabling the fieldset', function() {
+            beforeEach(async function() {
+              fieldset.disabled = false;
+              await element.updateComplete;
+            });
+            describe('tabbing through', function() {
+              beforeEach(async function() {
+                await sendKeys({ press: 'Tab' });
+              });
+              it('does focus the button', function() {
+                expect(document.activeElement)
+                  .to
+                  .be.an.instanceof(PfeButton);
+              });
+            });
+          });
+        });
+      });
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8081,6 +8081,11 @@
         "@babel/types": "^7.6.1"
       }
     },
+    "node_modules/construct-style-sheets-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
+      "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw=="
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "license": "MIT",
@@ -25605,6 +25610,7 @@
         "clean-css": "^5.3.1",
         "colorjs.io": "^0.4.0",
         "compression": "^1.7.4",
+        "construct-style-sheets-polyfill": "^3.1.0",
         "custom-elements-manifest": "^2.0.0",
         "dedent": "^0.7.0",
         "dotenv": "^16.0.3",
@@ -29263,6 +29269,7 @@
         "clean-css": "^5.3.1",
         "colorjs.io": "^0.4.0",
         "compression": "^1.7.4",
+        "construct-style-sheets-polyfill": "*",
         "custom-elements-manifest": "^2.0.0",
         "dedent": "^0.7.0",
         "dotenv": "^16.0.3",
@@ -31713,6 +31720,11 @@
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
       }
+    },
+    "construct-style-sheets-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
+      "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw=="
     },
     "content-disposition": {
       "version": "0.5.4",

--- a/tools/pfe-tools/dev-server/index.html
+++ b/tools/pfe-tools/dev-server/index.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="{{sheet}}">
   {% endfor %}
   <script type="module">
+    import 'construct-style-sheets-polyfill';
     import 'element-internals-polyfill';
     import '@patternfly/pfe-button';
     import '@patternfly/pfe-tools/dev-server/demo.ts';

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -92,6 +92,7 @@
     "clean-css": "^5.3.1",
     "colorjs.io": "^0.4.0",
     "compression": "^1.7.4",
+    "construct-style-sheets-polyfill": "^3.1.0",
     "custom-elements-manifest": "^2.0.0",
     "dedent": "^0.7.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
## What I did
- proxy `role` and `aria*` props in `ElementInternals` to `InternalsController`
- wrap the host's `form*Callback` methods in `InternalsController`
- add `formDisabled: boolean` to `InternalsController`
- disable BaseButton if it's disabled either by attr or by form, without requiring the reflected attr when form is disabled.

## Testing Instructions
Check out button's `form controls` demo and make sure everything's kosher there