### PR TITLE
fix(tools): typescript composite

### DIFF
--- a/.changeset/nasty-donuts-work.md
+++ b/.changeset/nasty-donuts-work.md
@@ -1,0 +1,12 @@
+---
+"@patternfly/pfe-tooltip": patch
+"@patternfly/pfe-tools": patch
+---
+
+`pfe-tools`:
+
+- Set typescript compilerOptions `composite: true`
+
+`pfe-tooltip`:
+
+- Added return type for anonymous function for content in constructor

--- a/elements/pfe-tooltip/BaseTooltip.ts
+++ b/elements/pfe-tooltip/BaseTooltip.ts
@@ -21,7 +21,7 @@ export abstract class BaseTooltip extends LitElement {
 
   #float = new FloatingDOMController(this, {
     arrow: true,
-    content: () => this.shadowRoot?.querySelector('#tooltip'),
+    content: (): HTMLElement | undefined | null => this.shadowRoot?.querySelector('#tooltip'),
   });
 
   override connectedCallback(): void {

--- a/tools/pfe-tools/tsconfig.json
+++ b/tools/pfe-tools/tsconfig.json
@@ -8,7 +8,7 @@
   ],
   "compilerOptions": {
     "target": "es2022",
-    "composite": false,
+    "composite": true,
     "allowJs": false,
     "checkJs": false,
     "emitDeclarationOnly": false


### PR DESCRIPTION
# What I did

`pfe-tools`: Set typescript compilerOptions `composite: true`

`pfe-tooltip`: Added return type for anonymous function for content in constructor
