### PR TITLE
fix(tabs): fix focus on keyboard navigation for safari

### DIFF
--- a/.changeset/perfect-dragons-double.md
+++ b/.changeset/perfect-dragons-double.md
@@ -2,6 +2,6 @@
 "@patternfly/elements": patch
 ---
 
-`BaseTabs`: 
+`BaseTab`: 
  - fixed Safari focus issue on keyboard navigation
  - fixed Safari focus issue on mouse click

--- a/.changeset/perfect-dragons-double.md
+++ b/.changeset/perfect-dragons-double.md
@@ -3,5 +3,5 @@
 ---
 
 `BaseTabs`: 
- - fixes Safari focus issue on keyboard navigation
- - fixes Safari focus issue on tab mouse click
+ - fixed Safari focus issue on keyboard navigation
+ - fixed Safari focus issue on mouse click

--- a/.changeset/perfect-dragons-double.md
+++ b/.changeset/perfect-dragons-double.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`BaseTabs`: fixed race condition where activeItem could be incorrectly set on tab expand'

--- a/.changeset/perfect-dragons-double.md
+++ b/.changeset/perfect-dragons-double.md
@@ -2,4 +2,6 @@
 "@patternfly/elements": patch
 ---
 
-`BaseTabs`: fixed race condition where activeItem could be incorrectly set on tab expand'
+`BaseTabs`: 
+ - fixed race condition where activeItem could be incorrectly set on tab expand'
+ - applied focus on tab for click event for Safari

--- a/.changeset/perfect-dragons-double.md
+++ b/.changeset/perfect-dragons-double.md
@@ -3,5 +3,5 @@
 ---
 
 `BaseTabs`: 
- - fixed race condition where activeItem could be incorrectly set on tab expand'
- - applied focus on tab for click event for Safari
+ - fixes Safari focus issue on keyboard navigation
+ - fixes Safari focus issue on tab mouse click

--- a/elements/pf-tabs/BaseTab.ts
+++ b/elements/pf-tabs/BaseTab.ts
@@ -6,6 +6,8 @@ import { query } from 'lit/decorators/query.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
 
+import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
+
 import style from './BaseTab.css';
 
 export class TabExpandEvent extends ComposedEvent {
@@ -34,6 +36,8 @@ export abstract class BaseTab extends LitElement {
   abstract disabled: boolean;
 
   #internals = this.attachInternals();
+
+  id: string = this.id || getRandomId(this.localName);
 
   connectedCallback() {
     super.connectedCallback();

--- a/elements/pf-tabs/BaseTab.ts
+++ b/elements/pf-tabs/BaseTab.ts
@@ -66,6 +66,7 @@ export abstract class BaseTab extends LitElement {
   #clickHandler() {
     if (!this.disabled && this.#internals.ariaDisabled !== 'true' && this.ariaDisabled !== 'true') {
       this.active = true;
+      this.focus(); // safari fix
     }
   }
 

--- a/elements/pf-tabs/BaseTab.ts
+++ b/elements/pf-tabs/BaseTab.ts
@@ -37,8 +37,6 @@ export abstract class BaseTab extends LitElement {
 
   #internals = this.attachInternals();
 
-  id: string = this.id || getRandomId(this.localName);
-
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('click', this.#clickHandler);

--- a/elements/pf-tabs/BaseTab.ts
+++ b/elements/pf-tabs/BaseTab.ts
@@ -63,6 +63,10 @@ export abstract class BaseTab extends LitElement {
     }
   }
 
+  focus() {
+    this.button.focus();
+  }
+
   #clickHandler() {
     if (!this.disabled && this.#internals.ariaDisabled !== 'true' && this.ariaDisabled !== 'true') {
       this.active = true;

--- a/elements/pf-tabs/BaseTab.ts
+++ b/elements/pf-tabs/BaseTab.ts
@@ -6,8 +6,6 @@ import { query } from 'lit/decorators/query.js';
 
 import { ComposedEvent } from '@patternfly/pfe-core';
 
-import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
-
 import style from './BaseTab.css';
 
 export class TabExpandEvent extends ComposedEvent {

--- a/elements/pf-tabs/BaseTabPanel.ts
+++ b/elements/pf-tabs/BaseTabPanel.ts
@@ -11,8 +11,6 @@ export abstract class BaseTabPanel extends LitElement {
 
   #internals = this.attachInternals();
 
-  id: string = this.id || getRandomId(this.localName);
-
   render() {
     return html`
       <slot></slot>

--- a/elements/pf-tabs/BaseTabPanel.ts
+++ b/elements/pf-tabs/BaseTabPanel.ts
@@ -1,7 +1,5 @@
 import { LitElement, html } from 'lit';
 
-import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
-
 import style from './BaseTabPanel.css';
 
 export abstract class BaseTabPanel extends LitElement {

--- a/elements/pf-tabs/BaseTabPanel.ts
+++ b/elements/pf-tabs/BaseTabPanel.ts
@@ -1,5 +1,7 @@
 import { LitElement, html } from 'lit';
 
+import { getRandomId } from '@patternfly/pfe-core/functions/random.js';
+
 import style from './BaseTabPanel.css';
 
 export abstract class BaseTabPanel extends LitElement {
@@ -8,6 +10,8 @@ export abstract class BaseTabPanel extends LitElement {
   hidden = true;
 
   #internals = this.attachInternals();
+
+  id: string = this.id || getRandomId(this.localName);
 
   render() {
     return html`

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -226,6 +226,9 @@ export abstract class BaseTabs extends LitElement {
     }
 
     if (event.active) {
+      if (event.tab !== this.#tabindex.activeItem) {
+        this.#tabindex.updateActiveItem(event.tab);
+      }
       this.activeIndex = this.#allTabs.findIndex(tab => tab === event.tab);
     }
   };

--- a/elements/pf-tabs/BaseTabs.ts
+++ b/elements/pf-tabs/BaseTabs.ts
@@ -227,7 +227,6 @@ export abstract class BaseTabs extends LitElement {
 
     if (event.active) {
       this.activeIndex = this.#allTabs.findIndex(tab => tab === event.tab);
-      this.#tabindex.updateActiveItem(this.#activeTab);
     }
   };
 


### PR DESCRIPTION
### What I did

1. Added a check in the tabExpand event handler to check the event.tab object ensuring it is not the same as the tabindex activeItem before updating.  
2. Override `focus()` on tab applying focus to the shadowroot `button`.


Closes #2484 

### Reviewer Notes

Changes here need to be tested upstream in RHDS.  You will need to copy  or `npm link` the compiled files into RHDS to test.

### Testing instructions

1. Ensure that all arrow keys, page up, page down, and click events continue work in all browsers under different network conditions and load using the [deploy preview](https://deploy-preview-2485--patternfly-elements.netlify.app/components/tabs/demo/)
3. Check to make sure focus styles are applied correctly.

