### PR TITLE
docs: set text color to white on hover

### DIFF
--- a/docs/home.css
+++ b/docs/home.css
@@ -44,14 +44,17 @@
   --pf-cta--Color: #06c;
 }
 
+#home-header a.cta.primary:hover, 
+#home-header a.cta.primary:focus {
+  --pf-cta--BackgroundColor: transparent;
+}
+
 #home-header a.cta.primary:hover {
   --pf-cta--Color--hover: var(--pf-theme--color--white, #fff);
-  --pf-cta--BackgroundColor: transparent;
-  color: var(--pf-theme--color--white, #fff);
 }
 
 #home-header a.cta.primary:focus {
-  color: var(--pf-theme--color--accent, #0066cc);
+  --pf-cta--Color--focus: var(--pf-theme--color--white, #fff);
 }
 
 #home-header a.cta.secondary:hover {

--- a/docs/home.css
+++ b/docs/home.css
@@ -51,7 +51,7 @@
 }
 
 #home-header a.cta.primary:focus {
-  color: var(--pf-theme--color--white, #fff);
+  color: var(--pf-theme--color--accent, #0066cc);
 }
 
 #home-header a.cta.secondary:hover {

--- a/docs/home.css
+++ b/docs/home.css
@@ -50,6 +50,10 @@
   color: var(--pf-theme--color--white, #fff);
 }
 
+#home-header a.cta.primary:focus {
+  color: var(--pf-theme--color--white, #fff);
+}
+
 #home-header a.cta.secondary:hover {
   --pf-cta--Color--hover: #06c;
 }

--- a/docs/home.css
+++ b/docs/home.css
@@ -47,6 +47,7 @@
 #home-header a.cta.primary:hover {
   --pf-cta--Color--hover: var(--pf-theme--color--white, #fff);
   --pf-cta--BackgroundColor: transparent;
+  color: var(--pf-theme--color--white, #fff);
 }
 
 #home-header a.cta.secondary:hover {


### PR DESCRIPTION
Closes #2453

## What I did

1. Fixed get started CTA color on hover 

## Testing Instructions

1. Open the docs link and hover over the get started CTA (also set focus + hover in dev tools) and verify the text color is white.

## Notes to Reviewers

1. I don't think we're using `pfe-cta` in the docs anymore? Should we remove those custom variable overrides?
