### PR TITLE
fix(clipboard-copy): inline styles

### DIFF
--- a/.changeset/forty-lamps-fold.md
+++ b/.changeset/forty-lamps-fold.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-clipboard-copy>`: Fixed inline variant styles, to `inline-flex`

--- a/.changeset/forty-lamps-fold.md
+++ b/.changeset/forty-lamps-fold.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`<pf-clipboard-copy>`: fixed inline variant styles to `display: inline-flex` to prevent wrapping
+`<pf-clipboard-copy>`: prevent component's internal layout from wrapping lines

--- a/.changeset/forty-lamps-fold.md
+++ b/.changeset/forty-lamps-fold.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`<pf-clipboard-copy>`: Fixed inline variant styles, to `inline-flex`
+`<pf-clipboard-copy>`: fixed inline variant styles to `display: inline-flex` to prevent wrapping

--- a/elements/pf-clipboard-copy/pf-clipboard-copy.css
+++ b/elements/pf-clipboard-copy/pf-clipboard-copy.css
@@ -10,6 +10,10 @@ pf-button {
   display: flex;
 }
 
+.inline #wrapper {
+  display: inline-flex;
+}
+
 pf-button {
   height: 100%;
 }


### PR DESCRIPTION
## What I did

1. Fixed inline variant styles to `display: inline-flex` to prevent wrapping

Closes #2433 

## Testing Instructions

1. Check the [deploy preview demo](https://deploy-preview-2434--patternfly-elements.netlify.app/components/clipboard-copy/), and ensure inline variant styles are correct

