### PR TITLE
feat(core): add overflow controller

### DIFF
--- a/.changeset/core-overflow-controller.md
+++ b/.changeset/core-overflow-controller.md
@@ -1,0 +1,9 @@
+---
+"@patternfly/pfe-core": minor
+---
+
+✨ Added `OverflowController`
+
+When added to a container and given a child array of elements, 
+`OverflowController` checks to see if those elements exceed the bounds of the 
+container.

--- a/.changeset/eighty-colts-study.md
+++ b/.changeset/eighty-colts-study.md
@@ -1,7 +1,0 @@
----
-"@patternfly/pfe-core": patch
-"@patternfly/elements": patch
----
-
-- ✨ `pfe-core`: Added `OverflowController` which when added to a container and given a child array of elements checks to see if those elements exceed the bounds of the container.
-- `pfe-tabs`: Integrated overflow controller into `BaseTabs`.

--- a/.changeset/eighty-colts-study.md
+++ b/.changeset/eighty-colts-study.md
@@ -3,5 +3,5 @@
 "@patternfly/elements": patch
 ---
 
-- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check to see if those elements exceed the bounds of the container. 
+- ✨ `pfe-core`: Added `OverflowController` which when added to a container and given a child array of elements checks to see if those elements exceed the bounds of the container.
 - `pfe-tabs`: Integrated overflow controller into `BaseTabs`.

--- a/.changeset/eighty-colts-study.md
+++ b/.changeset/eighty-colts-study.md
@@ -3,5 +3,5 @@
 "@patternfly/elements": patch
 ---
 
-- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check so see if those elements exceed the bounds of the container. 
+- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check to see if those elements exceed the bounds of the container. 
 - `pfe-tabs`: Integrated overflow controller into `BaseTabs`.

--- a/.changeset/eighty-colts-study.md
+++ b/.changeset/eighty-colts-study.md
@@ -3,5 +3,5 @@
 "@patternfly/elements": patch
 ---
 
-- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check so see if those elements exceed the bounds of hte container. 
+- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check so see if those elements exceed the bounds of the container. 
 - `pfe-tabs`: Integrated overflow controller into `BaseTabs`.

--- a/.changeset/eighty-colts-study.md
+++ b/.changeset/eighty-colts-study.md
@@ -1,0 +1,7 @@
+---
+"@patternfly/pfe-core": patch
+"@patternfly/elements": patch
+---
+
+- ✨ `pfe-core`: Added `OverflowController` which when added to a container and a group of elements check so see if those elements exceed the bounds of hte container. 
+- `pfe-tabs`: Integrated overflow controller into `BaseTabs`.

