### PR TITLE
feat: ssr-friendly slot-controller

### DIFF
--- a/docs/components/demos.html
+++ b/docs/components/demos.html
@@ -65,7 +65,7 @@ preloads: [
 }
 ---
 <!DOCTYPE html>
-<html lang="en" dir="ltr" style="height: 100%">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -90,14 +90,17 @@ preloads: [
     PfIcon.addIconSet('far', get);
     PfIcon.addIconSet('fab', get);
     </script>
+    <style>
+      html, body, main { min-height: 100%; }
+    </style>
     <noscript>
       <style>
         :not(:defined) { opacity: 1; }
       </style>
     </noscript>
   </head>
-  <body style="height: 100%">
-    <main style="height: 100%">
+  <body>
+    <main>
       <div data-demo="{{demo.tagName}}">{% if demo.filePath %}
         {%- include demo.filePath -%}{% endif %}
       </div>

--- a/docs/components/demos.html
+++ b/docs/components/demos.html
@@ -90,6 +90,11 @@ preloads: [
     PfIcon.addIconSet('far', get);
     PfIcon.addIconSet('fab', get);
     </script>
+    <noscript>
+      <style>
+        :not(:defined) { opacity: 1; }
+      </style>
+    </noscript>
   </head>
   <body style="height: 100%">
     <main style="height: 100%">

--- a/elements/pf-card/BaseCard.ts
+++ b/elements/pf-card/BaseCard.ts
@@ -25,7 +25,12 @@ import style from './BaseCard.css';
 export abstract class BaseCard extends LitElement {
   static readonly styles = [style];
 
-  protected slots = new SlotController(this, 'header', null, 'footer');
+  protected slots = new SlotController(
+    this,
+    'header',
+    SlotController.anonymous,
+    'footer',
+  );
 
   render() {
     return html`
@@ -37,7 +42,7 @@ export abstract class BaseCard extends LitElement {
         </header>
         <div id="body"
              part="body"
-             class="${classMap({ empty: !this.querySelector(':not([slot])') })}">
+             class="${classMap({ empty: !this.slots.hasSlotted(SlotController.anonymous) })}">
           <slot></slot>
         </div>
         <footer id="footer"

--- a/elements/pf-card/demo/ssr.html
+++ b/elements/pf-card/demo/ssr.html
@@ -4,34 +4,33 @@
   <span slot="footer">Footer</span>
 </pf-card>
 
-<!--
-  <pf-card has-slotted="anonymous">
-    <p>Body</p>
-  </pf-card>
+<pf-card has-slotted="anonymous">
+  <p>Body</p>
+</pf-card>
 
-  <pf-card has-slotted="header">
-    <h2 slot="header">Header</h2>
-  </pf-card>
+<pf-card has-slotted="header">
+  <h2 slot="header">Header</h2>
+</pf-card>
 
-  <pf-card has-slotted="header,anonymous">
-    <h2 slot="header">Header</h2>
-    <p>Body</p>
-  </pf-card>
+<pf-card has-slotted="header,anonymous">
+  <h2 slot="header">Header</h2>
+  <p>Body</p>
+</pf-card>
 
-  <pf-card has-slotted="header,footer">
-    <h2 slot="header">Header</h2>
-    <span slot="footer">Footer</span>
-  </pf-card>
+<pf-card has-slotted="header,footer">
+  <h2 slot="header">Header</h2>
+  <span slot="footer">Footer</span>
+</pf-card>
 
-  <pf-card has-slotted="anonymous,footer">
-    <p>Body</p>
-    <span slot="footer">Footer</span>
-  </pf-card>
+<pf-card has-slotted="anonymous,footer">
+  <p>Body</p>
+  <span slot="footer">Footer</span>
+</pf-card>
 
-  <pf-card has-slotted="footer">
-    <span slot="footer">Footer</span>
-  </pf-card>
--->
+<pf-card has-slotted="footer">
+  <span slot="footer">Footer</span>
+</pf-card>
+
 <style>
 
 main {

--- a/elements/pf-card/demo/ssr.html
+++ b/elements/pf-card/demo/ssr.html
@@ -33,13 +33,17 @@
 
 <style>
 
-main {
-  padding: 2em;
-  background: #eeeeee;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: max-content 1fr;
-  gap: 1em;
-}
+  main {
+    padding: 2em;
+    background: #eeeeee;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: max-content 1fr;
+    gap: 1em;
+  }
+
+  [data-demo] {
+    display: contents;
+  }
 
 </style>

--- a/elements/pf-card/demo/ssr.html
+++ b/elements/pf-card/demo/ssr.html
@@ -39,6 +39,7 @@ main {
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: max-content 1fr;
+  gap: 1em;
 }
 
 </style>

--- a/elements/pf-card/demo/ssr.html
+++ b/elements/pf-card/demo/ssr.html
@@ -1,0 +1,45 @@
+<pf-card has-slotted="header,anonymous,footer">
+  <h2 slot="header">Header</h2>
+  <p>Body</p>
+  <span slot="footer">Footer</span>
+</pf-card>
+
+<!--
+  <pf-card has-slotted="anonymous">
+    <p>Body</p>
+  </pf-card>
+
+  <pf-card has-slotted="header">
+    <h2 slot="header">Header</h2>
+  </pf-card>
+
+  <pf-card has-slotted="header,anonymous">
+    <h2 slot="header">Header</h2>
+    <p>Body</p>
+  </pf-card>
+
+  <pf-card has-slotted="header,footer">
+    <h2 slot="header">Header</h2>
+    <span slot="footer">Footer</span>
+  </pf-card>
+
+  <pf-card has-slotted="anonymous,footer">
+    <p>Body</p>
+    <span slot="footer">Footer</span>
+  </pf-card>
+
+  <pf-card has-slotted="footer">
+    <span slot="footer">Footer</span>
+  </pf-card>
+-->
+<style>
+
+main {
+  padding: 2em;
+  background: #eeeeee;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: max-content 1fr;
+}
+
+</style>

--- a/eleventy.config.cjs
+++ b/eleventy.config.cjs
@@ -2,6 +2,8 @@ const { EleventyRenderPlugin } = require('@11ty/eleventy');
 const SyntaxHighlightPlugin = require('@11ty/eleventy-plugin-syntaxhighlight');
 const DirectoryOutputPlugin = require('@11ty/eleventy-plugin-directory-output');
 
+const LitSSRPlugin = require('@lit-labs/eleventy-plugin-lit');
+
 const PfeAssetsPlugin = require('./docs/_plugins/pfe-assets.cjs');
 const EmptyParagraphPlugin = require('./docs/_plugins/empty-p.cjs');
 
@@ -40,6 +42,12 @@ module.exports = function(eleventyConfig) {
 
   /** list todos */
   eleventyConfig.addPlugin(TodosPlugin);
+
+  eleventyConfig.addPlugin(LitSSRPlugin, {
+    componentModules: [
+      'elements/pf-card/pf-card.js',
+    ],
+  });
 
   /** format date strings */
   eleventyConfig.addFilter('prettyDate', function(dateStr, options = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@jspm/generator": "^1.1.6",
+        "@lit-labs/ssr": "^3.1.2",
         "@octokit/core": "^4.2.0",
         "@patternfly/patternfly": "^4.224.2",
         "@rhds/elements": "^1.0.0",
@@ -2811,10 +2812,79 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@lit-labs/ssr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.1.2.tgz",
+      "integrity": "sha512-0VC5E0S5mSqKPsrzwKjRoeTOwuQ5tCQH7NL5tKLyRug5spEypbK0bT5SCxWZE9BL+94KtuwMYLCGMXBR7RK1nA==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.0",
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.6.0",
+        "@parse5/tools": "^0.1.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^2.7.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.1.tgz",
+      "integrity": "sha512-IwR/DgV4RUgnvTaZmSd7u48dhcRiKcCYyKn7b9OoQZloBGhnG4MWIPIAJVFHpccC7/S0qXJamCANzw9+rjbltg==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit": "^2.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
       "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong=="
+    },
+    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
+      "version": "16.18.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
+      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
+      "dev": true
+    },
+    "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.1",
@@ -3253,6 +3323,27 @@
         "@open-wc/scoped-elements": "^2.1.3",
         "lit": "^2.0.0",
         "lit-html": "^2.0.0"
+      }
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.1.0.tgz",
+      "integrity": "sha512-VB9+4BsFoS+4HdB/Ph9jD4FHQt7GyiWESVNfBSh8Eu54LujWyy+NySGLjg8GZFWSZcESG72F67LjgmKZDZCvPg==",
+      "dev": true,
+      "dependencies": {
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@parse5/tools/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@patternfly/create-element": {
@@ -6771,6 +6862,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -7225,6 +7325,19 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
+      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/enquirer": {
@@ -8249,6 +8362,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8443,6 +8579,18 @@
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fragment-cache": {
@@ -12479,6 +12627,25 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -16155,6 +16322,15 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -17225,6 +17401,15 @@
       "dependencies": {
         "@pwrs/lit-css": "^2.0.0",
         "@rollup/pluginutils": "^5.0.2"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -19993,6 +20178,64 @@
         }
       }
     },
+    "@lit-labs/ssr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.1.2.tgz",
+      "integrity": "sha512-0VC5E0S5mSqKPsrzwKjRoeTOwuQ5tCQH7NL5tKLyRug5spEypbK0bT5SCxWZE9BL+94KtuwMYLCGMXBR7RK1nA==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-client": "^1.1.0",
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.6.0",
+        "@parse5/tools": "^0.1.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^2.7.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.7.0",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.32",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
+          "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+          "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+          "dev": true,
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "dev": true,
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        }
+      }
+    },
+    "@lit-labs/ssr-client": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.1.tgz",
+      "integrity": "sha512-IwR/DgV4RUgnvTaZmSd7u48dhcRiKcCYyKn7b9OoQZloBGhnG4MWIPIAJVFHpccC7/S0qXJamCANzw9+rjbltg==",
+      "dev": true,
+      "requires": {
+        "@lit/reactive-element": "^1.0.0",
+        "lit": "^2.0.0",
+        "lit-html": "^2.0.0"
+      }
+    },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
@@ -20366,6 +20609,26 @@
         "@open-wc/scoped-elements": "^2.1.3",
         "lit": "^2.0.0",
         "lit-html": "^2.0.0"
+      }
+    },
+    "@parse5/tools": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.1.0.tgz",
+      "integrity": "sha512-VB9+4BsFoS+4HdB/Ph9jD4FHQt7GyiWESVNfBSh8Eu54LujWyy+NySGLjg8GZFWSZcESG72F67LjgmKZDZCvPg==",
+      "dev": true,
+      "requires": {
+        "parse5": "^7.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "dev": true,
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        }
       }
     },
     "@patternfly/create-element": {
@@ -23330,6 +23593,12 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true
+    },
     "debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -23674,6 +23943,16 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
+      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
       }
     },
     "enquirer": {
@@ -24462,6 +24741,16 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -24623,6 +24912,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -27703,6 +28001,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
@@ -30497,6 +30801,12 @@
         }
       }
     },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true
+    },
     "tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -31307,6 +31617,12 @@
         "@pwrs/lit-css": "^2.0.0",
         "@rollup/pluginutils": "^5.0.2"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@jspm/generator": "^1.1.6",
+        "@lit-labs/eleventy-plugin-lit": "^1.0.1",
         "@lit-labs/ssr": "^3.1.2",
         "@octokit/core": "^4.2.0",
         "@patternfly/patternfly": "^4.224.2",
@@ -2810,6 +2811,19 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@lit-labs/eleventy-plugin-lit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/eleventy-plugin-lit/-/eleventy-plugin-lit-1.0.1.tgz",
+      "integrity": "sha512-oYkbHkdepsgj6BjqDmdRSZGjCHR5sZEfl3We6NoRd0sw+LdPgirGanBLwUh69A/EgUruxYXWgKffvMfWA2X61Q==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr": "^3.0.0",
+        "lit": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=12.16.0"
       }
     },
     "node_modules/@lit-labs/ssr": {
@@ -20176,6 +20190,16 @@
             "multiformats": "^10.0.0"
           }
         }
+      }
+    },
+    "@lit-labs/eleventy-plugin-lit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/eleventy-plugin-lit/-/eleventy-plugin-lit-1.0.1.tgz",
+      "integrity": "sha512-oYkbHkdepsgj6BjqDmdRSZGjCHR5sZEfl3We6NoRd0sw+LdPgirGanBLwUh69A/EgUruxYXWgKffvMfWA2X61Q==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr": "^3.0.0",
+        "lit": "^2.6.0"
       }
     },
     "@lit-labs/ssr": {

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@jspm/generator": "^1.1.6",
+    "@lit-labs/ssr": "^3.1.2",
     "@octokit/core": "^4.2.0",
     "@patternfly/patternfly": "^4.224.2",
     "@rhds/elements": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -289,6 +289,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@jspm/generator": "^1.1.6",
+    "@lit-labs/eleventy-plugin-lit": "^1.0.1",
     "@lit-labs/ssr": "^3.1.2",
     "@octokit/core": "^4.2.0",
     "@patternfly/patternfly": "^4.224.2",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
         "build:core",
         "build:tools",
         "build:icons",
+        "build:elements",
         "analyze"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -199,7 +199,9 @@
       "command": "web-dev-server --open --watch",
       "service": true,
       "dependencies": [
-        "build:tools"
+        "build:tools",
+        "build:elements",
+        "analyze"
       ]
     },
     "watch:analyze": {

--- a/tools/pfe-tools/dev-server/demo.css
+++ b/tools/pfe-tools/dev-server/demo.css
@@ -599,3 +599,11 @@ footer ul {
     top: 2rem;
   }
 }
+
+strong.noscript {
+  background-color: var(--pf-global--danger-color--100, #c9190b);
+  color: white;
+  border-radius: 4px;
+  padding: 4px 12px;
+  display: inline-block;
+}

--- a/tools/pfe-tools/dev-server/index.html
+++ b/tools/pfe-tools/dev-server/index.html
@@ -28,6 +28,13 @@
   <title>{{ title }}</title>
   <link rel="stylesheet" href="/node_modules/@patternfly/pfe-tools/dev-server/fonts.css">
   <link rel="stylesheet" href="/node_modules/@patternfly/pfe-tools/dev-server/demo.css">
+  <noscript>
+    <style>
+    html[unresolved] {
+      opacity: 1;
+    }
+    </style>
+  </noscript>
   {% for sheet in options.site.stylesheets %}
   <link rel="stylesheet" href="{{sheet}}">
   {% endfor %}
@@ -54,8 +61,11 @@
       <a href="/" aria-label="{{title}} Home">
         <img src="{{ options.site.logoUrl }}" alt="{{title}}">
       </a>
+
+      <noscript><strong class="noscript">JavaScript is disabled</strong></noscript>
+
       <a href="{{ options.sourceControlURLPrefix.replace('tree/main/', '') }}{{ ('tree/main' + manifest.path.replace(context.cwd, '').replace('/custom-elements.json', '/')) if manifest else ''}}" id="source-control">
-        
+
         {% if options.sourceControlURLPrefix %}<span>Contribute on {{ repoHost }}</span>{% endif %}
         {% if repoHost === 'GitHub' %}
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512">

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -3,4 +3,7 @@ import { pfeDevServerConfig } from '@patternfly/pfe-tools/dev-server/config.js';
 export default pfeDevServerConfig({
   // workaround for https://github.com/evanw/esbuild/issues/3019
   tsconfig: 'tsconfig.esbuild.json',
+  ssrModules: [
+    'elements/pf-card/pf-card.js',
+  ],
 });


### PR DESCRIPTION
:point_right: DRAFT PR DO NOT MERGE :point_left: 
This approach is experimental and requires discussion before pursuing. This PR is a PoC only. However there is a lot to get excited about. for example, we could load a `/elements/pf-icon/pf-icon-ssr.js` at ssr time which, instead of setting up a bunch of client side js to fetch and render the icon, would just dump the contents of the svg into shadow root with `await readFile`, at SSR time.

Read more: https://lit.dev/docs/ssr/overview/

## TODO:
use export conditions instead of `isServer`

![image](https://github.com/patternfly/patternfly-elements/assets/1466420/14b534bd-fab1-4954-8c62-82638d7e1c3c)
![image](https://github.com/patternfly/patternfly-elements/assets/1466420/117a8ae6-cc83-4fff-bfcb-c3bab4859fae)

## What I did

1. implement lit-ssr in slot-controller via a new `has-slotted` host attr

## Testing Instructions

1. disable javascript and visit [PR Preview Card SSR demo](https://deploy-preview-2505--patternfly-elements.netlify.app/components/card/demo/ssr/) (webkit or chromium until [firefox implements](https://bugzilla.mozilla.org/show_bug.cgi?id=1712140))


## Notes to Reviewers

**Problem**: Lit-SSR can't access the children, whereas SlotController relies on knowledge about the children. 
**Proposal**: read `has-slotted="a,b,c"` attr on SlotController hosts. This has limitations: 
1. content author has to add attrs
2. we can't use `hasSlotted` in connectedCallback, only in `render` (lit may relax this limitation in the future) 