### PR TITLE
fix(tools): dev server aliased element redirects

### DIFF
--- a/.changeset/fuzzy-walls-walk.md
+++ b/.changeset/fuzzy-walls-walk.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+`dev-server`: Corrects aliased elements redirects

--- a/tools/pfe-tools/config.ts
+++ b/tools/pfe-tools/config.ts
@@ -86,7 +86,11 @@ function getSlugsMap(rootDir: string) {
   return slugsConfigMap.get(rootDir)!;
 }
 
+/**
+ * Returns the prefixed custom element name for a given slug
+ */
 export function deslugify(slug: string, rootDir = process.cwd()): string {
   const { slugs, config } = getSlugsMap(rootDir);
-  return slugs.get(slug) ?? `${config.tagPrefix}-${slug}`;
+  const prefixedSlug = (slug.startsWith(`${config.tagPrefix}-`)) ? slug : `${config.tagPrefix}-${slug}`;
+  return slugs.get(slug) ?? prefixedSlug;
 }

--- a/tools/pfe-tools/dev-server/config.ts
+++ b/tools/pfe-tools/dev-server/config.ts
@@ -94,13 +94,12 @@ function kebabCase(string: string) {
     .toLowerCase();
 }
 
-function convertAliases(aliases: Record<string, string>, tagPrefix: string) {
+function convertAliases(aliases: Record<string, string>) {
   const keyedAliases = {} as Record<string, string>;
   for (const key in aliases) {
     if ({}.hasOwnProperty.call(aliases, key)) {
       const newKey = kebabCase(aliases[key]);
-      const preFixedKey = `${tagPrefix}-${newKey}`;
-      keyedAliases[preFixedKey] = key;
+      keyedAliases[newKey] = key;
     }
   }
   return keyedAliases;
@@ -117,7 +116,7 @@ function pfeDevServerPlugin(options: PfeDevServerInternalConfig): Plugin {
       const { elementsDir, tagPrefix, aliases } = options;
       const { componentSubpath } = options.site;
 
-      const keyedAliases = convertAliases(aliases, tagPrefix);
+      const keyedAliases = convertAliases(aliases);
 
       const prefixTag = (tag: string) => {
         if (!tag.startsWith(tagPrefix)) {
@@ -140,8 +139,7 @@ function pfeDevServerPlugin(options: PfeDevServerInternalConfig): Plugin {
           .get(`/${componentSubpath}/:element/:fileName.js`, async ctx => {
             const { element, fileName } = ctx.params;
 
-            let prefixedElement = prefixTag(element);
-            prefixedElement = keyedAliases[prefixedElement] ?? prefixedElement;
+            const prefixedElement = keyedAliases[element] ?? prefixTag(element);
 
             ctx.redirect(`/${elementsDir}/${prefixedElement}/${fileName}.ts`);
           })
@@ -149,8 +147,7 @@ function pfeDevServerPlugin(options: PfeDevServerInternalConfig): Plugin {
           .get(`/${elementsDir}/:element/:fileName.js`, async ctx => {
             const { element, fileName } = ctx.params;
 
-            let prefixedElement = prefixTag(element);
-            prefixedElement = keyedAliases[prefixedElement] ?? prefixedElement;
+            const prefixedElement = keyedAliases[element] ?? prefixTag(element);
 
             ctx.redirect(`/${elementsDir}/${prefixedElement}/${fileName}.ts`);
           })
@@ -159,8 +156,7 @@ function pfeDevServerPlugin(options: PfeDevServerInternalConfig): Plugin {
           .get(`/${componentSubpath}/:element/demo/:demoSubDir?/:fileName.:ext`, async (ctx, next) => {
             const { element, fileName, ext } = ctx.params;
 
-            let prefixedElement = prefixTag(element);
-            prefixedElement = keyedAliases[prefixedElement] ?? prefixedElement;
+            const prefixedElement = keyedAliases[element] ?? prefixTag(element);
 
             if (fileName.includes('-lightdom') && ext === 'css') {
               ctx.redirect(`/${elementsDir}/${prefixedElement}/${fileName}.${ext}`);

--- a/tools/pfe-tools/dev-server/config.ts
+++ b/tools/pfe-tools/dev-server/config.ts
@@ -88,9 +88,10 @@ async function renderURL(context: Context, options: PfeDevServerInternalConfig):
 
 function kebabCase(string: string) {
   return string
-    .replace(/([a-z])([A-Z])/g, '$1-$2') // Replace capital letters with lowercase
+    .replace(/[^a-zA-Z0-9\s]/g, '') // Remove all characters not letters, numbers or spaces
     .replace(/[\s_]+/g, '-') // Replace spaces and underscores with -
-    .replace(/[^-a-zA-Z]/g, '') // Remove all chars not letters, numbers or -
+    .replace(/-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+|-+$/g, '') // Remove leading and trailing -
     .toLowerCase();
 }
 


### PR DESCRIPTION
## What I did

1. Corrects aliased elements redirects in dev-server

## Testing Instructions

1. Dev Server locally add the configuration from the `.pfe.config.json` below:

## Notes to Reviewers

Given a `.pfe.conf.json`  with the following contents:

```
{
  "renderTitleInOverview": false,
  "aliases": {
    "pf-modal": "Marvelous Modals",
    "pf-tabs": "Terrific Tabs",
    "pf-clipboard-copy": "Making Copies",
    "pf-tile": "Tantalizing Tiles"
  }
}
```
A request  to pf-modals demo.css would produce a URL in the dev-server as: 

http://localhost:8000/components/magnificent-modal/demo/demo.css

Using deslugify we take the `magnificient-modal` slug and check for an alias and return it, If there is no alias we simply return the original path requested ensuring it has the correct tag prefix.

http://localhost:8000/components/magnificent-modal/demo/demo.css
Redirects to => 
http://localhost:8000/components/pf-modal/demo/demo.css
