### PR TITLE
fix(tools): remove special characters from slugs

### DIFF
--- a/.changeset/cuddly-scissors-reply.md
+++ b/.changeset/cuddly-scissors-reply.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+Removes special characters from component slugs ie. `special (characters)` becomes `special-characters`

--- a/tools/pfe-tools/11ty/DocsPage.ts
+++ b/tools/pfe-tools/11ty/DocsPage.ts
@@ -74,7 +74,7 @@ export class DocsPage implements DocsPageRenderer {
     private options?: DocsPageOptions) {
     this.tagName = options?.tagName ?? '';
     this.title = options?.title ?? Manifest.prettyTag(this.tagName);
-    this.slug = slugify(options?.aliases?.[this.tagName] ?? this.tagName.replace(/^\w+-/, '')).toLowerCase();
+    this.slug = slugify(options?.aliases?.[this.tagName] ?? this.tagName.replace(/^\w+-/, ''), { strict: true, lower: true });
     this.summary = this.manifest.getSummary(this.tagName);
     this.description = this.manifest.getDescription(this.tagName);
     this.templates = nunjucks.configure(DocsPage.#templatesDir);

--- a/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
@@ -266,7 +266,9 @@ export class Manifest {
     const { prettyTag } = Manifest;
     return this.getDemos(tagName).map(demo => {
       const permalink = demo.url.replace(options.demoURLPrefix, '/');
-      const [, slug = ''] = permalink.match(/\/components\/(.*)\/demo/) ?? [];
+      let [, slug = ''] = permalink.match(/\/components\/(.*)\/demo/) ?? [];
+      // remove all special characters from slug
+      slug = slug.replace(/^a-zA-Z0-9 ]/g, '');
       const primaryElementName = deslugify(slug, options.rootDir);
       const filePath = demo.source?.href.replace(options.sourceControlURLPrefix, `${options.rootDir}/`) ?? '';
       const [last = ''] = filePath.split('/').reverse();

--- a/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest/lib/Manifest.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 
 import { getAllPackages } from './get-all-packages.js';
+import slugify from 'slugify';
 import { deslugify } from '@patternfly/pfe-tools/config.js';
 
 type PredicateFn = (x: unknown) => boolean;
@@ -267,8 +268,8 @@ export class Manifest {
     return this.getDemos(tagName).map(demo => {
       const permalink = demo.url.replace(options.demoURLPrefix, '/');
       let [, slug = ''] = permalink.match(/\/components\/(.*)\/demo/) ?? [];
-      // remove all special characters from slug
-      slug = slug.replace(/^a-zA-Z0-9 ]/g, '');
+      // strict removes all special characters from slug
+      slug = slugify(slug, { strict: true, lower: true });
       const primaryElementName = deslugify(slug, options.rootDir);
       const filePath = demo.source?.href.replace(options.sourceControlURLPrefix, `${options.rootDir}/`) ?? '';
       const [last = ''] = filePath.split('/').reverse();


### PR DESCRIPTION
## What I did

1. Removed special characters from component slugs.
2. Used [slugify](https://github.com/simov/slugify#options) `strict` mode and `lower` options to ensure slugs are lowercase and do not contain special characters.

## Testing Instructions

1. Double-check all demos and docs pages that no URLs are broken in Deploy Preview
2. Add an alias to `.pfe.config.json`. Fire up the local server and docs site, again ensure no URLs are broken

```json
{
  "aliases": {
      "pf-tabs": "Tabs (Special Snowflake)"
  }
  ...
}
```


