### PR TITLE
docs: passthrough copy and import maps for pfe.min.js

### DIFF
--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -87,18 +87,22 @@ module.exports = async function() {
   const map = generator.getMap();
   map.imports['/docs/zero-md.js'] = '/zero-md.js';
   map.imports['@patternfly/elements'] = '/pfe.min.js';
+
+  // add imports for imports under pfe-core
+  const pfeCoreImports = (await glob('./{functions,controllers,decorators}/*.ts', { cwd: path.join(__dirname, '../../core/pfe-core') }))
+    .filter(x => !x.endsWith('.d.ts'))
+    .map(x => x.replace('.ts', '.js'));
+  for (const file of pfeCoreImports) {
+    map.imports[path.join('@patternfly/pfe-core', file)] = '/pfe.min.js';
+  }
+  map.imports['@patternfly/pfe-core/decorators.js'] = '/pfe.min.js';
+  map.imports['@patternfly/pfe-core'] = '/pfe.min.js';
+
   for (const tagName of fs.readdirSync(path.join(__dirname, '..', '..', 'elements'))) {
     map.imports[`@patternfly/elements/${tagName}/${tagName}.js`] = `/pfe.min.js`;
   }
   map.imports['@patternfly/pfe-tools/environment.js'] = '/tools/environment.js';
 
-  // add imports for imports under pfe-core
-  const pfeCoreImports = (await glob('./{functions,controllers}/*.ts', { cwd: path.join(__dirname, '../../core/pfe-core') }))
-    .filter(x => !x.endsWith('.d.ts'))
-    .map(x => x.replace('.ts', '.js'));
-  for (const file of pfeCoreImports) {
-    map.imports[path.join('@patternfly/elements', file)] = '/pfe.min.js';
-  }
 
   return map;
 };

--- a/docs/_plugins/pfe-assets.cjs
+++ b/docs/_plugins/pfe-assets.cjs
@@ -74,7 +74,7 @@ module.exports = {
   configFunction(eleventyConfig, options) {
     eleventyConfig.addPassthroughCopy('docs/bundle.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
-    eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
+    eleventyConfig.addPassthroughCopy({ 'elements/pfe.min.js': 'pfe.min.js' } );
     eleventyConfig.addPassthroughCopy('docs/demo.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/main.mjs');
     eleventyConfig.addPassthroughCopy({ 'elements/pf-icon/icons/': 'components/icon/icons' });

--- a/docs/_plugins/pfe-assets.cjs
+++ b/docs/_plugins/pfe-assets.cjs
@@ -77,7 +77,7 @@ module.exports = {
     eleventyConfig.addPassthroughCopy({ 'elements/pfe.min.js': 'pfe.min.js' } );
     eleventyConfig.addPassthroughCopy('docs/demo.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/main.mjs');
-    eleventyConfig.addPassthroughCopy({ 'elements/pf-icon/icons/': 'components/icon/icons' });
+    eleventyConfig.addPassthroughCopy({ 'elements/pf-icon/icons/': 'icons' });
     eleventyConfig.addPassthroughCopy({
       'node_modules/@rhds/elements': '/assets/@rhds'
     });

--- a/docs/_plugins/pfe-assets.cjs
+++ b/docs/_plugins/pfe-assets.cjs
@@ -74,6 +74,7 @@ module.exports = {
   configFunction(eleventyConfig, options) {
     eleventyConfig.addPassthroughCopy('docs/bundle.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
+    eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
     eleventyConfig.addPassthroughCopy('docs/demo.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/main.mjs');
     eleventyConfig.addPassthroughCopy({ 'elements/pf-icon/icons/': 'components/icon/icons' });

--- a/docs/_plugins/pfe-assets.cjs
+++ b/docs/_plugins/pfe-assets.cjs
@@ -74,7 +74,7 @@ module.exports = {
   configFunction(eleventyConfig, options) {
     eleventyConfig.addPassthroughCopy('docs/bundle.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
-    eleventyConfig.addPassthroughCopy({ 'elements/pfe.min.js': 'pfe.min.js' } );
+    eleventyConfig.addPassthroughCopy({ 'elements/pfe.min.*': '/' } );
     eleventyConfig.addPassthroughCopy('docs/demo.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/main.mjs');
     eleventyConfig.addPassthroughCopy({ 'elements/pf-icon/icons/': 'icons' });

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -38,7 +38,6 @@ export async function bundle() {
     minifyWhitespace: true,
 
     external: [
-      '@patternfly*',
       'lit',
       'tslib',
       '@floating-ui*'


### PR DESCRIPTION
## What I did

- Added passthroughcopy for `pfe.min.js`
- Added import map for `pfe-core` controllers, functions and decorators 