### PR TITLE
fix(tools): calculate path to demo files

### DIFF
--- a/.changeset/famous-cars-dress.md
+++ b/.changeset/famous-cars-dress.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+11ty plugin: calculate path to demo files in more circumstances

--- a/tools/pfe-tools/config.ts
+++ b/tools/pfe-tools/config.ts
@@ -20,6 +20,8 @@ export interface PfeConfig {
   rootDir?: string;
   /** object mapping custom element name to page title */
   aliases?: Record<string, string> ;
+  /** Directory containing the custom elements, defaults to `elements` */
+  elementsDir?: string;
   /** absolute URL to the web page representing the repo root in source control, with trailing slash. default 'https://github.com/patternfly/patternfly-elements/tree/main/' */
   sourceControlURLPrefix?: string ;
   /** absolute URL prefix for demos, with trailing slash. Default 'https://patternflyelements.org/' */


### PR DESCRIPTION
Closes #2376

## What I did

1. added an `elementsDir` option to pfe.config.json
2. use that to compute demo paths, or default to `elements`

## Testing Instructions

1. copy the contents of custom-elements-manifest.cjs to `node_modules/@patternfly/pfe-tools/11ty/plugins/custom-elements-manifest.cjs`
2. make sure both the dev server and the 11ty site demos work as expected

