### PR TITLE
fix(accordion): removing auto focus on expanded in the header

### DIFF
--- a/.changeset/stale-boxes-watch.md
+++ b/.changeset/stale-boxes-watch.md
@@ -2,4 +2,15 @@
 "@patternfly/elements": patch
 ---
 
-`accordion` - removed auto focus on the header when the expanded attribute is added. This is being removed so that if a page loads with an expanded accordion it does not scroll the user to it automatically.
+`accordion` - removed auto-focus on accordion header when the header contains the `expanded` attribute.  
+
+**Example**
+```
+  <pf-accordion>
+    <pf-accordion-header expanded>
+      Header Item
+    </pf-accordion-header>
+  </pf-accordion>
+```
+
+Previously, if you set the expanded attribute to expand the header when the component loaded it would also focus the element on the page for the user.  This has been removed.

--- a/.changeset/stale-boxes-watch.md
+++ b/.changeset/stale-boxes-watch.md
@@ -2,15 +2,5 @@
 "@patternfly/elements": patch
 ---
 
-`accordion` - removed auto-focus on accordion header when the header contains the `expanded` attribute.  
+`<pf-accordion>`: prevented `expanded` accordion headers from stealing focus when the page loads.
 
-**Example**
-```
-  <pf-accordion>
-    <pf-accordion-header expanded>
-      Header Item
-    </pf-accordion-header>
-  </pf-accordion>
-```
-
-Previously, if you set the expanded attribute to expand the header when the component loaded it would also focus the element on the page for the user.  This has been removed.

