### PR TITLE
docs: fix favicon not appearing in url bar

### DIFF
--- a/docs/_plugins/pfe-assets.cjs
+++ b/docs/_plugins/pfe-assets.cjs
@@ -72,6 +72,7 @@ async function bundle() {
 
 module.exports = {
   configFunction(eleventyConfig, options) {
+    eleventyConfig.addPassthroughCopy('docs/images/favicon.ico');
     eleventyConfig.addPassthroughCopy('docs/bundle.{js,map,ts}');
     eleventyConfig.addPassthroughCopy('docs/pfe.min.{map,css}');
     eleventyConfig.addPassthroughCopy({ 'elements/pfe.min.*': '/' } );
@@ -96,5 +97,3 @@ module.exports = {
     eleventyConfig.on('eleventy.before', () => bundle(options));
   },
 };
-
-


### PR DESCRIPTION
## What I did

1. Copying the favicon for the `docs` directory to the generated `_site` directory

## Testing Instructions

1.  

## Notes to Reviewers

1.
