### PR TITLE
fix(core): roving tabindex controller arrow up/down keys set focus in…

### DIFF
--- a/.changeset/tasty-ties-try.md
+++ b/.changeset/tasty-ties-try.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+
+Fixed `roving-tabindex-controller.js` so active item can be set without setting focus

--- a/.changeset/tasty-ties-try.md
+++ b/.changeset/tasty-ties-try.md
@@ -1,6 +1,0 @@
----
-"@patternfly/pfe-core": patch
----
-
-
-Fixed `roving-tabindex-controller.js` so active item can be set without setting focus

--- a/.changeset/tiny-boxes-compare.md
+++ b/.changeset/tiny-boxes-compare.md
@@ -2,4 +2,6 @@
 "@patternfly/pfe-core": patch
 ---
 
-Fixed `roving-tabindex-controller.js` so that up / down arrow keys listeners to move focus up / down respectively
+Fixed `roving-tabindex-controller.js`: 
+- so that up / down arrow keys listeners to move focus up / down respectively
+- so active item can be set without setting focus

--- a/.changeset/tiny-boxes-compare.md
+++ b/.changeset/tiny-boxes-compare.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+Fixed `roving-tabindex-controller.js` so that up / down arrow keys listeners to move focus up / down respectively

--- a/core/pfe-core/controllers/roving-tabindex-controller.ts
+++ b/core/pfe-core/controllers/roving-tabindex-controller.ts
@@ -109,14 +109,14 @@ export class RovingTabindexController implements ReactiveController {
         this.focusOnItem(this.nextItem);
         shouldPreventDefault = true;
         break;
-      case 'ArrowDown':
+      case 'ArrowUp':
         if (horizontalOnly) {
           return;
         }
         this.focusOnItem(this.prevItem);
         shouldPreventDefault = true;
         break;
-      case 'ArrowUp':
+      case 'ArrowDown':
         if (horizontalOnly) {
           return;
         }

--- a/core/pfe-core/controllers/roving-tabindex-controller.ts
+++ b/core/pfe-core/controllers/roving-tabindex-controller.ts
@@ -158,7 +158,7 @@ export class RovingTabindexController implements ReactiveController {
   /**
    * sets tabindex of item based on whether or not it is active
    */
-  #updateActiveItem(item?: HTMLElement):void {
+  updateActiveItem(item?: HTMLElement):void {
     if (item) {
       if (!!this.#activeItem && item !== this.#activeItem) {
         this.#activeItem.tabIndex = -1;
@@ -172,7 +172,7 @@ export class RovingTabindexController implements ReactiveController {
    * focuses on an item and sets it as active
    */
   focusOnItem(item?: HTMLElement):void {
-    this.#updateActiveItem(item || this.firstItem);
+    this.updateActiveItem(item || this.firstItem);
     this.#activeItem?.focus();
   }
 


### PR DESCRIPTION
## What I did

- switched Arrow Up and Arrow Down in `roving-tabindex-controller`
- made `roving-tabindex-controller`'s updateActiveItem public

## What was changed and why
- In Jump Links, Tabs, and anything else that uses the controller, the arrow up and arrow down keys were moving counterintuitively. (Up was moving to the next item and down to the previous, when it should have been vice versa.)
- In tabs, an active item could already be set when the page loads. Now the active item can be updated with the controller without moving focus to the active tab.

## Testing Instructions
From `jump-links/demo/scrollspy-with-subsections`...

1. Use TAB key to focus on first jump link.
2. Use the ARROW DOWN key to move to the second link.
3. Use ARROW UP to focus on the first jump link.
