### PR TITLE
fix(accordion): fixing header tag, fixing heading text attribute  

### DIFF
--- a/.changeset/bright-papayas-crash.md
+++ b/.changeset/bright-papayas-crash.md
@@ -1,0 +1,7 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-accordion-header>`: 
+  - Fixed `header-tag`, `header-text` attributes not functioning as expected.
+  - **BREAKING**: Fixed issue where slotted headings would have duplicated headings in the `shadow-root`.  There will no longer be a heading in the `shadow-root` if there is a slotted element in the `pf-accordion-header`.

--- a/.changeset/bright-papayas-crash.md
+++ b/.changeset/bright-papayas-crash.md
@@ -1,7 +1,0 @@
----
-"@patternfly/elements": patch
----
-
-`<pf-accordion-header>`: 
-  - Fixed `header-tag`, `header-text` attributes not functioning as expected.
-  - **BREAKING**: Fixed issue where slotted headings would have duplicated headings in the `shadow-root`.  There will no longer be a heading in the `shadow-root` if there is a slotted element in the `pf-accordion-header`.

--- a/.changeset/pf-accordion-header-tags.md
+++ b/.changeset/pf-accordion-header-tags.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+`<pf-accordion-header>`: fixed duplicated/nested headings when slotted heading 
+elements are used instead of the `header-text` attribute.

--- a/.changeset/pf-accordion-headers.md
+++ b/.changeset/pf-accordion-headers.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-accordion-header>`: fixed broken `header-tag` and `header-text` attributes

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -32,13 +32,15 @@ export abstract class BaseAccordionHeader extends LitElement {
 
   @property({ type: Boolean, reflect: true }) expanded = false;
 
-  @property({ reflect: true, attribute: 'heading-text' }) headingText = '';
+  @property({ reflect: true, attribute: 'heading-text' }) headingText?: string;
 
-  @property({ reflect: true, attribute: 'heading-tag' }) headingTag = '';
+  @property({ reflect: true, attribute: 'heading-tag' }) headingTag?: string;
 
   #generatedHtag?: HTMLHeadingElement;
 
   #logger = new Logger(this);
+
+  #header?: HTMLElement;
 
   override connectedCallback() {
     super.connectedCallback();
@@ -52,14 +54,12 @@ export abstract class BaseAccordionHeader extends LitElement {
     if (this.headingText && !this.headingTag) {
       this.headingTag = 'h3';
     }
-    const header = this.#getOrCreateHeader();
+    this.#header = this.#getOrCreateHeader();
 
     // prevent double-logging
-    if (header !== this.#generatedHtag) {
+    if (this.#header !== this.#generatedHtag) {
       this.#generatedHtag = undefined;
     }
-
-    this.headingText = this.headingText ? this.headingText.trim() : header?.textContent?.trim() ?? '';
 
     do {
       await this.updateComplete;
@@ -73,33 +73,29 @@ export abstract class BaseAccordionHeader extends LitElement {
   renderAfterButton?(): TemplateResult;
 
   #renderHeaderContent() {
-    const ariaExpandedState = String(!!this.expanded) as 'true'|'false';
-
-    return html`<button id="button"
-                  class="toggle"
-                  aria-expanded="${ariaExpandedState}">
-                  
-                  <span part="text">
-                    ${this.headingText || html`<slot></slot>`}
-                  </span>
-                  
-                  ${this.renderAfterButton?.()}
-                </button>`;
+    const headingText = this.headingText?.trim() ?? this.#header?.textContent?.trim();
+    return html`
+      <button id="button"
+              class="toggle"
+              aria-expanded="${String(!!this.expanded) as 'true'|'false'}">
+        <span part="text">${headingText ?? html`
+          <slot></slot>`}
+        </span>
+        ${this.renderAfterButton?.()}
+      </button>
+    `;
   }
 
   override render(): TemplateResult {
-    if (this.headingTag) {
-      switch (this.headingTag) {
-        case 'h1': return html`<h1 id="heading">${this.#renderHeaderContent()}</h1>`;
-        case 'h2': return html`<h2 id="heading">${this.#renderHeaderContent()}</h2>`;
-        case 'h4': return html`<h4 id="heading">${this.#renderHeaderContent()}</h4>`;
-        case 'h5': return html`<h5 id="heading">${this.#renderHeaderContent()}</h5>`;
-        case 'h6': return html`<h6 id="heading">${this.#renderHeaderContent()}</h6>`;
-        case 'h3':
-        default: return html`<h3 id="heading">${this.#renderHeaderContent()}</h3>`;
-      }
+    switch (this.headingTag) {
+      case 'h1': return html`<h1 id="heading">${this.#renderHeaderContent()}</h1>`;
+      case 'h2': return html`<h2 id="heading">${this.#renderHeaderContent()}</h2>`;
+      case 'h3': return html`<h3 id="heading">${this.#renderHeaderContent()}</h3>`;
+      case 'h4': return html`<h4 id="heading">${this.#renderHeaderContent()}</h4>`;
+      case 'h5': return html`<h5 id="heading">${this.#renderHeaderContent()}</h5>`;
+      case 'h6': return html`<h6 id="heading">${this.#renderHeaderContent()}</h6>`;
+      default: return this.#renderHeaderContent();
     }
-    return this.#renderHeaderContent();
   }
 
   #getOrCreateHeader(): HTMLElement|undefined {

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -2,7 +2,6 @@ import type { TemplateResult } from 'lit';
 
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators/property.js';
-import { unsafeStatic, html as staticH } from 'lit/static-html.js';
 
 import { BaseAccordion } from './BaseAccordion.js';
 import { ComposedEvent } from '@patternfly/pfe-core';
@@ -78,23 +77,110 @@ export abstract class BaseAccordionHeader extends LitElement {
   /** Template hook: before </button> */
   renderAfterButton?(): TemplateResult;
 
+
+  #renderHeader(ariaExpandedState: 'true'|'false'|'undefined' = 'false') {
+    switch (this.headingTag) {
+      case 'h1':
+        return html`<h1 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h1>`;
+      case 'h2':
+        return html`<h2 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h2>`;
+      case 'h3':
+        return html`<h3 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h3>`;
+      case 'h4':
+        return html`<h4 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h4>`;
+      case 'h5':
+        return html`<h5 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h5>`;
+      case 'h6':
+        return html`<h6 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h6>`;
+      default:
+        return html`<h3 id="heading">
+                      <button id="button"
+                        class="toggle"
+                        aria-expanded="${ariaExpandedState}">
+                        
+                        <span part="text">
+                          ${this.headingText || html`<slot></slot>`}
+                        </span>
+              
+                        ${this.renderAfterButton?.()}
+                      </button>
+                    </h3>`;
+    }
+  }
+
   override render(): TemplateResult {
     const hasAnonymousSlot = this.#slots.getSlotted()?.length > 0;
-    const tag = unsafeStatic(this.headingTag);
     const ariaExpandedState = String(!!this.expanded) as 'true'|'false';
-    return staticH`
+
+    return html`
       ${!hasAnonymousSlot ?
-        staticH`
-          <${tag} id="heading">
-            <button id="button"
-                class="toggle"
-                aria-expanded="${ariaExpandedState}">
-              <span part="text">
-                ${this.headingText || html`<slot></slot>`}
-              </span>
-              ${this.renderAfterButton?.()}
-            </button>
-          </${tag}>`
+          this.#renderHeader(ariaExpandedState)
         : html`
         <button id="button"
                 class="toggle"

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -7,7 +7,6 @@ import { BaseAccordion } from './BaseAccordion.js';
 import { ComposedEvent } from '@patternfly/pfe-core';
 import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
-import { SlotController } from '@patternfly/pfe-core/controllers/slot-controller.js';
 
 import style from './BaseAccordionHeader.css';
 

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -77,120 +77,36 @@ export abstract class BaseAccordionHeader extends LitElement {
   /** Template hook: before </button> */
   renderAfterButton?(): TemplateResult;
 
+  #renderHeaderContent() {
+    const ariaExpandedState = String(!!this.expanded) as 'true'|'false';
 
-  #renderHeader(ariaExpandedState: 'true'|'false'|'undefined' = 'false') {
-    switch (this.headingTag) {
-      case 'h1':
-        return html`<h1 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h1>`;
-      case 'h2':
-        return html`<h2 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h2>`;
-      case 'h3':
-        return html`<h3 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h3>`;
-      case 'h4':
-        return html`<h4 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h4>`;
-      case 'h5':
-        return html`<h5 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h5>`;
-      case 'h6':
-        return html`<h6 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h6>`;
-      default:
-        return html`<h3 id="heading">
-                      <button id="button"
-                        class="toggle"
-                        aria-expanded="${ariaExpandedState}">
-                        
-                        <span part="text">
-                          ${this.headingText || html`<slot></slot>`}
-                        </span>
-              
-                        ${this.renderAfterButton?.()}
-                      </button>
-                    </h3>`;
-    }
+    return html`<button id="button"
+                  class="toggle"
+                  aria-expanded="${ariaExpandedState}">
+                  
+                  <span part="text">
+                    ${this.headingText || html`<slot></slot>`}
+                  </span>
+                  
+                  ${this.renderAfterButton?.()}
+                </button>`;
   }
 
   override render(): TemplateResult {
     const hasAnonymousSlot = this.#slots.getSlotted()?.length > 0;
-    const ariaExpandedState = String(!!this.expanded) as 'true'|'false';
 
-    return html`
-      ${!hasAnonymousSlot ?
-          this.#renderHeader(ariaExpandedState)
-        : html`
-        <button id="button"
-                class="toggle"
-                aria-expanded="${ariaExpandedState}">
-          <span part="text">${this.headingText || html`
-            <slot></slot>`}
-          </span>
-          ${this.renderAfterButton?.()}
-        </button>
-`}`;
+    if (!hasAnonymousSlot) {
+      switch (this.headingTag) {
+        case 'h1': return html`<h1 id="heading">${this.#renderHeaderContent()}</h1>`;
+        case 'h2': return html`<h2 id="heading">${this.#renderHeaderContent()}</h2>`;
+        case 'h4': return html`<h4 id="heading">${this.#renderHeaderContent()}</h4>`;
+        case 'h5': return html`<h5 id="heading">${this.#renderHeaderContent()}</h5>`;
+        case 'h6': return html`<h6 id="heading">${this.#renderHeaderContent()}</h6>`;
+        case 'h3':
+        default: return html`<h3 id="heading">${this.#renderHeaderContent()}</h3>`;
+      }
+    }
+    return this.#renderHeaderContent();
   }
 
   #getOrCreateHeader(): HTMLElement|undefined {

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -34,13 +34,11 @@ export abstract class BaseAccordionHeader extends LitElement {
 
   @property({ reflect: true, attribute: 'heading-text' }) headingText = '';
 
-  @property({ reflect: true, attribute: 'heading-tag' }) headingTag = 'h3';
+  @property({ reflect: true, attribute: 'heading-tag' }) headingTag = '';
 
   #generatedHtag?: HTMLHeadingElement;
 
   #logger = new Logger(this);
-
-  #slots = new SlotController(this, null);
 
   override connectedCallback() {
     super.connectedCallback();
@@ -51,6 +49,9 @@ export abstract class BaseAccordionHeader extends LitElement {
   }
 
   async #initHeader() {
+    if (this.headingText && !this.headingTag) {
+      this.headingTag = 'h3';
+    }
     const header = this.#getOrCreateHeader();
 
     // prevent double-logging
@@ -58,13 +59,7 @@ export abstract class BaseAccordionHeader extends LitElement {
       this.#generatedHtag = undefined;
     }
 
-    if (!this.headingTag) {
-      this.headingTag = header?.tagName.toLowerCase() ?? 'h3';
-    }
-
-    if (!this.headingText) {
-      this.headingText = header?.textContent?.trim() ?? '';
-    }
+    this.headingText = this.headingText ? this.headingText.trim() : header?.textContent?.trim() ?? '';
 
     do {
       await this.updateComplete;
@@ -93,9 +88,7 @@ export abstract class BaseAccordionHeader extends LitElement {
   }
 
   override render(): TemplateResult {
-    const hasAnonymousSlot = this.#slots.getSlotted()?.length > 0;
-
-    if (!hasAnonymousSlot) {
+    if (this.headingTag) {
       switch (this.headingTag) {
         case 'h1': return html`<h1 id="heading">${this.#renderHeaderContent()}</h1>`;
         case 'h2': return html`<h2 id="heading">${this.#renderHeaderContent()}</h2>`;

--- a/elements/pf-accordion/demo/pf-accordion.html
+++ b/elements/pf-accordion/demo/pf-accordion.html
@@ -5,17 +5,18 @@
   <h2>Single Expanded Panel</h2>
   <pf-accordion single>
     <pf-accordion-header expanded>
-      <h3>Item one</h3>
+      <h3>Level One - Item one</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Level One - Item two</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
       <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices,
-      faucibus erat id, maximus nunc.</p>
+        faucibus erat id, maximus nunc.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Level One - Item three</h3>
@@ -29,11 +30,14 @@
     <pf-accordion-panel>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
     </pf-accordion-panel>
@@ -54,14 +58,15 @@
       <h3>Item one</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Item two</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
       <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices,
-      faucibus erat id, maximus nunc.</p>
+        faucibus erat id, maximus nunc.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Item three</h3>
@@ -76,38 +81,50 @@
     <pf-accordion-panel fixed>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
     </pf-accordion-panel>
@@ -134,14 +151,15 @@
       <h3>Item one</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Item two</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
       <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices,
-      faucibus erat id, maximus nunc.</p>
+        faucibus erat id, maximus nunc.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Item three</h3>
@@ -155,11 +173,14 @@
     <pf-accordion-panel>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
       <pf-cta><a href="#">Call To Action</a></pf-cta>
@@ -190,52 +211,59 @@
               <h3>Level Three - Item one (single attr: false)</h3>
             </pf-accordion-header>
             <pf-accordion-panel>
-              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
             </pf-accordion-panel>
             <pf-accordion-header>
               <h3>Level Three - Item Two</h3>
             </pf-accordion-header>
             <pf-accordion-panel>
-              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
             </pf-accordion-panel>
             <pf-accordion-header>
               <h3>Level Three - Item Three</h3>
             </pf-accordion-header>
             <pf-accordion-panel>
-              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
             </pf-accordion-panel>
           </pf-accordion>
         </pf-accordion-panel>
-          <pf-accordion-header>
-            <h3>Level Two - Item Two</h3>
-          </pf-accordion-header>
+        <pf-accordion-header>
+          <h3>Level Two - Item Two</h3>
+        </pf-accordion-header>
+        <pf-accordion-panel>
+          <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+            ultrices, faucibus erat id, maximus nunc.</p>
+        </pf-accordion-panel>
+        <pf-accordion-header>
+          <h3>Level Two - Item Three</h3>
+        </pf-accordion-header>
+        <pf-accordion-panel>
+          <pf-accordion>
+            <pf-accordion-header>
+              <h3>Level Three - Item one (single attr: true)</h3>
+            </pf-accordion-header>
             <pf-accordion-panel>
-              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
             </pf-accordion-panel>
-          <pf-accordion-header>
-            <h3>Level Two - Item Three</h3>
-          </pf-accordion-header>
-          <pf-accordion-panel>
-            <pf-accordion>
-              <pf-accordion-header>
-                <h3>Level Three - Item one (single attr: true)</h3>
-              </pf-accordion-header>
-              <pf-accordion-panel>
-                <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
-              </pf-accordion-panel>
-              <pf-accordion-header>
-                <h3>Level Three - Item Two</h3>
-              </pf-accordion-header>
-              <pf-accordion-panel>
-                <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
-              </pf-accordion-panel>
-              <pf-accordion-header>
-                <h3>Level Three - Item Three</h3>
-              </pf-accordion-header>
-              <pf-accordion-panel>
-                <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
-              </pf-accordion-panel>
-            </pf-accordion>
+            <pf-accordion-header>
+              <h3>Level Three - Item Two</h3>
+            </pf-accordion-header>
+            <pf-accordion-panel>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
+            </pf-accordion-panel>
+            <pf-accordion-header>
+              <h3>Level Three - Item Three</h3>
+            </pf-accordion-header>
+            <pf-accordion-panel>
+              <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
+                ultrices, faucibus erat id, maximus nunc.</p>
+            </pf-accordion-panel>
+          </pf-accordion>
         </pf-accordion-panel>
       </pf-accordion>
     </pf-accordion-panel>
@@ -243,7 +271,8 @@
       <h3>Level One - Item two</h3>
     </pf-accordion-header>
     <pf-accordion-panel>
-      <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices, faucibus erat id, maximus nunc.</p>
+      <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices,
+        faucibus erat id, maximus nunc.</p>
     </pf-accordion-panel>
     <pf-accordion-header>
       <h3>Level One - Item three</h3>
@@ -257,11 +286,14 @@
     <pf-accordion-panel>
       <p>
         Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
-        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;
+        sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+        cubilia Curae;
         Vestibulum ultricies nulla nibh. Etiam vel dui fermentum ligula ullamcorper eleifend non quis tortor. Morbi
-        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris
+        tempus ornare tempus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        Mauris
         et velit neque. Donec ultricies condimentum mauris, pellentesque imperdiet libero convallis convallis. Aliquam
-        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed tincidunt
+        erat volutpat. Donec rutrum semper tempus. Proin dictum imperdiet nibh, quis dapibus nulla. Integer sed
+        tincidunt
         lectus, sit amet auctor eros.
       </p>
     </pf-accordion-panel>
@@ -270,6 +302,35 @@
     </pf-accordion-header>
     <pf-accordion-panel>
       <p>Vivamus finibus dictum ex id ultrices. Mauris dictum neque a iaculis blandit.</p>
+    </pf-accordion-panel>
+  </pf-accordion>
+</article>
+
+<article>
+  <h2>Accordion with attribute headers</h2>
+
+  <pf-accordion>
+    <pf-accordion-header heading-text="Level One - Item One, H1 Tag" heading-tag="h1">
+    </pf-accordion-header>
+    <pf-accordion-panel>
+      <p>Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam ultrices,
+        faucibus erat id, maximus nunc.</p>
+    </pf-accordion-panel>
+    <pf-accordion-header heading-text="Level One - Item 2, H2 tag" heading-tag="h2">
+    </pf-accordion-header>
+    <pf-accordion-panel>
+      <p>Morbi vitae urna quis nunc convallis hendrerit. Aliquam congue orci quis ultricies tempus.</p>
+    </pf-accordion-panel>
+    <pf-accordion-header heading-text="Level One - Item 3, No passed in tag (defaults to h3)">
+    </pf-accordion-header>
+    <pf-accordion-panel>
+      <p>Morbi vitae urna quis nunc convallis hendrerit. Aliquam congue orci quis ultricies tempus.</p>
+    </pf-accordion-panel>
+    <pf-accordion-header>
+      <h3>Level One - Item 4, Slotted (no shadow header)</h3>
+    </pf-accordion-header>
+    <pf-accordion-panel>
+      <p>Morbi vitae urna quis nunc convallis hendrerit. Aliquam congue orci quis ultricies tempus.</p>
     </pf-accordion-panel>
   </pf-accordion>
 </article>


### PR DESCRIPTION
## What I did

1. Added an `anonymous` slot checker in the `pf-accordion-header` component. 
  - This checks for whether an `anonymous` slot has been passed in for the header
    - DOES NOT have an `anonymous` slot = we add the header tag to the shadow dom
    - DOES have an `anonymous` slot = we DO NOT add the header tag to the shadow dom
 2. We have / had an issue with the `heading-text` attribute not showing correctly in the header, this has been fixed
 3. Adding a demo to show the attributes being used instead of the `anonymous` slot

## Testing Instructions

1. [DP](https://deploy-preview-2435--patternfly-elements.netlify.app/components/accordion/demo/)
2. Open the developer console and inspect the accordion demos
3. Verify that the accordion headers with slotted in content do not have nested header tags in the shadow dom
4. Verify that the accrdion headers in the demo that have text / tags passed in via attributes have the nested header tags in the shadow dom. 
5. Verify that the text passed in through `heading-text` is showing in the header as expected