### PR TITLE
docs: band padding & node engine increment in package.json 

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -72,13 +72,7 @@ strong {
 }
 
 @media screen and (min-width: 768px) {
-  .band { padding-inline: calc(100vw - 768px + var(--pfe-theme--container-spacer,1rem) * 4); }
-}
-@media screen and (min-width: 992px) {
-  .band { padding-inline: calc(100vw - 992px + var(--pfe-theme--container-spacer,1rem) * 4); }
-}
-@media screen and (min-width: 1200px) {
-  .band { padding-inline: calc(100vw - 1200px + var(--pfe-theme--container-spacer,1rem) * 4); }
+  .band { padding-inline: calc(100vw - 100% + var(--pfe-theme--container-spacer,1rem) * 4); }
 }
 
 a.cta {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "github:patternfly/patternfly-elements"
   },
   "engines": {
-    "node": ">=14 <=18"
+    "node": ">=16 <=19"
   },
   "scripts": {
     "👷‍♀️-----DEV--------👷‍♀️": "❓ Development aids",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "github:patternfly/patternfly-elements"
   },
   "engines": {
-    "node": ">=14 <=17"
+    "node": ">=14 <=18"
   },
   "scripts": {
     "👷‍♀️-----DEV--------👷‍♀️": "❓ Development aids",


### PR DESCRIPTION
1. Changed the engines included in the package.json since we are currently on node v18.12.1
2. Updated the styles for the `.band` class as they weren't showing up with the correct width for me in Firefox or Chrome.  Open to suggestions on this one as I'm not sure if it's necessary to keep the code or to have it only apply for screens >= 768px.