### PR TITLE
docs: add html example styles

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -702,10 +702,38 @@ code {
 
 .html-example {
   display: flex;
+  padding-block: 6px;
+}
+
+.html-example:hover summary {
+  color: var(--pf-c-expandable-section__toggle--hover--Color, var(--pf-global--link--Color--hover, #004080));
 }
 
 .html-example summary {
+  display: flex;
   cursor: pointer;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--pf-c-expandable-section__toggle--Color, var(--pf-global--link--Color, #06c));
+}
+
+.html-example > summary::-webkit-details-marker,
+.html-example > summary::marker {
+  display: none;
+}
+
+.html-example > summary::before {
+  content: "";
+  display: inline-block;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 256 512' aria-hidden='true' role='img' style='vertical-align: -0.125em;'%3E%3Cpath d='M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z'%3E%3C/path%3E%3C/svg%3E");
+  background-size: 1rem 1rem;
+  height: 1rem;
+  width: 1rem;
+  transition: all .2s ease-in;
+}
+
+.html-example[open] > summary::before {
+  transform: rotate(90deg);
 }
 
 .html-example p:empty {


### PR DESCRIPTION
## What I did

1. Added styles for `htmlexample` shortcode (details/summary) that mimics [Patternfly Expandable section](https://www.patternfly.org/v4/components/expandable-section) 


