### PR TITLE
fix: order name typo

### DIFF
--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -33,7 +33,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(CustomElementsManifestPlugin);
 
   /** Collections to organize alphabetically instead of by date */
-  eleventyConfig.addPlugin(OrderTagsPlugin, { tags: ['component'], order: 'alphabetically' });
+  eleventyConfig.addPlugin(OrderTagsPlugin, { tags: ['component'], order: 'alphabetical' });
 
   /** Collections to organize by order instead of date */
   eleventyConfig.addPlugin(OrderTagsPlugin, { tags: ['develop'] });


### PR DESCRIPTION
## What I did

1. Corrected sorting type spelling

Closes #2465.

## Testing Instructions

1. Run the docs site locally and verify that the nav items are ordered alphabetically.
