### PR TITLE
feat(tools): add minify option to ts css-imports

### DIFF
--- a/.changeset/curvy-windows-poke.md
+++ b/.changeset/curvy-windows-poke.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Allowed TypeScript modules to import multiple CSS modules when inlining CSS.

--- a/.changeset/itchy-roses-vanish.md
+++ b/.changeset/itchy-roses-vanish.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": minor
+---
+
+✨ Added `minify` option to `@patternfly/pfe-tools/typescript/transformers/css-imports.cjs`

--- a/tools/pfe-tools/typescript/transformers/css-imports.cjs
+++ b/tools/pfe-tools/typescript/transformers/css-imports.cjs
@@ -45,10 +45,10 @@ function createLitCssImportStatement(ctx, sourceFile) {
 
 /**
  * @param {import('typescript').CoreTransformationContext} ctx
- * @param {string} content
+ * @param {string} stylesheet
  * @param {string} [name]
  */
-function createLitCssTaggedTemplateLiteral(ctx, content, name) {
+function createLitCssTaggedTemplateLiteral(ctx, stylesheet, name) {
   return ctx.factory.createVariableStatement(
     undefined,
     ctx.factory.createVariableDeclarationList([
@@ -59,7 +59,7 @@ function createLitCssTaggedTemplateLiteral(ctx, content, name) {
         ctx.factory.createTaggedTemplateExpression(
           ctx.factory.createIdentifier('css'),
           undefined,
-          ctx.factory.createNoSubstitutionTemplateLiteral(content),
+          ctx.factory.createNoSubstitutionTemplateLiteral(stylesheet),
         )
       )
     ], ts.NodeFlags.Const)
@@ -67,11 +67,29 @@ function createLitCssTaggedTemplateLiteral(ctx, content, name) {
 }
 
 /**
+ * @param {string} stylesheet
+ * @param {string} filePath
+ */
+function minifyCss(stylesheet, filePath) {
+  const CleanCSS = require('clean-css');
+
+  try {
+    const clean = new CleanCSS({ returnPromise: false });
+    const { styles } = clean.minify(stylesheet);
+    return styles;
+  } catch (e) {
+    console.log('Could not minify ', filePath);
+    console.error(e);
+    return stylesheet;
+  }
+}
+
+/**
  * Replace .css import specifiers with .css.js import specifiers
  * @param {import('typescript').Program} _program
  * @return {import('typescript').TransformerFactory<import('typescript').Node>}
  */
-module.exports = function(_program, { inline = false } = {}) {
+module.exports = function(_program, { inline = false, minify = false } = {}) {
   return ctx => {
     /**
      * @param {import('typescript').Node} node
@@ -85,9 +103,10 @@ module.exports = function(_program, { inline = false } = {}) {
             const dir = pathToFileURL(fileName);
             const url = new URL(specifier, dir);
             const content = fs.readFileSync(url, 'utf-8');
+            const stylesheet = minify ? minifyCss(content, url.pathname) : content;
             return [
               createLitCssImportStatement(ctx, node.getSourceFile()),
-              createLitCssTaggedTemplateLiteral(ctx, content, node.importClause?.name?.getText()),
+              createLitCssTaggedTemplateLiteral(ctx, stylesheet, node.importClause?.name?.getText()),
             ];
           } else {
             return ctx.factory.createImportDeclaration(

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -38,7 +38,8 @@
     "plugins": [
       {
         "transform": "@patternfly/pfe-tools/typescript/transformers/css-imports.cjs",
-        "inline": true
+        "inline": true,
+        "minify": true
       },
       {
         "name": "typescript-lit-html-plugin"


### PR DESCRIPTION
## What I did

1. Added `minify` option to css-imports typescript transform and enabled it in build config
2. Fixed `inline` option of css-imports transformer to allow ts sources to import multiple css sheets

## Testing Instructions

Say you had these files:
- a.css
  ```css
  a { color: var(--a); }
  ```
- b.css
  ```css
  b { color: var(--b); }
  ```
- m.ts
  ```ts
  import a from './a.css';
  import b from './b.css';
  export {a, b};
  ```

Try building using ttsc with this config:

```json
{
  "compilerOptions": {
    "module": "es2020",
    "moduleResolution": "Node",
    "strict": true,
    "target": "es2020",
    "plugins": [
      {
        "transform": "@patternfly/pfe-tools/typescript/transformers/css-imports.cjs",
        "inline": true,
        "minify": true
      }
    ]
  }
}
```
Before: 
```js
import { css } from "lit";
const a = css `a { color: var(--a); }`;
import { css } from "lit";
const b = css `b { color: var(--b); }`;
export { a, b };
```
After:
```js
import { css } from "lit";
const styles = css `a{color:var(--a);}`;
const styles = css `b{color:var(--b);}`;
export { a, b };
```

You can try this by building rhds. `rh-context-provider.ts` imports 2 stylesheets.
