### PR TITLE
fix(docs): Updating footer copyright date to 2018-2023

### DIFF
--- a/docs/_includes/_foot.njk
+++ b/docs/_includes/_foot.njk
@@ -34,7 +34,7 @@
     <li><a href="https://github.com/patternfly/patternfly-elements/blob/main/CODE_OF_CONDUCT.md">Code of conduct</a></li>
     <li><a href="https://www.redhat.com/mailman/listinfo/patternfly-elements-contribute">Contributors email list</a></li>
   </ul>
-  <rh-footer-copyright slot="links-secondary">© 2022-{{ page.date.getFullYear() }} Red Hat, Inc.</rh-footer-copyright>
+  <rh-footer-copyright slot="links-secondary">© 2018-{{ page.date.getFullYear() }} Red Hat, Inc.</rh-footer-copyright>
   <h3 slot="links-secondary" hidden>Resources</h3>
   <ul slot="links-secondary">
     <li><a href="/get-started">Documentation</a></li>{% if page.url == component.url %}

--- a/docs/home.css
+++ b/docs/home.css
@@ -83,6 +83,7 @@
 rh-global-footer {
   width: 100vw !important;
   translate: none !important;
+  transform: none;
   --rh-footer-icon-color: var(--rh-color-black-500, #8a8d90);
   --rh-footer-icon-color-hover: var(--rh-color-black-400, #b8bbbe);
 }


### PR DESCRIPTION
Previously we had updated the copyright date in the footer to 2022 - {{ currentYear }}, this needs to be updated to 2018 - {{ currentYear }}