### PR TITLE
fix(accordion): fixing font-family styling, fixed height demo 

### DIFF
--- a/.changeset/silent-bats-crash.md
+++ b/.changeset/silent-bats-crash.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-accordion>`: fixed font family from "RedHatTextUpdated" to "Red Hat Text".  Updated fixed height demo to auto expand on load.

--- a/.changeset/silent-bats-crash.md
+++ b/.changeset/silent-bats-crash.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`<pf-accordion>`: fixed font family from "RedHatTextUpdated" to "Red Hat Text".  Updated fixed height demo to auto expand on load.
+`<pf-accordion>`: fixed font family

--- a/elements/pf-accordion/demo/pf-accordion.html
+++ b/elements/pf-accordion/demo/pf-accordion.html
@@ -50,7 +50,7 @@
 <article>
   <h2>Fixed Panel</h2>
   <pf-accordion>
-    <pf-accordion-header>
+    <pf-accordion-header expanded>
       <h3>Item one</h3>
     </pf-accordion-header>
     <pf-accordion-panel>

--- a/elements/pf-accordion/pf-accordion-header.css
+++ b/elements/pf-accordion/pf-accordion-header.css
@@ -53,7 +53,7 @@
   font-family:
     var(--pf-c-accordion__toggle--FontFamily,
       var(--pf-global--FontFamily--redhat-updated--heading--sans-serif,
-        "RedHatTextUpdated",
+        "Red Hat Text",
         helvetica,
         arial,
         sans-serif));


### PR DESCRIPTION
## What I did

1.  Updated the font-family for `pf-accordion` to "Red Hat Text"
2. Updated the demo page to expand the fixed height demos first panel automatically on load

## Related Issues

- #2397 
- #2416 
