### PR TITLE
fix(eslint-config): add more formatting rules

### DIFF
--- a/.changeset/eslint-config-more-rules.md
+++ b/.changeset/eslint-config-more-rules.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/eslint-config-elements": patch
+---
+Added more formatting rules (infix spacing and type annotation spacing).

--- a/core/pfe-core/controllers/cascade-controller.ts
+++ b/core/pfe-core/controllers/cascade-controller.ts
@@ -5,7 +5,7 @@ import { debounce } from '../functions/debounce.js';
 import { Logger } from './logger.js';
 
 export interface Options<E extends ReactiveElement> {
-  properties: Partial<Record<keyof E, string|string[]>>;
+  properties: Partial<Record<keyof E, string | string[]>>;
   prefix?: string;
 }
 
@@ -49,7 +49,7 @@ export class CascadeController<E extends ReactiveElement> implements ReactiveCon
    * Handles the cascading of properties to nested components when new elements are added
    * Attribute updates/additions are handled by the attribute callback
    */
-  cascadeProperties(nodeList: HTMLCollection|NodeList = this.host.children) {
+  cascadeProperties(nodeList: HTMLCollection | NodeList = this.host.children) {
     if (this.host.isConnected) {
       const selectors = this.cache.keys();
 
@@ -84,7 +84,7 @@ export class CascadeController<E extends ReactiveElement> implements ReactiveCon
    * falling back to the lowercased property name, and caches the attribute name
    * with it's designated child selectors for value-propagation on change
    */
-  initProp(propName: string, cascade: string|string[]) {
+  initProp(propName: string, cascade: string | string[]) {
     for (const nodeItem of [cascade].flat(Infinity).filter(Boolean) as string[]) {
       const { attribute } = this.class.getPropertyOptions(propName);
 

--- a/core/pfe-core/controllers/floating-dom-controller.ts
+++ b/core/pfe-core/controllers/floating-dom-controller.ts
@@ -14,7 +14,7 @@ import {
   flip as flipMiddleware,
 } from '@floating-ui/dom';
 
-type Lazy<T> = T|(() => T|null|undefined);
+type Lazy<T> = T | (() => T | null | undefined);
 
 interface FloatingDOMControllerOptions {
   content: Lazy<HTMLElement>;
@@ -30,8 +30,8 @@ interface ShowOptions {
   placement?: Placement;
 }
 
-export type Anchor = ''|'top'|'left'|'bottom'|'right';
-export type Alignment = 'center'|'start'|'end';
+export type Anchor = '' | 'top' | 'left' | 'bottom' | 'right';
+export type Alignment = 'center' | 'start' | 'end';
 
 /**
  * Controls floating DOM within a web component, e.g. tooltips and popovers

--- a/core/pfe-core/controllers/light-dom-controller.ts
+++ b/core/pfe-core/controllers/light-dom-controller.ts
@@ -3,7 +3,7 @@ import type { ReactiveController, ReactiveElement } from 'lit';
 import { Logger } from './logger.js';
 
 export interface Options {
-  observe?: boolean|MutationObserverInit;
+  observe?: boolean | MutationObserverInit;
   emptyWarning?: string;
 }
 

--- a/core/pfe-core/controllers/roving-tabindex-controller.ts
+++ b/core/pfe-core/controllers/roving-tabindex-controller.ts
@@ -161,7 +161,7 @@ export class RovingTabindexController implements ReactiveController {
   /**
    * sets tabindex of item based on whether or not it is active
    */
-  updateActiveItem(item?: HTMLElement):void {
+  updateActiveItem(item?: HTMLElement): void {
     if (item) {
       if (!!this.#activeItem && item !== this.#activeItem) {
         this.#activeItem.tabIndex = -1;
@@ -174,7 +174,7 @@ export class RovingTabindexController implements ReactiveController {
   /**
    * focuses on an item and sets it as active
    */
-  focusOnItem(item?: HTMLElement):void {
+  focusOnItem(item?: HTMLElement): void {
     this.updateActiveItem(item || this.firstItem);
     this.#activeItem?.focus();
   }

--- a/core/pfe-core/controllers/scroll-spy-controller.ts
+++ b/core/pfe-core/controllers/scroll-spy-controller.ts
@@ -22,7 +22,7 @@ export interface ScrollSpyControllerOptions extends IntersectionObserverInit {
    * function to call on link children to get their URL hash (i.e. id to scroll to)
    * @default el => el.getAttribute('href');
    */
-  getHash?: (el: Element) => string|null;
+  getHash?: (el: Element) => string | null;
 }
 
 export class ScrollSpyController implements ReactiveController {
@@ -42,10 +42,10 @@ export class ScrollSpyController implements ReactiveController {
 
   #root: ScrollSpyControllerOptions['root'];
   #rootMargin?: string;
-  #threshold: number|number[];
+  #threshold: number | number[];
 
   #rootNode: Node;
-  #getHash: (el: Element) => string|null;
+  #getHash: (el: Element) => string | null;
 
   get #linkChildren(): Element[] {
     return Array.from(this.host.querySelectorAll(this.#tagNames.join(',')))
@@ -122,7 +122,7 @@ export class ScrollSpyController implements ReactiveController {
     }
   }
 
-  #setActive(link?: EventTarget|null) {
+  #setActive(link?: EventTarget | null) {
     for (const child of this.#linkChildren) {
       child.toggleAttribute(this.#activeAttribute, child === link);
     }
@@ -154,7 +154,7 @@ export class ScrollSpyController implements ReactiveController {
   }
 
   /** Explicitly set the active item */
-  public async setActive(link: EventTarget|null) {
+  public async setActive(link: EventTarget | null) {
     this.#force = true;
     this.#setActive(link);
     let sawActive = false;

--- a/core/pfe-core/controllers/slot-controller.ts
+++ b/core/pfe-core/controllers/slot-controller.ts
@@ -6,7 +6,7 @@ import { Logger } from './logger.js';
 interface AnonymousSlot {
   hasContent: boolean;
   elements: Element[];
-  slot: HTMLSlotElement|null;
+  slot: HTMLSlotElement | null;
 }
 
 interface NamedSlot extends AnonymousSlot {
@@ -14,10 +14,10 @@ interface NamedSlot extends AnonymousSlot {
   initialized: true;
 }
 
-export type Slot = NamedSlot|AnonymousSlot;
+export type Slot = NamedSlot | AnonymousSlot;
 
 export interface SlotsConfig {
-  slots: (string|null)[];
+  slots: (string | null)[];
   /**
    * Object mapping new slot name keys to deprecated slot name values
    * @example `pf-modal--header` is deprecated in favour of `header`
@@ -33,7 +33,7 @@ export interface SlotsConfig {
   deprecations?: Record<string, string>;
 }
 
-function isObjectConfigSpread(config: ([SlotsConfig]|(string|null)[])): config is [SlotsConfig] {
+function isObjectConfigSpread(config: ([SlotsConfig] | (string | null)[])): config is [SlotsConfig] {
   return config.length === 1 && typeof config[0] === 'object' && config[0] !== null;
 }
 
@@ -42,7 +42,7 @@ function isObjectConfigSpread(config: ([SlotsConfig]|(string|null)[])): config i
  * for the default slot, look for direct children not assigned to a slot
  */
 const isSlot =
-  <T extends Element = Element>(n: string|typeof SlotController.anonymous) =>
+  <T extends Element = Element>(n: string | typeof SlotController.anonymous) =>
     (child: Element): child is T =>
         n === SlotController.anonymous ? !child.hasAttribute('slot')
       : child.getAttribute('slot') === n;
@@ -50,7 +50,7 @@ const isSlot =
 export class SlotController implements ReactiveController {
   public static anonymous = Symbol('anonymous slot');
 
-  private nodes = new Map<string|typeof SlotController.anonymous, Slot>();
+  private nodes = new Map<string | typeof SlotController.anonymous, Slot>();
 
   private logger: Logger;
 
@@ -58,11 +58,11 @@ export class SlotController implements ReactiveController {
 
   private mo = new MutationObserver(this.onMutation);
 
-  private slotNames: (string|null)[];
+  private slotNames: (string | null)[];
 
   private deprecations: Record<string, string> = {};
 
-  constructor(public host: ReactiveElement, ...config: ([SlotsConfig]|(string|null)[])) {
+  constructor(public host: ReactiveElement, ...config: ([SlotsConfig] | (string | null)[])) {
     this.logger = new Logger(this.host);
 
     if (isObjectConfigSpread(config)) {
@@ -163,12 +163,12 @@ export class SlotController implements ReactiveController {
     }
   }
 
-  private getChildrenForSlot<T extends Element = Element>(name: string|typeof SlotController.anonymous): T[] {
+  private getChildrenForSlot<T extends Element = Element>(name: string | typeof SlotController.anonymous): T[] {
     const children = Array.from(this.host.children) as T[];
     return children.filter(isSlot(name));
   }
 
-  @bound private initSlot(slotName: string|null) {
+  @bound private initSlot(slotName: string | null) {
     const name = slotName || SlotController.anonymous;
     const elements = this.nodes.get(name)?.slot?.assignedElements?.() ?? this.getChildrenForSlot(name);
     const selector = slotName ? `slot[name="${slotName}"]` : 'slot:not([name])';

--- a/core/pfe-core/core.ts
+++ b/core/pfe-core/core.ts
@@ -13,7 +13,7 @@ export interface PfeConfig {
 const noPref = Symbol();
 
 /** Retrieve an HTML metadata item */
-function getMeta(name: string): string|undefined {
+function getMeta(name: string): string | undefined {
   return document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`)?.content;
 }
 
@@ -33,7 +33,7 @@ export function trackPerformance(preference: boolean | typeof noPref = noPref) {
  * A LitElement property converter which represents a list of numbers as a comma separated string
  * @see https://lit.dev/docs/components/properties/#conversion-converter
  */
-export const NumberListConverter: ComplexAttributeConverter<null|number[]> = {
+export const NumberListConverter: ComplexAttributeConverter<null | number[]> = {
   fromAttribute(value: string) {
     if (typeof value !== 'string') {
       return null;

--- a/core/pfe-core/decorators/observed.ts
+++ b/core/pfe-core/decorators/observed.ts
@@ -40,7 +40,7 @@ type TypedFieldDecorator<T> = (proto: T, key: string | keyof T) => void ;
 export function observed<T extends ReactiveElement>(methodName: string): TypedFieldDecorator<T>
 export function observed<T extends ReactiveElement>(cb: ChangeCallback<T>): TypedFieldDecorator<T>
 export function observed<T extends ReactiveElement>(proto: T, key: string): void
-export function observed<T extends ReactiveElement>(...as: any[]): void|TypedFieldDecorator<T> {
+export function observed<T extends ReactiveElement>(...as: any[]): void | TypedFieldDecorator<T> {
   /** @observed('_myCustomChangeCallback') */
   if (as.length === 1) {
     const [methodNameOrCallback] = as;

--- a/core/pfe-core/functions/debounce.ts
+++ b/core/pfe-core/functions/debounce.ts
@@ -11,7 +11,7 @@ export function debounce(
   delay: number,
   immediate = false
 ) {
-  let timeout: number|null;
+  let timeout: number | null;
   return function(this: unknown, ...args: any[]) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const context = this;

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -72,7 +72,7 @@ export abstract class BaseAccordionHeader extends LitElement {
 
   override render(): TemplateResult {
     const tag = unsafeStatic(this.headingTag);
-    const ariaExpandedState = String(!!this.expanded) as 'true'|'false';
+    const ariaExpandedState = String(!!this.expanded) as 'true' | 'false';
     return staticH`
       <${tag} id="heading">
         <button id="button"
@@ -87,7 +87,7 @@ export abstract class BaseAccordionHeader extends LitElement {
     `;
   }
 
-  #getOrCreateHeader(): HTMLElement|undefined {
+  #getOrCreateHeader(): HTMLElement | undefined {
     // Check if there is no nested element or nested textNodes
     if (!this.firstElementChild && !this.firstChild) {
       return void this.#logger.warn('No header content provided');

--- a/elements/pf-accordion/pf-accordion-header.ts
+++ b/elements/pf-accordion/pf-accordion-header.ts
@@ -84,7 +84,7 @@ import '@patternfly/elements/pf-icon/pf-icon.js';
 export class PfAccordionHeader extends BaseAccordionHeader {
   static readonly styles = [...BaseAccordionHeader.styles, style];
 
-  @property({ reflect: true }) bordered?: 'true'|'false';
+  @property({ reflect: true }) bordered?: 'true' | 'false';
 
   @property({ reflect: true }) icon?: string;
 

--- a/elements/pf-accordion/pf-accordion-panel.ts
+++ b/elements/pf-accordion/pf-accordion-panel.ts
@@ -48,7 +48,7 @@ import style from './pf-accordion-panel.css';
 export class PfAccordionPanel extends BaseAccordionPanel {
   static readonly styles = [...BaseAccordionPanel.styles, style];
 
-  @property({ reflect: true }) bordered?: 'true'|'false';
+  @property({ reflect: true }) bordered?: 'true' | 'false';
 }
 
 declare global {

--- a/elements/pf-avatar/BaseAvatar.ts
+++ b/elements/pf-avatar/BaseAvatar.ts
@@ -26,7 +26,7 @@ export class BaseAvatar extends LitElement {
   @property({ reflect: true }) alt?: string = 'Avatar image';
 
   /** Size of the Avatar */
-  @property({ reflect: true }) size: 'sm'|'md'|'lg'|'xl' = 'sm';
+  @property({ reflect: true }) size: 'sm' | 'md' | 'lg' | 'xl' = 'sm';
 
   /** Whether or not the Avatar image is dark */
   @property({ type: Boolean, reflect: true }) dark = false;

--- a/elements/pf-avatar/pf-avatar.ts
+++ b/elements/pf-avatar/pf-avatar.ts
@@ -15,10 +15,10 @@ export class PfAvatar extends BaseAvatar {
   static readonly styles = [style];
 
   /** Size of the Avatar */
-  @property({ reflect: true }) size: 'sm'|'md'|'lg'|'xl' = 'sm';
+  @property({ reflect: true }) size: 'sm' | 'md' | 'lg' | 'xl' = 'sm';
 
   /** Whether to display a border around the avatar */
-  @property({ reflect: true }) border?: 'light'|'dark';
+  @property({ reflect: true }) border?: 'light' | 'dark';
 }
 
 declare global {

--- a/elements/pf-badge/pf-badge.ts
+++ b/elements/pf-badge/pf-badge.ts
@@ -38,7 +38,7 @@ export class PfBadge extends BaseBadge {
    * Denotes the state-of-affairs this badge represents
    * Options include read and unread
    */
-  @property({ reflect: true }) state?: 'unread'|'read';
+  @property({ reflect: true }) state?: 'unread' | 'read';
 
   @property({ reflect: true, type: Number }) number?: number;
 

--- a/elements/pf-button/BaseButton.ts
+++ b/elements/pf-button/BaseButton.ts
@@ -26,7 +26,7 @@ export abstract class BaseButton extends LitElement {
   /** Disables the button */
   @property({ reflect: true, type: Boolean }) disabled = false;
 
-  @property({ reflect: true }) type?: 'button'|'submit'|'reset';
+  @property({ reflect: true }) type?: 'button' | 'submit' | 'reset';
 
   /** Accessible name for the button, use when the button does not have slotted text */
   @property() label?: string;
@@ -64,7 +64,7 @@ export abstract class BaseButton extends LitElement {
               @click="${this.#onClick}"
               ?disabled="${this.disabled || this.#internals.formDisabled}">
         <slot id="icon" part="icon" aria-hidden="true" name="icon">${this.renderDefaultIcon()}</slot>
-        <slot id="text" aria-hidden=${String(!!this.label) as 'true'|'false'}></slot>
+        <slot id="text" aria-hidden=${String(!!this.label) as 'true' | 'false'}></slot>
       </button>
     `;
   }

--- a/elements/pf-button/pf-button.ts
+++ b/elements/pf-button/pf-button.ts
@@ -163,7 +163,7 @@ export class PfButton extends BaseButton {
   /** Not as urgent as danger */
   @property({ type: Boolean, reflect: true }) warning = false;
 
-  @property({ reflect: true }) size?: 'small'|'large';
+  @property({ reflect: true }) size?: 'small' | 'large';
 
   /** Icon set for the `icon` property */
   @property({ attribute: 'icon-set' }) iconSet?: string;

--- a/elements/pf-icon/BaseIcon.ts
+++ b/elements/pf-icon/BaseIcon.ts
@@ -82,7 +82,7 @@ export abstract class BaseIcon extends LitElement {
    * - `idle`: wait for the browser to attain an idle state before loading
    * - `lazy` (default): wait for the element to enter the viewport before loading
    */
-  @property() loading?: 'idle'|'lazy'|'eager' = 'lazy';
+  @property() loading?: 'idle' | 'lazy' | 'eager' = 'lazy';
 
   /** Icon content. Any value that lit can render */
   @state() private content?: unknown;

--- a/elements/pf-icon/pf-icon.ts
+++ b/elements/pf-icon/pf-icon.ts
@@ -20,7 +20,7 @@ export class PfIcon extends BaseIcon {
   public static defaultIconSet = 'fas';
 
   /** Size of the icon */
-  @property({ reflect: true }) size: 'sm'|'md'|'lg'|'xl' = 'sm';
+  @property({ reflect: true }) size: 'sm' | 'md' | 'lg' | 'xl' = 'sm';
 }
 
 declare global {

--- a/elements/pf-jump-links/test/pf-jump-links.spec.ts
+++ b/elements/pf-jump-links/test/pf-jump-links.spec.ts
@@ -1,5 +1,5 @@
 import type { ReactiveElement } from 'lit';
-import { expect, html, nextFrame, aTimeout } from '@open-wc/testing';
+import { expect, html, nextFrame } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 
@@ -24,7 +24,6 @@ describe('<pf-jump-links>', function() {
   let element: PfJumpLinks;
   let firstItem: PfJumpLinksItem;
   let secondItem: PfJumpLinksItem;
-  let thirdItem: PfJumpLinksItem;
 
   beforeEach(async function() {
     element = await createFixture<PfJumpLinks>(html`
@@ -35,11 +34,11 @@ describe('<pf-jump-links>', function() {
       </pf-jump-links>
     `);
     await allUpdates(element);
-    [firstItem, secondItem, thirdItem] = element.querySelectorAll<PfJumpLinksItem>('pf-jump-links-item');
+    [firstItem, secondItem] = element.querySelectorAll<PfJumpLinksItem>('pf-jump-links-item');
   });
 
   describe('tabbing to first item', function() {
-    let initialActiveElement: Element|null;
+    let initialActiveElement: Element | null;
     beforeEach(async function() {
       initialActiveElement = document.activeElement;
       await sendKeys({ press: 'Tab' });

--- a/elements/pf-panel/pf-panel.ts
+++ b/elements/pf-panel/pf-panel.ts
@@ -22,7 +22,7 @@ export class PfPanel extends LitElement {
 
   @property({ type: Boolean, reflect: true }) scrollable = false;
 
-  @property({ reflect: true }) variant?: 'raised'|'bordered';
+  @property({ reflect: true }) variant?: 'raised' | 'bordered';
 
   #slots = new SlotController(this, 'header', null, 'footer');
 

--- a/elements/pf-progress-stepper/pf-progress-step.ts
+++ b/elements/pf-progress-stepper/pf-progress-step.ts
@@ -44,7 +44,7 @@ export class PfProgressStep extends LitElement {
   @property({ attribute: 'icon-set' }) iconSet?: string;
 
   /** Describes the state of the current item */
-  @property({ reflect: true }) variant?: 'pending'|'info'|'success'|'warning'|'danger';
+  @property({ reflect: true }) variant?: 'pending' | 'info' | 'success' | 'warning' | 'danger';
 
   /** Indicates if this item is the current active item. */
   @property({ type: Boolean, reflect: true }) current = false;

--- a/elements/pf-spinner/BaseSpinner.ts
+++ b/elements/pf-spinner/BaseSpinner.ts
@@ -36,7 +36,7 @@ export abstract class BaseSpinner extends LitElement {
   @property({ reflect: true }) size: SpinnerSize = 'xl';
 
   /** Custom diameter of spinner set as CSS variable */
-  @property({ reflect: true }) diameter?: `${string}${'px'|'%'|'rem'|'em'|'fr'|'pt'}`;
+  @property({ reflect: true }) diameter?: `${string}${'px' | '%' | 'rem' | 'em' | 'fr' | 'pt'}`;
 
   override render() {
     return html`

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -180,7 +180,7 @@ export abstract class BaseTabs extends LitElement {
     `;
   }
 
-  #onSlotchange(event: { target: { name: string; }; }) {
+  #onSlotchange(event: { target: { name: string } }) {
     if (event.target.name === 'tab') {
       this.#allTabs = this.tabs;
     } else {

--- a/elements/pf-tabs/test/pf-tabs.spec.ts
+++ b/elements/pf-tabs/test/pf-tabs.spec.ts
@@ -198,8 +198,8 @@ describe('<pf-tabs>', function() {
     let element: PfTabs;
     let firstTab: PfTab;
     let secondTab: PfTab;
-    let initialFocus: Element|null;
-    let afterFocus: Element|null;
+    let initialFocus: Element | null;
+    let afterFocus: Element | null;
     beforeEach(async function() {
       element = await createFixture<PfTabs>(html`
         <pf-tabs manual>

--- a/elements/pf-tooltip/BaseTooltip.ts
+++ b/elements/pf-tooltip/BaseTooltip.ts
@@ -55,7 +55,7 @@ export abstract class BaseTooltip extends LitElement {
         <slot id="invoker" role="tooltip" aria-labelledby="tooltip"></slot>
         <slot id="tooltip"
               name="content"
-              aria-hidden="${String(!open) as 'true'|'false'}">${this.content}</slot>
+              aria-hidden="${String(!open) as 'true' | 'false'}">${this.content}</slot>
       </div>
     `;
   }

--- a/scripts/icons/icons.ts
+++ b/scripts/icons/icons.ts
@@ -17,7 +17,7 @@ export interface IconSpec {
   /** Icon height in pixels */
   height: number;
   /** SVG path attribute value */
-  path: string|string[ ];
+  path: string | string[ ];
 }
 
 type JsonIconPack = Record<string, Omit<IconSpec, 'path'> & { svgPathData: string }>;

--- a/tools/create-element/main.ts
+++ b/tools/create-element/main.ts
@@ -29,8 +29,6 @@ export type PromptOptions<T> =
 const ERR_BAD_CE_TAG_NAME =
   'Custom element tag names must contain a hyphen (-)';
 
-const b = Chalk.cyanBright;
-
 interface PackageJSON {
   customElements?: string;
   name: string;

--- a/tools/eslint-config/index.js
+++ b/tools/eslint-config/index.js
@@ -169,9 +169,12 @@ const config = {
       'plugin:@typescript-eslint/recommended',
     ],
     rules: {
+      'valid-jsdoc': OFF,
+      'space-infix-ops': OFF,
+      '@typescript-eslint/space-infix-ops': ERROR,
+      '@typescript-eslint/type-annotation-spacing': ERROR,
       'no-invalid-this': OFF,
       '@typescript-eslint/no-invalid-this': [ERROR],
-      'valid-jsdoc': OFF,
       '@typescript-eslint/no-explicit-any': [WARNING, {
         ignoreRestArgs: true,
       }],
@@ -180,6 +183,16 @@ const config = {
       }],
       '@typescript-eslint/ban-ts-comment': [WARNING, {
         'ts-expect-error': 'allow-with-description',
+      }],
+      '@typescript-eslint/member-delimiter-style': [ERROR, {
+        multiline: {
+          delimiter: 'semi',
+          requireLast: true,
+        },
+        singleline: {
+          delimiter: 'semi',
+          requireLast: false,
+        },
       }],
     },
   }, {

--- a/tools/pfe-tools/11ty/DocsPage.ts
+++ b/tools/pfe-tools/11ty/DocsPage.ts
@@ -63,8 +63,8 @@ export class DocsPage implements DocsPageRenderer {
   title: string;
   slug: string;
   templates: Environment;
-  description?: string|null;
-  summary?: string|null;
+  description?: string | null;
+  summary?: string | null;
   docsTemplatePath?: string;
 
   constructor(

--- a/tools/pfe-tools/11ty/plugins/custom-elements-manifest.cjs
+++ b/tools/pfe-tools/11ty/plugins/custom-elements-manifest.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const { EleventyRenderPlugin } = require('@11ty/eleventy');
-const { join, dirname } = require('node:path');
+const { join } = require('node:path');
 const { existsSync } = require('node:fs');
 const glob = require('node:util').promisify(require('glob'));
 const { stat, rm } = require('node:fs/promises');

--- a/tools/pfe-tools/11ty/plugins/types.ts
+++ b/tools/pfe-tools/11ty/plugins/types.ts
@@ -15,7 +15,7 @@ export interface DemoRecord {
 
 export interface PluginOptions extends PfeConfig {
   /** list of extra demo records not included in the custom-elements-manifest. Default [] */
-  extraDemos?: DemoRecord[]
+  extraDemos?: DemoRecord[];
 }
 
 export interface EleventyPage {
@@ -42,12 +42,12 @@ export interface EleventyContext {
 }
 
 export type RendererName = `render${
-  |'Attributes'
-  |'CssCustomProperties'
-  |'CssParts'
-  |'Events'
-  |'Methods'
-  |'Overview'
-  |'Properties'
-  |'Slots'
+  | 'Attributes'
+  | 'CssCustomProperties'
+  | 'CssParts'
+  | 'Events'
+  | 'Methods'
+  | 'Overview'
+  | 'Properties'
+  | 'Slots'
 }`[];

--- a/tools/pfe-tools/config.ts
+++ b/tools/pfe-tools/config.ts
@@ -68,7 +68,7 @@ export function getPfeConfig(rootDir = process.cwd()): Required<PfeConfig> {
   };
 }
 
-const slugsConfigMap = new Map<string, { config: PfeConfig, slugs: Map<string, string> }>();
+const slugsConfigMap = new Map<string, { config: PfeConfig; slugs: Map<string, string> }>();
 const reverseSlugifyObject = ([k, v]: [string, string]): [string, string] =>
   [slugify(v).toLowerCase(), k];
 function getSlugsMap(rootDir: string) {

--- a/tools/pfe-tools/custom-elements-manifest/config.ts
+++ b/tools/pfe-tools/custom-elements-manifest/config.ts
@@ -14,7 +14,7 @@ import { getPfeConfig, type PfeConfig } from '../config.js';
 
 import Chalk from 'chalk';
 
-type Options = Config & Pick<PfeConfig, 'sourceControlURLPrefix'|'demoURLPrefix'>;
+type Options = Config & Pick<PfeConfig, 'sourceControlURLPrefix' | 'demoURLPrefix'>;
 
 /**
  * PFE Default custom-elements-manifest analyzer config

--- a/tools/pfe-tools/custom-elements-manifest/jsdoc-description-default.ts
+++ b/tools/pfe-tools/custom-elements-manifest/jsdoc-description-default.ts
@@ -21,7 +21,7 @@ function deinlineDefault(
     return;
   }
 
-  const existing = (classDoc[groupKey] as (Attribute|CssCustomProperty)[])?.find?.(x =>
+  const existing = (classDoc[groupKey] as (Attribute | CssCustomProperty)[])?.find?.(x =>
     x.name === jsDoc.name);
 
   if (!existing) {

--- a/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
@@ -138,7 +138,7 @@ export class Manifest {
     return new Manifest(null, null);
   }
 
-  public static from({ package: packageJson, location }: { package: PackageJSON, location: string }): Manifest {
+  public static from({ package: packageJson, location }: { package: PackageJSON; location: string }): Manifest {
     if (!Manifest.#instances.has(packageJson)) {
       const manifestPath = join(location, packageJson?.customElements ?? '');
       const json = readJsonSync(manifestPath);
@@ -164,8 +164,8 @@ export class Manifest {
   path = '';
 
   constructor(
-    public manifest: Package|null,
-    public packageJson: PackageJSON|null,
+    public manifest: Package | null,
+    public packageJson: PackageJSON | null,
     public location?: string
   ) {
     if (manifest && packageJson && location && packageJson.customElements) {
@@ -180,7 +180,7 @@ export class Manifest {
     }
   }
 
-  #tag(tagName: string): ManifestCustomElement|null {
+  #tag(tagName: string): ManifestCustomElement | null {
     return this.declarations?.get(tagName) ?? null;
   }
 
@@ -195,55 +195,55 @@ export class Manifest {
 
   /**
    */
-  getAttributes(tagName: string): undefined|Attribute[] {
+  getAttributes(tagName: string): undefined | Attribute[] {
     return this.#tag(tagName)?.attributes;
   }
 
   /**
    */
-  getCssCustomProperties(tagName: string): undefined|CssCustomProperty[] {
+  getCssCustomProperties(tagName: string): undefined | CssCustomProperty[] {
     return this.#tag(tagName)?.cssCustomProperties;
   }
 
   /**
    */
-  getCssParts(tagName: string): undefined|CssPart[] {
+  getCssParts(tagName: string): undefined | CssPart[] {
     return this.#tag(tagName)?.cssParts;
   }
 
   /**
    */
-  getDescription(tagName: string): undefined|string {
+  getDescription(tagName: string): undefined | string {
     return this.#tag(tagName)?.description;
   }
 
   /**
    */
-  getEvents(tagName: string): undefined|Event[] {
+  getEvents(tagName: string): undefined | Event[] {
     return this.#tag(tagName)?.events;
   }
 
   /**
    */
-  getMethods(tagName: string): undefined|ClassMethod[] {
+  getMethods(tagName: string): undefined | ClassMethod[] {
     return this.#tag(tagName)?.methods;
   }
 
   /**
    */
-  getProperties(tagName: string): undefined|ClassField[] {
+  getProperties(tagName: string): undefined | ClassField[] {
     return this.#tag(tagName)?.properties;
   }
 
   /**
    */
-  getSummary(tagName: string): undefined|string {
+  getSummary(tagName: string): undefined | string {
     return this.#tag(tagName)?.summary;
   }
 
   /**
    */
-  getSlots(tagName: string): undefined|Slot[] {
+  getSlots(tagName: string): undefined | Slot[] {
     return this.#tag(tagName)?.slots;
   }
 

--- a/tools/pfe-tools/dev-server/config.ts
+++ b/tools/pfe-tools/dev-server/config.ts
@@ -38,7 +38,7 @@ type Base = (DevServerConfig & PfeConfig);
 export interface PfeDevServerConfigOptions extends Base {
   hostname?: string;
   importMap?: InjectSetting['importMap'];
-  litcssOptions?: LitCSSOptions,
+  litcssOptions?: LitCSSOptions;
   tsconfig?: string;
   /** Extra dev server plugins */
   loadDemo?: boolean;

--- a/tools/pfe-tools/test/config.ts
+++ b/tools/pfe-tools/test/config.ts
@@ -9,7 +9,7 @@ import { pfeDevServerConfig, type PfeDevServerConfigOptions } from '../dev-serve
 
 export interface PfeTestRunnerConfigOptions extends PfeDevServerConfigOptions {
   files?: string[];
-  reporter?: 'summary'|'default';
+  reporter?: 'summary' | 'default';
 }
 
 const isWatchMode = process.argv.some(x => x.match(/-w|--watch/));

--- a/tools/pfe-tools/test/create-fixture.ts
+++ b/tools/pfe-tools/test/create-fixture.ts
@@ -5,7 +5,7 @@ import Color from 'colorjs.io';
 import { chai } from '@open-wc/testing';
 
 type TestHelpers = {
-  fixture: <T extends Element = HTMLElement>(testCase: string|TemplateResult) => Promise<T>;
+  fixture: <T extends Element = HTMLElement>(testCase: string | TemplateResult) => Promise<T>;
 };
 
 /**
@@ -55,7 +55,7 @@ const helpers: Promise<TestHelpers> = new Promise(resolve => {
  * @returns  Returns the new web component fixture rendered and ready for tests.
  */
 export async function createFixture<T extends Element = HTMLElement>(
-  code: string|TemplateResult
+  code: string | TemplateResult
 ): Promise<T> {
   const { fixture } = await helpers;
   return fixture<T>(code);

--- a/tools/pfe-tools/test/playwright/PfeDemoPage.ts
+++ b/tools/pfe-tools/test/playwright/PfeDemoPage.ts
@@ -53,7 +53,7 @@ export class PfeDemoPage {
   }
 
   /** Wait for the element, or a given selector, to update */
-  async updateComplete(selector: string|null = this.tagName) {
+  async updateComplete(selector: string | null = this.tagName) {
     await this.page.waitForLoadState('domcontentloaded');
     await this.page.waitForLoadState('networkidle');
     if (selector) {

--- a/tools/pfe-tools/test/react-wrapper.ts
+++ b/tools/pfe-tools/test/react-wrapper.ts
@@ -48,7 +48,7 @@ const markupRuiner = (_: unknown, css: string) =>
  * @returns  Returns the new web component rendered within React.
  */
 export async function fixture<T extends Element = HTMLElement>(
-  testCase: string|TemplateResult
+  testCase: string | TemplateResult
 ): Promise<T> {
   const code = (typeof testCase === 'string') ? testCase : renderToString(testCase);
   const appRoot = document.getElementById('root');

--- a/tools/pfe-tools/test/vue-wrapper.ts
+++ b/tools/pfe-tools/test/vue-wrapper.ts
@@ -4,13 +4,13 @@ import { elementUpdated, nextFrame, oneEvent } from '@open-wc/testing';
 import { renderToString } from './render-to-string';
 
 declare class Vue {
-  constructor(opts: { el: string|Element, template: string; mounted(): void });
+  constructor(opts: { el: string | Element; template: string; mounted(): void });
   $destroy(): void;
   $forceUpdate(): void;
   $nextTick(f: () => void): void;
   static nextTick(f: () => void): void;
   static config: {
-    ignoredElements?: string[]
+    ignoredElements?: string[];
   };
 }
 
@@ -30,7 +30,7 @@ let app: Vue;
  * @returns  Returns the new web component rendered within Vue.
  */
 export async function fixture<T extends Element = HTMLElement>(
-  testCase: string|TemplateResult
+  testCase: string | TemplateResult
 ): Promise<T> {
   const code = (typeof testCase === 'string') ? testCase : renderToString(testCase);
 


### PR DESCRIPTION
## What I did

1. added some formatting rules to automate spacing around typescript enums and type annotations
2. linted files