### PR TITLE
fix(tabs): focus on keyboard navigation

### DIFF
--- a/.changeset/fuzzy-plants-peel.md
+++ b/.changeset/fuzzy-plants-peel.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tabs": patch
+---
+
+Fixed focus on keyboard navigation, await tabindex update before applying focus to tab

--- a/elements/pfe-tabs/BaseTab.ts
+++ b/elements/pfe-tabs/BaseTab.ts
@@ -1,7 +1,7 @@
 import type { PropertyValues } from 'lit';
 
 import { LitElement, html } from 'lit';
-import { queryAssignedElements } from 'lit/decorators.js';
+import { query, queryAssignedElements } from 'lit/decorators.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
 
@@ -20,6 +20,8 @@ export abstract class BaseTab extends LitElement {
   static readonly styles = [style];
 
   static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+  @query('button') _button!: HTMLButtonElement;
 
   @queryAssignedElements({ slot: 'icon', flatten: true })
   private icons!: Array<HTMLElement>;
@@ -67,10 +69,10 @@ export abstract class BaseTab extends LitElement {
 
   #activeChanged() {
     if (this.active && !this.disabled) {
-      this.removeAttribute('tabindex');
+      this._button.removeAttribute('tabindex');
       this.#internals.ariaSelected = 'true';
     } else {
-      this.tabIndex = -1;
+      this._button.tabIndex = -1;
       this.#internals.ariaSelected = 'false';
     }
     this.dispatchEvent(new TabExpandEvent(this.active, this));

--- a/elements/pfe-tabs/BaseTabPanel.ts
+++ b/elements/pfe-tabs/BaseTabPanel.ts
@@ -18,6 +18,15 @@ export abstract class BaseTabPanel extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.#internals.role = 'tabpanel';
+    /*
+     To make it easy for screen reader users to navigate from a tab
+     to the beginning of content in the active tabpanel, the tabpanel
+     element has tabindex="0" to include the panel in the page Tab sequence.
+     It is recommended that all tabpanel elements in a tab set are focusable
+     if there are any panels in the set that contain content where the first
+     element in the panel is not focusable.
+     https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic
+    */
     this.tabIndex = 0;
   }
 }

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -141,7 +141,6 @@ export abstract class BaseTabs extends LitElement {
 
   set #focusTab(tab: BaseTab | undefined) {
     this.#_focusTab = tab;
-    this.#_focusTab?.focus();
   }
 
   override connectedCallback() {
@@ -261,7 +260,6 @@ export abstract class BaseTabs extends LitElement {
       // get index of that focusable tab from all tabs
       nextTab = this.#_focusableTabs[nextFocusableIndex];
     }
-
     this.#select(nextTab);
   }
 
@@ -298,9 +296,11 @@ export abstract class BaseTabs extends LitElement {
     }
   }
 
-  #select(selectedTab: BaseTab): void {
+  async #select(selectedTab: BaseTab): Promise<void> {
     this.#activate(selectedTab);
     this.#focusTab = selectedTab;
+    await this.updateComplete;
+    selectedTab.focus();
   }
 
   #onKeydown = (event: KeyboardEvent): void => {

--- a/elements/pfe-tabs/BaseTabs.ts
+++ b/elements/pfe-tabs/BaseTabs.ts
@@ -300,7 +300,7 @@ export abstract class BaseTabs extends LitElement {
     this.#activate(selectedTab);
     this.#focusTab = selectedTab;
     await this.updateComplete;
-    selectedTab.focus();
+    this.#focusTab.focus();
   }
 
   #onKeydown = (event: KeyboardEvent): void => {

--- a/elements/pfe-tabs/test/pfe-tabs.spec.ts
+++ b/elements/pfe-tabs/test/pfe-tabs.spec.ts
@@ -1,7 +1,8 @@
 import { expect, html, nextFrame, aTimeout } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 import { a11ySnapshot } from '@patternfly/pfe-tools/test/a11y-snapshot.js';
-import { setViewport } from '@web/test-runner-commands';
+import { setViewport, sendKeys } from '@web/test-runner-commands';
+
 import { BaseTab } from '../BaseTab.js';
 import { PfeTabs } from '../pfe-tabs.js';
 
@@ -91,6 +92,21 @@ describe('<pfe-tabs>', function() {
     expect(tab!.hasAttribute('active')).to.equal(true);
     const panel = (await a11ySnapshot()).children.find(x => x.role === 'tabpanel');
     expect(panel?.name, 'active panel').to.equal('Users');
+  });
+
+  it('should change focus when keyboard navigation is used', async function() {
+    const el = await createFixture<PfeTabs>(TEMPLATE);
+    await el.updateComplete;
+    const firstTab = el.querySelector('pfe-tab:first-of-type') as HTMLElement;
+    const secondTab = el.querySelector('pfe-tab:nth-of-type(2)')?.id;
+    firstTab?.focus();
+    await nextFrame();
+    const initial = document.activeElement?.id;
+    await sendKeys({ down: 'ArrowRight' });
+    await nextFrame();
+    const after = document.activeElement?.id;
+    expect(initial).to.not.equal(after);
+    expect(secondTab).to.equal(after);
   });
 
   it('should open panel at same index of selected tab', async function() {


### PR DESCRIPTION
## What I did

- Fixed focus on keyboard navigation, await tabindex update before applying `.focus()` on selected tab.
- Fixed incorrect placement of tabindex on the container of tab and not the button

### Todo:
 - [x] Add spec test that checks for correct focus on keyboard navigation

## Testing Instructions

See [deploy preview demo](https://deploy-preview-2301--patternfly-elements.netlify.app/components/tabs/demo/).

## Reviewer Notes

Check for accessibility of keyboard navigation and correctness of set focus.