### PR TITLE
chore: remove extraneous script entrypoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
-        "@actions/glob": "^0.3.0",
+        "@actions/glob": "^0.4.0",
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
         "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -39,7 +39,7 @@
         "open": "^8.4.0",
         "prompts": "^2.4.2",
         "renamer": "^4.0.0",
-        "wireit": "^0.9.3"
+        "wireit": "^0.9.4"
       },
       "engines": {
         "node": ">=16 <=19"
@@ -47,7 +47,7 @@
     },
     "core/pfe-core": {
       "name": "@patternfly/pfe-core",
-      "version": "2.0.0-rc.0",
+      "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -65,10 +65,10 @@
     },
     "elements": {
       "name": "@patternfly/elements",
-      "version": "2.0.0-rc.0",
+      "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/pfe-core": "^2.0.0-beta.14",
+        "@patternfly/pfe-core": "^2.0.0-rc.1",
         "lit": "2.3.0",
         "tslib": "^2.4.1"
       }
@@ -235,11 +235,12 @@
       }
     },
     "node_modules/@actions/glob": {
-      "version": "0.3.0",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.4.0.tgz",
+      "integrity": "sha512-+eKIGFhsFa4EBwaf/GMyzCdWrXWymGXfFmZU3FHQvYS8mPcHtTtZONbkcqqUMzw9mJ/pImEBFET1JNifhqGsAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.9.1",
         "minimatch": "^3.0.4"
       }
     },
@@ -17205,9 +17206,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.3.tgz",
-      "integrity": "sha512-o31NkFrr+AjGNgarZB094Tw6xWcmNn1uts672B1qKzSo2XMFBt5abjtg/SBUNlBcQPtPryEXJkIUQ6i9p+1Y9w==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
+      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -17441,7 +17442,7 @@
     },
     "tools/create-element": {
       "name": "@patternfly/create-element",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "case": "1.6.3",
@@ -17585,7 +17586,7 @@
     },
     "tools/eslint-config": {
       "name": "@patternfly/eslint-config-elements",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "^8.4.10",
@@ -17602,7 +17603,7 @@
       }
     },
     "tools/netlify-plugin-github-actions": {
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@octokit/core": "4.0.5"
       }
@@ -17636,7 +17637,7 @@
     },
     "tools/pfe-tools": {
       "name": "@patternfly/pfe-tools",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0-beta.1 || ^2.0.0",
@@ -17946,10 +17947,12 @@
       }
     },
     "@actions/glob": {
-      "version": "0.3.0",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.4.0.tgz",
+      "integrity": "sha512-+eKIGFhsFa4EBwaf/GMyzCdWrXWymGXfFmZU3FHQvYS8mPcHtTtZONbkcqqUMzw9mJ/pImEBFET1JNifhqGsAQ==",
       "dev": true,
       "requires": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.9.1",
         "minimatch": "^3.0.4"
       }
     },
@@ -19408,7 +19411,7 @@
     "@patternfly/elements": {
       "version": "file:elements",
       "requires": {
-        "@patternfly/pfe-core": "^2.0.0-beta.14",
+        "@patternfly/pfe-core": "^2.0.0-rc.1",
         "lit": "2.3.0",
         "tslib": "^2.4.1"
       },
@@ -29630,9 +29633,9 @@
       }
     },
     "wireit": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.3.tgz",
-      "integrity": "sha512-o31NkFrr+AjGNgarZB094Tw6xWcmNn1uts672B1qKzSo2XMFBt5abjtg/SBUNlBcQPtPryEXJkIUQ6i9p+1Y9w==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.4.tgz",
+      "integrity": "sha512-QGDxePp956+tBXFAKt/1+cBwfUdCQ23+AcGnjmdTN/9GfkNqiHwfq6n7HyoYEx08tmN6K/faEozkLcMIllhVVg==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,19 +14,9 @@
     "🐒-DEV": "❓ Development aids",
     "start": "wireit",
     "dev": "wireit",
-    "dev:server": "wireit",
-    "dev:tools": "wireit",
-    "watch:analyze": "wireit",
     "new": "npm run build:create && ./tools/create-element/bin/main.js",
     "🚧-BUILD": "❓ Make packages and artifacts",
     "build": "wireit",
-    "build:tools": "wireit",
-    "build:elements": "wireit",
-    "build:icons": "wireit",
-    "build:core": "wireit",
-    "build:lightdom": "wireit",
-    "build:bundle": "wireit",
-    "build:create": "wireit",
     "analyze": "wireit",
     "docs": "wireit",
     "site": "npm run build",
@@ -274,7 +264,7 @@
   "devDependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "@actions/glob": "^0.3.0",
+    "@actions/glob": "^0.4.0",
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -299,7 +289,7 @@
     "open": "^8.4.0",
     "prompts": "^2.4.2",
     "renamer": "^4.0.0",
-    "wireit": "^0.9.3"
+    "wireit": "^0.9.4"
   },
   "workspaces": [
     "./core/*",


### PR DESCRIPTION
## What I did
- update wireit, allowing script dependencies that aren't defined in `"scripts"`
- remove intermediate scripts from `"scripts"`