### PR TITLE
docs: fix blog layout and component headers

### DIFF
--- a/.pfe.config.json
+++ b/.pfe.config.json
@@ -1,0 +1,6 @@
+{
+  "renderTitleInOverview": false,
+  "site": {
+    "renderTitleInOverview": false
+  }
+}

--- a/docs/_includes/_nav.njk
+++ b/docs/_includes/_nav.njk
@@ -112,6 +112,9 @@
             </ul>
             </details>
         </li>
+        <li class="site-navigation__item">
+          <a class="site-navigation__link{% if page.url == "/blog/" %} site-navigation__link--active{% endif %}" href="/blog/">Blog</a>
+        </li>       
         <!-- <li class="site-navigation__item">
             <a class="site-navigation__link{% if page.url == "/about/" %} site-navigation__link--active{% endif %}" href="/about/">About PatternFly Elements</a>
           </li> -->

--- a/docs/_includes/layout-basic.njk
+++ b/docs/_includes/layout-basic.njk
@@ -3,6 +3,6 @@ layout: layout-base.njk
 ---
 {% include '_nav.njk' %}
 <main class="basic">
-    {{ content | safe }}
+  {{ content | safe }}
 </main>
 {% include '_foot.njk' %}

--- a/docs/_includes/layout-blog-index.njk
+++ b/docs/_includes/layout-blog-index.njk
@@ -5,33 +5,38 @@ layout: layout-base.njk
 
 
 <main class="basic">
-  <header class="band">
-    <h1>{{ title }}</h1>
-  </header>
-  <section class="band">{% if content.trim().length %}
-    <div id="content">{{ content | safe }}</div>{% endif %}{% for post in collections.blog %}
-    <pf-card>
-      <h2 slot="header">{{ post.data.title }}</h2>{% if post.data.tagline %}
-        <p class="tagline">{{ post.data.tagline }}</p>{% endif %}
-      {% if post.data.description %}
-        {{ post.data.description }}
-      {% endif %}
-      <a class="cta" slot="footer" href="{{ post.data.page.url }}">Read Post</a>
-    </pf-card>{% endfor %}
-  </section>
+  {{ content | safe }}
+
+  <div class="posts">
+    {% for post in collections.blog | reverse %}
+      <pf-card>
+        <h2 slot="header">{{ post.data.title }}</h2>
+        {% if post.data.tagline %}
+          <p class="tagline"><a href="{{ post.data.page.url }}">{{ post.data.tagline }}</a></p>{% endif %}
+        {% if post.data.description %}
+          {{ post.data.description }}
+        {% endif %}
+        <a slot="footer" class="cta" href="{{ post.data.page.url }}">Read Post</a>
+        <time slot="footer" datetime="{{ post.data.page.date }}">{{ post.data.page.date | prettyDate }}</time>
+      </pf-card>
+    {% endfor %}
+  </div>
 </main>
+
 
 {% include '_foot.njk' %}
 
 <style>
-section.band {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-}
+  .posts {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    padding: var(--pf-global--spacer--3xl, 4rem);
+    gap: 2rem;
+  }
 
-h1,
-#content {
-  grid-column: -1/1;
-}
+  pf-card::part(footer) {
+    justify-content: space-between;
+    align-items: center;
+  }
 </style>
 

--- a/docs/_includes/layout-blog.njk
+++ b/docs/_includes/layout-blog.njk
@@ -5,8 +5,8 @@ layout: layout-base.njk
 
 <main class="blog">
   <header class="band header">
-    <h1>{{ title }}</h1>{% if tagline %}
-    <p class="tagline">{{ tagline }}</p>{% endif %}
+    <h1>{{ title }}</h1>
+    {% if tagline %}<p class="tagline">{{ tagline }}</p>{% endif %} 
     <time datetime="{{ page.date }}">{{ page.date | prettyDate }}</time>
   </header>
 
@@ -16,15 +16,16 @@ layout: layout-base.njk
   </aside>
 
   {% band %}
-  <details class="inline-toc">
-    <summary>Contents</summary>
-    {{- content | toc | safe -}}
-  </details>
+    <details class="inline-toc">
+      <summary>Contents</summary>
+      {{- content | toc | safe -}}
+    </details>
   {% endband %}
 
-  {%- band -%}
+  <section class="band">
     {{ content | safe }}
-  {%- endband -%}
+  </section>
+
 </main>
 
 {% include '_foot.njk' %}
@@ -67,10 +68,3 @@ layout: layout-base.njk
 
 </script>
 
-<style>
-main.blog > header.band {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-}
-</style>

--- a/docs/components/components.md
+++ b/docs/components/components.md
@@ -15,4 +15,8 @@
 }
 ---
 
+<header class="band">
+  <h1>{{element.title}}</h1>
+</header>
+
 {% renderFile element.docsTemplatePath, element %}

--- a/docs/main.css
+++ b/docs/main.css
@@ -848,7 +848,8 @@ nav.toc li {
     display: grid;
     position: relative;
     grid-template-areas: 'header header' 'content toc';
-    grid-template-columns: auto 300px;
+    grid-template-columns: auto 18rem;
+    grid-template-rows: min-content;
   }
 
   main.blog > header.band {
@@ -857,6 +858,7 @@ nav.toc li {
 
   main.blog > .block-toc {
     grid-area: toc;
+    padding: 1rem 2rem;
   }
 
   main.blog > .band:not(header) {
@@ -865,8 +867,7 @@ nav.toc li {
 
   aside.block-toc > nav.toc {
     position: sticky;
-    top: 60px;
-    padding: 10px 16px;
+    top: 126px;
   }
 
   aside.block-toc > h2 {
@@ -884,7 +885,7 @@ nav.toc li {
     transition: opacity 0.2s ease-in-out;
     position: absolute;
     left: -1.2em;
-    top: .2em;
+    top: 0.35em;
   }
 
   nav.toc .active::after {


### PR DESCRIPTION
## What I did

1. Fixed blog layout
2. Fixed regression in component headers style due to changes with addition of `renderTitleInOverview` https://github.com/patternfly/patternfly-elements/pull/2444
3. Added a `.pfe.config.json` to include the new `renderTitleInOverview: false` setting.

Closes #2451

## Testing Instructions

1. [Check out the blog](https://deploy-preview-2459--patternfly-elements.netlify.app/blog/)
2. [Check out component headers](https://deploy-preview-2459--patternfly-elements.netlify.app/components/tabs/)


