### PR TITLE
fix(accordion): large panel accent not covering whole side panel 

### DIFF
--- a/.changeset/wild-falcons-do.md
+++ b/.changeset/wild-falcons-do.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-accordion-panel`: - removing position relative from body class which was causing the accent color to not fill the entire panel
+`pf-accordion-panel`: - adding overflow hidden to the body tag for an issue where the border would not span the whole height of the panel.

--- a/.changeset/wild-falcons-do.md
+++ b/.changeset/wild-falcons-do.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-accordion-panel`: - removing position relative from body class which was causing the accent color to not fill the entire panel

--- a/.changeset/wild-falcons-do.md
+++ b/.changeset/wild-falcons-do.md
@@ -2,7 +2,6 @@
 "@patternfly/elements": patch
 ---
 
-`pf-accordion`: 
-  - fixed issue where accent would not display full height if the following conditions were met:
+`<pf-accordion>`: fixed issue where accent would not display full height if the following conditions were met:
     - `pf-accordion` was set to `large` 
     - `pf-accordion-panel` slotted content had padding or margins 

--- a/.changeset/wild-falcons-do.md
+++ b/.changeset/wild-falcons-do.md
@@ -2,4 +2,7 @@
 "@patternfly/elements": patch
 ---
 
-`pf-accordion-panel`: - adding overflow hidden to the body tag for an issue where the border would not span the whole height of the panel.
+`pf-accordion`: 
+  - fixed issue where accent would not display full height if the following conditions were met:
+    - `pf-accordion` was set to `large` 
+    - `pf-accordion-panel` slotted content had padding or margins 

--- a/elements/pf-accordion/BaseAccordionPanel.css
+++ b/elements/pf-accordion/BaseAccordionPanel.css
@@ -18,6 +18,11 @@
   overflow-y: auto;
 }
 
+.body {
+  position: relative;
+  overflow: hidden;
+}
+
 .body:after {
   content: "";
   position: absolute;

--- a/elements/pf-accordion/BaseAccordionPanel.css
+++ b/elements/pf-accordion/BaseAccordionPanel.css
@@ -18,10 +18,6 @@
   overflow-y: auto;
 }
 
-.body {
-  position: relative;
-}
-
 .body:after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## What I did

1.  Added `overflow:hidden` to the panel so that the accent will span the whole height of the div in cases where the slotted content has margins / padding.