### PR TITLE
fix(create-element): remove pfelement decorator

### DIFF
--- a/.changeset/short-donuts-remain.md
+++ b/.changeset/short-donuts-remain.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/create-element": patch
+---
+
+Removed `@pfelement` decorator

--- a/tools/create-element/templates/element/custom-elements-manifest.config.js
+++ b/tools/create-element/templates/element/custom-elements-manifest.config.js
@@ -1,5 +1,5 @@
 import { pfeCustomElementsManifestConfig } from '@patternfly/pfe-tools/custom-elements-manifest.js';
 
 export default pfeCustomElementsManifestConfig({
-globs: ['<%= tagPrefix %>-*.ts'],
+  globs: ['<%= tagPrefix %>-*.ts', 'Base*.ts'],
 });

--- a/tools/create-element/templates/element/demo/demo.css
+++ b/tools/create-element/templates/element/demo/demo.css
@@ -1,3 +1,3 @@
-:host {
-  display: block;
+<%= tagName %> {
+  /* insert demo styles */
 }

--- a/tools/create-element/templates/element/demo/element.html
+++ b/tools/create-element/templates/element/demo/element.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="./demo.css"/>
 <script type="module" src="./<%= tagName %>.js"></script>
+
 <<%= tagName %>></<%= tagName %>>

--- a/tools/create-element/templates/element/demo/element.js
+++ b/tools/create-element/templates/element/demo/element.js
@@ -1,5 +1,3 @@
 import '<%= importSpecifier %>';
 
-const root = document.querySelector('[data-demo="<%= tagName %>"]')?.shadowRoot ?? document;
-
-root.querySelector('<%= tagName %>');
+const element = document.querySelector('<%= tagName %>');

--- a/tools/create-element/templates/element/element.ts
+++ b/tools/create-element/templates/element/element.ts
@@ -1,18 +1,14 @@
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import { pfelement } from '@patternfly/pfe-core/decorators.js';
-
 import styles from '<%= cssRelativePath %>';
 
 /**
  * <%= readmeName %>
  * @slot - Place element content here
  */
-@customElement('<%= tagName %>') @pfelement()
+@customElement('<%= tagName %>')
 export class <%= className %> extends LitElement {
-  static readonly version = '{{version}}';
-
   static readonly styles = [styles];
 
   render() {
@@ -25,5 +21,5 @@ export class <%= className %> extends LitElement {
 declare global {
   interface HTMLElementTagNameMap {
     '<%= tagName %>': <%= className %>;
-}
+  }
 }


### PR DESCRIPTION
## What I did
- remove `@pfelement` decorator from create-element templates
- remove static version string from same
- update demo css and js

closes https://github.com/RedHat-UX/red-hat-design-system/issues/577