--- a/.changeset/tabs-update-overflow.md
+++ b/.changeset/tabs-update-overflow.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-tabs>`: integrated overflow controller.

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -55,38 +55,38 @@ export class OverflowController implements ReactiveController {
     this.#scrollTimeout = setTimeout(() => this.#setOverflowState(), this.#scrollTimeoutDelay);
   };
 
-  scrollLeft(instance: OverflowController) {
-    if (!instance.#container) {
+  scrollLeft() {
+    if (!this.#container) {
       return;
     }
     let firstElementInView: HTMLElement | undefined;
     let lastElementOutOfView: HTMLElement | undefined;
-    for (let i = 0; i < instance.#items.length && !firstElementInView; i++) {
-      if (isElementInView(instance.#container, instance.#items[i] as HTMLElement, false)) {
-        firstElementInView = instance.#items[i];
-        lastElementOutOfView = instance.#items[i - 1];
+    for (let i = 0; i < this.#items.length && !firstElementInView; i++) {
+      if (isElementInView(this.#container, this.#items[i] as HTMLElement, false)) {
+        firstElementInView = this.#items[i];
+        lastElementOutOfView = this.#items[i - 1];
       }
     }
     if (lastElementOutOfView) {
-      instance.#container.scrollLeft -= lastElementOutOfView.scrollWidth;
+      this.#container.scrollLeft -= lastElementOutOfView.scrollWidth;
     }
     this.#setOverflowState();
   }
 
-  scrollRight(instance: OverflowController) {
-    if (!instance.#container) {
+  scrollRight() {
+    if (!this.#container) {
       return;
     }
     let lastElementInView: HTMLElement | undefined;
     let firstElementOutOfView: HTMLElement | undefined;
-    for (let i = instance.#items.length - 1; i >= 0 && !lastElementInView; i--) {
-      if (isElementInView(instance.#container, instance.#items[i] as HTMLElement, false)) {
-        lastElementInView = instance.#items[i];
-        firstElementOutOfView = instance.#items[i + 1];
+    for (let i = this.#items.length - 1; i >= 0 && !lastElementInView; i--) {
+      if (isElementInView(this.#container, this.#items[i] as HTMLElement, false)) {
+        lastElementInView = this.#items[i];
+        firstElementOutOfView = this.#items[i + 1];
       }
     }
     if (firstElementOutOfView) {
-      instance.#container.scrollLeft += firstElementOutOfView.scrollWidth;
+      this.#container.scrollLeft += firstElementOutOfView.scrollWidth;
     }
     this.#setOverflowState();
   }

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -91,7 +91,6 @@ export class OverflowController implements ReactiveController {
     this.#setOverflowState();
   }
 
-
   update() {
     this.#setOverflowState();
   }

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -22,7 +22,7 @@ export class OverflowController implements ReactiveController {
   }
 
   get firstItem(): HTMLElement | undefined {
-    return this.#items[0];
+    return this.#items.at(0);
   }
 
   get lastItem(): HTMLElement | undefined {

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -1,0 +1,103 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+import { isElementInView } from '@patternfly/pfe-core/functions/isElementInView.js';
+
+export class OverflowController implements ReactiveController {
+  /** Overflow container */
+  #container?: HTMLElement;
+  /** Children that can overflow */
+  #items: HTMLElement[] = [];
+
+  #scrollTimeoutDelay = 0;
+  #scrollTimeout?: ReturnType<typeof setTimeout>;
+
+  /** Default state */
+  showScrollButtons = false;
+  overflowLeft = false;
+  overflowRight = false;
+
+  /** override to prevent scroll buttons from showing */
+  protected get canShowScrollButtons() {
+    return true;
+  }
+
+  get firstItem(): HTMLElement | undefined {
+    return this.#items[0];
+  }
+
+  get lastItem(): HTMLElement | undefined {
+    return this.#items.at(-1);
+  }
+
+  constructor(public host: ReactiveControllerHost & HTMLElement) {
+    this.host.addController(this);
+  }
+
+  #setOverflowState(): void {
+    const { canShowScrollButtons } = this;
+    if (!this.firstItem || !this.lastItem || !this.#container) {
+      return;
+    }
+    this.overflowLeft = canShowScrollButtons && !isElementInView(this.#container, this.firstItem);
+    this.overflowRight = canShowScrollButtons && !isElementInView(this.#container, this.lastItem);
+    this.showScrollButtons = canShowScrollButtons && (this.overflowLeft || this.overflowRight);
+    this.host.requestUpdate();
+  }
+
+  init(container: HTMLElement, items: HTMLElement[]) {
+    this.#container = container;
+    // convert HTMLCollection to HTMLElement[]
+    this.#items = items;
+  }
+
+  onScroll = () => {
+    clearTimeout(this.#scrollTimeout);
+    this.#scrollTimeout = setTimeout(() => this.#setOverflowState(), this.#scrollTimeoutDelay);
+  };
+
+  scrollLeft(instance: OverflowController) {
+    if (!instance.#container) {
+      return;
+    }
+    let firstElementInView: HTMLElement | undefined;
+    let lastElementOutOfView: HTMLElement | undefined;
+    for (let i = 0; i < instance.#items.length && !firstElementInView; i++) {
+      if (isElementInView(instance.#container, instance.#items[i] as HTMLElement, false)) {
+        firstElementInView = instance.#items[i];
+        lastElementOutOfView = instance.#items[i - 1];
+      }
+    }
+    if (lastElementOutOfView) {
+      instance.#container.scrollLeft -= lastElementOutOfView.scrollWidth;
+    }
+    this.#setOverflowState();
+  }
+
+  scrollRight(instance: OverflowController) {
+    if (!instance.#container) {
+      return;
+    }
+    let lastElementInView: HTMLElement | undefined;
+    let firstElementOutOfView: HTMLElement | undefined;
+    for (let i = instance.#items.length - 1; i >= 0 && !lastElementInView; i--) {
+      if (isElementInView(instance.#container, instance.#items[i] as HTMLElement, false)) {
+        lastElementInView = instance.#items[i];
+        firstElementOutOfView = instance.#items[i + 1];
+      }
+    }
+    if (firstElementOutOfView) {
+      instance.#container.scrollLeft += firstElementOutOfView.scrollWidth;
+    }
+    this.#setOverflowState();
+  }
+
+
+  update() {
+    this.#setOverflowState();
+  }
+
+  hostConnected(): void {
+    this.onScroll();
+    this.#setOverflowState();
+  }
+}

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -29,7 +29,7 @@ export class OverflowController implements ReactiveController {
     return this.#items.at(-1);
   }
 
-  constructor(public host: ReactiveControllerHost & HTMLElement) {
+  constructor(public host: ReactiveControllerHost & Element) {
     this.host.addController(this);
   }
 

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -2,6 +2,10 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 import { isElementInView } from '@patternfly/pfe-core/functions/isElementInView.js';
 
+export interface Options {
+  hideOverflowButtons?: boolean;
+}
+
 export class OverflowController implements ReactiveController {
   /** Overflow container */
   #container?: HTMLElement;
@@ -12,14 +16,10 @@ export class OverflowController implements ReactiveController {
   #scrollTimeout?: ReturnType<typeof setTimeout>;
 
   /** Default state */
+  #hideOverflowButtons = false;
   showScrollButtons = false;
   overflowLeft = false;
   overflowRight = false;
-
-  /** override to prevent scroll buttons from showing */
-  protected get canShowScrollButtons() {
-    return true;
-  }
 
   get firstItem(): HTMLElement | undefined {
     return this.#items.at(0);
@@ -29,18 +29,20 @@ export class OverflowController implements ReactiveController {
     return this.#items.at(-1);
   }
 
-  constructor(public host: ReactiveControllerHost & Element) {
+  constructor(public host: ReactiveControllerHost & Element, private options?: Options) {
     this.host.addController(this);
+    if (options?.hideOverflowButtons) {
+      this.#hideOverflowButtons = options?.hideOverflowButtons;
+    }
   }
 
   #setOverflowState(): void {
-    const { canShowScrollButtons } = this;
     if (!this.firstItem || !this.lastItem || !this.#container) {
       return;
     }
-    this.overflowLeft = canShowScrollButtons && !isElementInView(this.#container, this.firstItem);
-    this.overflowRight = canShowScrollButtons && !isElementInView(this.#container, this.lastItem);
-    this.showScrollButtons = canShowScrollButtons && (this.overflowLeft || this.overflowRight);
+    this.overflowLeft = !this.#hideOverflowButtons && !isElementInView(this.#container, this.firstItem);
+    this.overflowRight = !this.#hideOverflowButtons && !isElementInView(this.#container, this.lastItem);
+    this.showScrollButtons = !this.#hideOverflowButtons && (this.overflowLeft || this.overflowRight);
     this.host.requestUpdate();
   }
 

--- a/core/pfe-core/functions/isElementInView.ts
+++ b/core/pfe-core/functions/isElementInView.ts
@@ -2,10 +2,10 @@
  * This function returns whether or not an element is within the viewable area of a container. If partial is true,
  * then this function will return true even if only part of the element is in view.
  *
- * @param container  The container to check if the element is in view of.
- * @param element    The element to check if it is view
- * @param partial   true if partial view is allowed
- * @param strict    true if strict mode is set, never consider the container width and element width
+ * @param {HTMLElement} container  The container to check if the element is in view of.
+ * @param {HTMLElement} element    The element to check if it is view
+ * @param {boolean} partial   true if partial view is allowed
+ * @param {boolean} strict    true if strict mode is set, never consider the container width and element width
  *
  * @returns True if the component is in View.
  */

--- a/docs/components/demos.html
+++ b/docs/components/demos.html
@@ -82,6 +82,7 @@ preloads: [
     <noscript><link href="{{ '/core/styles/pf--noscript.min.css' | url }}" rel="stylesheet"></noscript>
     <script async src="https://ga.jspm.io/npm:es-module-shims@1.6.1/dist/es-module-shims.js"></script>
     <script type="module">
+    import 'element-internals-polyfill';
     import { PfIcon } from '@patternfly/elements/pf-icon/pf-icon.js';
     const get = (set, icon) => new URL(`/components/icon/icons/${set}/${icon}.js`, import.meta.url);
     PfIcon.addIconSet('patternfly', get);

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -147,7 +147,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   async firstUpdated() {
-    this.tabList.addEventListener('scroll', this.#overflow.onScroll);
+    this.tabList.addEventListener('scroll', this.#overflow.onScroll.bind(this));
   }
 
   override render() {

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -17,7 +17,6 @@ import { BaseTabPanel } from './BaseTabPanel.js';
 
 import styles from './BaseTabs.css';
 
-
 /**
  * BaseTabs
  *

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -41,9 +41,6 @@ export abstract class BaseTabs extends LitElement {
   /** Icon set to use for the scroll buttons */
   protected static readonly scrollIconSet: string = 'fas';
 
-  #tabindex = new RovingTabindexController(this);
-  #overflow = new OverflowController(this);
-
   static #instances = new Set<BaseTabs>();
 
   static {
@@ -60,6 +57,10 @@ export abstract class BaseTabs extends LitElement {
   @queryAssignedElements() private panels!: BaseTabPanel[];
 
   @query('[part="tabs"]') private tabList!: HTMLElement;
+
+  #tabindex = new RovingTabindexController(this);
+
+  #overflow = new OverflowController(this);
 
   #logger = new Logger(this);
 

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -161,7 +161,7 @@ export abstract class BaseTabs extends LitElement {
           <button id="previousTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"
               ?disabled="${!this.#overflow.overflowLeft}"
-              @click="${this.#scrollLeft.bind(this)}">
+              @click="${this.#scrollLeft}">
             <pf-icon icon="${scrollIconLeft}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
           <slot name="tab"
@@ -171,7 +171,7 @@ export abstract class BaseTabs extends LitElement {
           <button id="nextTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
               ?disabled="${!this.#overflow.overflowRight}"
-              @click="${this.#scrollRight.bind(this)}">
+              @click="${this.#scrollRight}">
             <pf-icon icon="${scrollIconRight}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
         </div>

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -41,8 +41,8 @@ export abstract class BaseTabs extends LitElement {
   /** Icon set to use for the scroll buttons */
   protected static readonly scrollIconSet: string = 'fas';
 
-  #rovingTabindexController = new RovingTabindexController(this);
-  #overflowController = new OverflowController(this);
+  #tabindex = new RovingTabindexController(this);
+  #overflow = new OverflowController(this);
 
   static #instances = new Set<BaseTabs>();
 
@@ -50,7 +50,7 @@ export abstract class BaseTabs extends LitElement {
     // on resize check for overflows to add or remove scroll buttons
     window.addEventListener('resize', () => {
       for (const instance of this.#instances) {
-        instance.#overflowController.onScroll();
+        instance.#overflow.onScroll();
       }
     }, { capture: false });
   }
@@ -89,7 +89,7 @@ export abstract class BaseTabs extends LitElement {
     if (tab) {
       if (tab.disabled) {
         this.#logger.warn(`Disabled tabs can not be active, setting first focusable tab to active`);
-        this.#rovingTabindexController.updateActiveItem(this.#firstFocusable);
+        this.#tabindex.updateActiveItem(this.#firstFocusable);
         index = this.#activeItemIndex;
       } else if (!tab.active) {
         // if the activeIndex was set through the CLI e.g.`$0.activeIndex = 2`
@@ -100,8 +100,8 @@ export abstract class BaseTabs extends LitElement {
 
     if (index === -1) {
       this.#logger.warn(`No active tab found, setting first focusable tab to active`);
-      const first = this.#rovingTabindexController.firstItem as BaseTab;
-      this.#rovingTabindexController.updateActiveItem(first);
+      const first = this.#tabindex.firstItem as BaseTab;
+      this.#tabindex.updateActiveItem(first);
       index = this.#activeItemIndex;
     }
     this.#activeIndex = index;
@@ -146,27 +146,27 @@ export abstract class BaseTabs extends LitElement {
   }
 
   async firstUpdated() {
-    this.tabList.addEventListener('scroll', this.#overflowController.onScroll);
+    this.tabList.addEventListener('scroll', this.#overflow.onScroll);
   }
 
   override render() {
     const { scrollIconSet, scrollIconLeft, scrollIconRight } = this.constructor as typeof BaseTabs;
     return html`
