### PR TITLE
fix(tabs): make showOverflow protected

### DIFF
--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
@@ -151,9 +152,9 @@ export abstract class BaseTabs extends LitElement {
 
   override render() {
     const { scrollIconSet, scrollIconLeft, scrollIconRight } = this.constructor as typeof BaseTabs;
-
+    const classes = { overflow: this.#showScrollButtons };
     return html`
-      <div part="container">
+      <div part="container" class="${classMap(classes)}">
         <div part="tabs-container">${!this.#showScrollButtons ? '' : html`
           <button id="previousTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -1,6 +1,5 @@
 import { LitElement, html } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 
 import { RovingTabindexController } from '@patternfly/pfe-core/controllers/roving-tabindex-controller.js';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
@@ -58,7 +57,7 @@ export abstract class BaseTabs extends LitElement {
 
   @query('[part="tabs"]') private tabList!: HTMLElement;
 
-  #showScrollButtons = false;
+  protected _showScrollButtons = false;
 
   #overflowOnLeft = false;
 
@@ -152,10 +151,9 @@ export abstract class BaseTabs extends LitElement {
 
   override render() {
     const { scrollIconSet, scrollIconLeft, scrollIconRight } = this.constructor as typeof BaseTabs;
-    const classes = { overflow: this.#showScrollButtons };
     return html`
-      <div part="container" class="${classMap(classes)}">
-        <div part="tabs-container">${!this.#showScrollButtons ? '' : html`
+      <div part="container">
+        <div part="tabs-container">${!this._showScrollButtons ? '' : html`
           <button id="previousTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"
               ?disabled="${!this.#overflowOnLeft}"
@@ -165,7 +163,7 @@ export abstract class BaseTabs extends LitElement {
           <slot name="tab"
                 part="tabs"
                 role="tablist"
-                @slotchange="${this.#onSlotchange}"></slot> ${!this.#showScrollButtons ? '' : html`
+                @slotchange="${this.#onSlotchange}"></slot> ${!this._showScrollButtons ? '' : html`
           <button id="nextTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
               ?disabled="${!this.#overflowOnRight}"
@@ -315,7 +313,7 @@ export abstract class BaseTabs extends LitElement {
     const { canShowScrollButtons } = this;
     this.#overflowOnLeft = canShowScrollButtons && !isElementInView(this.tabList, this.#firstTab);
     this.#overflowOnRight = canShowScrollButtons && !isElementInView(this.tabList, this.#lastTab);
-    this.#showScrollButtons = canShowScrollButtons && (this.#overflowOnLeft || this.#overflowOnRight);
+    this._showScrollButtons = canShowScrollButtons && (this.#overflowOnLeft || this.#overflowOnRight);
     this.requestUpdate();
   }
 


### PR DESCRIPTION
## What I did

1. Made `showScrollButtons` protected in order to be able to read it from a child class.


## Notes:  

By making `showScrollButtons` protected I can read it in a child class downstream. This will allow the child class to know if the overflow has occurred or not.    