--- a/.changeset/stale-boxes-watch.md
+++ b/.changeset/stale-boxes-watch.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`accordion` - removed auto focus on the header when the expanded attribute is added. This is being removed so that if a page loads with an expanded accordion it does not scroll the user to it automatically.

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -117,7 +117,7 @@ export abstract class BaseAccordion extends LitElement {
   async firstUpdated() {
     const { headers } = this;
     for (const header of headers.filter(x => x.expanded)) {
-      await this.expand(headers.indexOf(header), this, true);
+      await this.expand(headers.indexOf(header), this, false);
     }
   }
 

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -116,9 +116,11 @@ export abstract class BaseAccordion extends LitElement {
 
   async firstUpdated() {
     const { headers } = this;
-    for (const header of headers.filter(x => x.expanded)) {
-      await this.expand(headers.indexOf(header), this, false);
-    }
+    headers.forEach((header, index) => {
+      if (header.expanded) {
+        this.#expandHeader(header, index);
+      }
+    });
   }
 
   /**
@@ -351,9 +353,8 @@ export abstract class BaseAccordion extends LitElement {
   /**
    * Accepts a 0-based index value (integer) for the set of accordion items to expand.
    * Accepts an optional parent accordion to search for headers and panels.
-   * Accepts an optional boolean to focus the header after expanding.
    */
-  public async expand(index: number, parentAccordion?: BaseAccordion, focus?: boolean) {
+  public async expand(index: number, parentAccordion?: BaseAccordion) {
     if (index === -1) {
       return;
     }
@@ -374,7 +375,7 @@ export abstract class BaseAccordion extends LitElement {
     this.#expandHeader(header, index),
     this.#expandPanel(panel),
 
-    focus && header.focus();
+    header.focus();
 
     this.dispatchEvent(new AccordionExpandEvent(header, panel));
 

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -119,6 +119,10 @@ export abstract class BaseAccordion extends LitElement {
     headers.forEach((header, index) => {
       if (header.expanded) {
         this.#expandHeader(header, index);
+        const panel = this.#panelForHeader(header);
+        if (panel) {
+          this.#expandPanel(panel);
+        }
       }
     });
   }

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -117,7 +117,7 @@ export abstract class BaseAccordion extends LitElement {
   async firstUpdated() {
     const { headers } = this;
     for (const header of headers.filter(x => x.expanded)) {
-      await this.expand(headers.indexOf(header));
+      await this.expand(headers.indexOf(header), this, true);
     }
   }
 
@@ -350,8 +350,10 @@ export abstract class BaseAccordion extends LitElement {
 
   /**
    * Accepts a 0-based index value (integer) for the set of accordion items to expand.
+   * Accepts an optional parent accordion to search for headers and panels.
+   * Accepts an optional boolean to focus the header after expanding.
    */
-  public async expand(index: number, parentAccordion?: BaseAccordion) {
+  public async expand(index: number, parentAccordion?: BaseAccordion, focus?: boolean) {
     if (index === -1) {
       return;
     }
@@ -371,6 +373,8 @@ export abstract class BaseAccordion extends LitElement {
     // If the header and panel exist, open both
     this.#expandHeader(header, index),
     this.#expandPanel(panel),
+
+    focus && header.focus();
 
     this.dispatchEvent(new AccordionExpandEvent(header, panel));
 

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -372,8 +372,6 @@ export abstract class BaseAccordion extends LitElement {
     this.#expandHeader(header, index),
     this.#expandPanel(panel),
 
-    header.focus();
-
     this.dispatchEvent(new AccordionExpandEvent(header, panel));
 
     await this.updateComplete;

--- a/elements/pf-accordion/pf-accordion.ts
+++ b/elements/pf-accordion/pf-accordion.ts
@@ -44,13 +44,9 @@ export class PfAccordion extends BaseAccordion {
 
   @property({ type: Boolean, reflect: true }) fixed = false;
 
-  override async expand(index: number, parentAccordion?: BaseAccordion, focus?: boolean) {
+  override async expand(index: number, parentAccordion?: BaseAccordion) {
     if (index === -1) {
       return;
-    }
-
-    if (focus === undefined) {
-      focus = true;
     }
 
     const allHeaders: Array<BaseAccordionHeader> = this.headers;
@@ -61,7 +57,8 @@ export class PfAccordion extends BaseAccordion {
         ...allHeaders.map((header, index) => header.expanded && this.collapse(index)),
       ]);
     }
-    await super.expand(index, parentAccordion, focus);
+
+    await super.expand(index, parentAccordion);
   }
 }
 

--- a/elements/pf-accordion/pf-accordion.ts
+++ b/elements/pf-accordion/pf-accordion.ts
@@ -44,9 +44,13 @@ export class PfAccordion extends BaseAccordion {
 
   @property({ type: Boolean, reflect: true }) fixed = false;
 
-  override async expand(index: number, parentAccordion?: BaseAccordion) {
+  override async expand(index: number, parentAccordion?: BaseAccordion, focus?: boolean) {
     if (index === -1) {
       return;
+    }
+
+    if (focus === undefined) {
+      focus = true;
     }
 
     const allHeaders: Array<BaseAccordionHeader> = this.headers;
@@ -57,7 +61,7 @@ export class PfAccordion extends BaseAccordion {
         ...allHeaders.map((header, index) => header.expanded && this.collapse(index)),
       ]);
     }
-    await super.expand(index, parentAccordion);
+    await super.expand(index, parentAccordion, focus);
   }
 }
 

--- a/elements/pf-accordion/pf-accordion.ts
+++ b/elements/pf-accordion/pf-accordion.ts
@@ -44,6 +44,24 @@ export class PfAccordion extends BaseAccordion {
 
   @property({ type: Boolean, reflect: true }) fixed = false;
 
+  async firstUpdated() {
+    let index: number | null = null;
+    if (this.single) {
+      const allHeaders = [...this.querySelectorAll('pf-accordion-header')];
+      const lastExpanded = allHeaders.filter(x => x.hasAttribute('expanded')).pop();
+      if (lastExpanded) {
+        index = allHeaders.indexOf(lastExpanded);
+      }
+    }
+    await super.firstUpdated();
+    if (index !== null) {
+      this.headers.forEach((_, i) => {
+        this.headers.at(i)?.toggleAttribute('expanded', i === index);
+        this.panels.at(i)?.toggleAttribute('expanded', i === index);
+      });
+    }
+  }
+
   override async expand(index: number, parentAccordion?: BaseAccordion) {
     if (index === -1) {
       return;

--- a/elements/pf-accordion/test/pf-accordion.spec.ts
+++ b/elements/pf-accordion/test/pf-accordion.spec.ts
@@ -954,7 +954,7 @@ describe('<pf-accordion>', function() {
       [header, secondHeader] = headers;
       [panel, secondPanel] = panels;
       await allUpdates(element);
-      await nextFrame();
+      await aTimeout(100);
     });
     it('hides the first panel', function() {
       expect(panel).to.not.have.attribute('expanded');
@@ -966,6 +966,7 @@ describe('<pf-accordion>', function() {
       expect(panels[2]).to.not.have.attribute('expanded');
     });
   });
+
   describe('with no h* tag in heading lightdom', function() {
     beforeEach(async function() {
       element = await createFixture<PfAccordion>(html`
@@ -1088,4 +1089,3 @@ describe('<pf-accordion>', function() {
     });
   });
 });
-


### PR DESCRIPTION
## What I did

1. Removed auto focus on expanded for the accordion header

Closes #2454 

This is so that if you have an expanded accordion down the page it doesn't automatically scroll the user down to the accordion.

## Testing Instructions

1. Check out the DP and verify the accordion docs page doesn't auto focus on the expanded header in the demo docs 
