### PR TITLE
fix(core): overflow controller scroll on small screens

### DIFF
--- a/.changeset/two-pugs-add.md
+++ b/.changeset/two-pugs-add.md
@@ -1,0 +1,7 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+`overflow-controller`: 
+ - improves display calculations for overflow scroll buttons
+ - adds smooth scroll behavior

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -61,17 +61,8 @@ export class OverflowController implements ReactiveController {
     if (!this.#container) {
       return;
     }
-    let firstElementInView: HTMLElement | undefined;
-    let lastElementOutOfView: HTMLElement | undefined;
-    for (let i = 0; i < this.#items.length && !firstElementInView; i++) {
-      if (isElementInView(this.#container, this.#items[i] as HTMLElement, false)) {
-        firstElementInView = this.#items[i];
-        lastElementOutOfView = this.#items[i - 1];
-      }
-    }
-    if (lastElementOutOfView) {
-      this.#container.scrollLeft -= lastElementOutOfView.scrollWidth;
-    }
+    const leftScroll = this.#container.scrollLeft - this.#container.clientWidth;
+    this.#container.scroll({ left: leftScroll });
     this.#setOverflowState();
   }
 
@@ -79,17 +70,8 @@ export class OverflowController implements ReactiveController {
     if (!this.#container) {
       return;
     }
-    let lastElementInView: HTMLElement | undefined;
-    let firstElementOutOfView: HTMLElement | undefined;
-    for (let i = this.#items.length - 1; i >= 0 && !lastElementInView; i--) {
-      if (isElementInView(this.#container, this.#items[i] as HTMLElement, false)) {
-        lastElementInView = this.#items[i];
-        firstElementOutOfView = this.#items[i + 1];
-      }
-    }
-    if (firstElementOutOfView) {
-      this.#container.scrollLeft += firstElementOutOfView.scrollWidth;
-    }
+    const leftScroll = this.#container.scrollLeft + this.#container.clientWidth;
+    this.#container.scroll({ left: leftScroll });
     this.#setOverflowState();
   }
 

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -62,7 +62,7 @@ export class OverflowController implements ReactiveController {
       return;
     }
     const leftScroll = this.#container.scrollLeft - this.#container.clientWidth;
-    this.#container.scroll({ left: leftScroll });
+    this.#container.scroll({ left: leftScroll, behavior: 'smooth' });
     this.#setOverflowState();
   }
 
@@ -71,7 +71,7 @@ export class OverflowController implements ReactiveController {
       return;
     }
     const leftScroll = this.#container.scrollLeft + this.#container.clientWidth;
-    this.#container.scroll({ left: leftScroll });
+    this.#container.scroll({ left: leftScroll, behavior: 'smooth' });
     this.#setOverflowState();
   }
 

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -42,7 +42,12 @@ export class OverflowController implements ReactiveController {
     }
     this.overflowLeft = !this.#hideOverflowButtons && !isElementInView(this.#container, this.firstItem);
     this.overflowRight = !this.#hideOverflowButtons && !isElementInView(this.#container, this.lastItem);
-    this.showScrollButtons = !this.#hideOverflowButtons && (this.overflowLeft || this.overflowRight);
+    let scrollButtonsWidth = 0;
+    if (this.overflowLeft || this.overflowRight) {
+      scrollButtonsWidth = (this.#container.parentElement?.querySelector('button')?.getBoundingClientRect().width || 0) * 2;
+    }
+    this.showScrollButtons = !this.#hideOverflowButtons &&
+    this.#container.scrollWidth > (this.#container.clientWidth + scrollButtonsWidth);
     this.host.requestUpdate();
   }
 


### PR DESCRIPTION
## What I did

1. Refactored scroll calculation for scrollLeft and scrollRight in overflow controller
2. Added smooth scroll behavior
3. Refactored showScrollButtons calculation to include scroll button width in hiding and showing the buttons.

## Testing Instructions

1. View [Deploy preview ](https://deploy-preview-2486--patternfly-elements.netlify.app/components/tabs/demo/)

## Notes to Reviewers

1. Ensure that this works across all browsers and screen sizes.  Please use Browserstack and try a variety of devices