-      <div part="container" class="${classMap({ overflow: this.#overflowController.showScrollButtons })}">
-        <div part="tabs-container">${!this.#overflowController.showScrollButtons ? '' : html`
+      <div part="container" class="${classMap({ overflow: this.#overflow.showScrollButtons })}">
+        <div part="tabs-container">${!this.#overflow.showScrollButtons ? '' : html`
           <button id="previousTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"
-              ?disabled="${!this.#overflowController.overflowLeft}"
+              ?disabled="${!this.#overflow.overflowLeft}"
               @click="${this.#scrollLeft}">
             <pf-icon icon="${scrollIconLeft}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
           <slot name="tab"
                 part="tabs"
                 role="tablist"
-                @slotchange="${this.#onSlotchange}"></slot> ${!this.#overflowController.showScrollButtons ? '' : html`
+                @slotchange="${this.#onSlotchange}"></slot> ${!this.#overflow.showScrollButtons ? '' : html`
           <button id="nextTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
-              ?disabled="${!this.#overflowController.overflowRight}"
+              ?disabled="${!this.#overflow.overflowRight}"
               @click="${this.#scrollRight}">
             <pf-icon icon="${scrollIconRight}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
@@ -187,10 +187,10 @@ export abstract class BaseTabs extends LitElement {
       (this.#allTabs.length !== 0 || this.#allPanels.length !== 0)) {
       this.#updateAccessibility();
       this.#firstLastClasses();
-      this.#rovingTabindexController.initItems(this.#allTabs);
+      this.#tabindex.initItems(this.#allTabs);
       this.activeIndex = this.#allTabs.findIndex(tab => tab.active);
-      this.#rovingTabindexController.updateActiveItem(this.#activeTab);
-      this.#overflowController.init(this.tabList, this.#allTabs);
+      this.#tabindex.updateActiveItem(this.#activeTab);
+      this.#overflow.init(this.tabList, this.#allTabs);
     }
   }
 
@@ -222,11 +222,11 @@ export abstract class BaseTabs extends LitElement {
   }
 
   get #firstFocusable(): BaseTab {
-    return this.#rovingTabindexController.firstItem as BaseTab;
+    return this.#tabindex.firstItem as BaseTab;
   }
 
   get #lastFocusable(): BaseTab {
-    return this.#rovingTabindexController.lastItem as BaseTab;
+    return this.#tabindex.lastItem as BaseTab;
   }
 
   get #firstTab(): BaseTab {
@@ -239,7 +239,7 @@ export abstract class BaseTabs extends LitElement {
   }
 
   get #activeItemIndex() {
-    const { activeItem } = this.#rovingTabindexController;
+    const { activeItem } = this.#tabindex;
     return this.#allTabs.findIndex(t => t === activeItem);
   }
 
@@ -265,13 +265,13 @@ export abstract class BaseTabs extends LitElement {
       case 'ArrowUp':
       case 'ArrowLeft':
         event.preventDefault();
-        this.#select(this.#rovingTabindexController.activeItem as BaseTab);
+        this.#select(this.#tabindex.activeItem as BaseTab);
         break;
 
       case 'ArrowDown':
       case 'ArrowRight':
         event.preventDefault();
-        this.#select(this.#rovingTabindexController.activeItem as BaseTab);
+        this.#select(this.#tabindex.activeItem as BaseTab);
         break;
 
       case 'Home':
@@ -295,10 +295,10 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #scrollLeft() {
-    this.#overflowController.scrollLeft(this.#overflowController);
+    this.#overflow.scrollLeft(this.#overflow);
   }
 
   #scrollRight() {
-    this.#overflowController.scrollRight(this.#overflowController);
+    this.#overflow.scrollRight(this.#overflow);
   }
 }

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -158,7 +158,7 @@ export abstract class BaseTabs extends LitElement {
           <button id="previousTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-left') ?? 'Scroll left'}"
               ?disabled="${!this.#overflow.overflowLeft}"
-              @click="${this.#scrollLeft}">
+              @click="${this.#scrollLeft.bind(this)}">
             <pf-icon icon="${scrollIconLeft}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
           <slot name="tab"
@@ -168,7 +168,7 @@ export abstract class BaseTabs extends LitElement {
           <button id="nextTab" tabindex="-1"
               aria-label="${this.getAttribute('label-scroll-right') ?? 'Scroll right'}"
               ?disabled="${!this.#overflow.overflowRight}"
-              @click="${this.#scrollRight}">
+              @click="${this.#scrollRight.bind(this)}">
             <pf-icon icon="${scrollIconRight}" set="${scrollIconSet}" loading="eager"></pf-icon>
           </button>`}
         </div>
@@ -296,10 +296,10 @@ export abstract class BaseTabs extends LitElement {
   }
 
   #scrollLeft() {
-    this.#overflow.scrollLeft(this.#overflow);
+    this.#overflow.scrollLeft();
   }
 
   #scrollRight() {
-    this.#overflow.scrollRight(this.#overflow);
+    this.#overflow.scrollRight();
   }
 }

--- a/elements/pf-tabs/demo/pf-tabs.js
+++ b/elements/pf-tabs/demo/pf-tabs.js
@@ -1,4 +1,3 @@
-import 'element-internals-polyfill';
 import '@patternfly/elements/pf-icon/pf-icon.js';
 import '@patternfly/elements/pf-switch/pf-switch.js';
 import '@patternfly/elements/pf-tabs/pf-tabs.js';

--- a/elements/pf-tabs/pf-tabs.css
+++ b/elements/pf-tabs/pf-tabs.css
@@ -136,6 +136,7 @@ button {
   transition:
     margin var(--pf-c-tabs__scroll-button--TransitionDuration--margin, .125s),
     translate var(--pf-c-tabs__scroll-button--TransitionDuration--transform, .125s), opacity var(--pf-c-tabs__scroll-button--TransitionDuration--opacity, .125s);
+  --pf-icon--size: 16px;
 }
 
 button:hover {


### PR DESCRIPTION
## What I did

1.  Added `OverflowController` which when added to a container and given a child array of elements checks to see if those elements exceed the bounds of the container. 
2. Integrated overflow controller into `BaseTabs`.

## Testing Instructions
1. View [deploy preview tabs demo](https://deploy-preview-2375--patternfly-elements.netlify.app/components/tabs/demo/)
2. View at varying browser sizes mobile -> desktop

## Notes to Reviewers

1. Look for any issues around overflow such next and previous buttons not properly displaying the disabled state when tabs are overflowed left or right.
2. Assuming we will want to move the changeset back into the reorganized condensed format.  
