### PR TITLE
fix(popover): add outsideClick event on popover show

### DIFF
--- a/elements/pf-popover/pf-popover.ts
+++ b/elements/pf-popover/pf-popover.ts
@@ -321,7 +321,6 @@ export class PfPopover extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('keydown', this.onKeydown);
-    PfPopover.instances.add(this);
   }
 
   render() {
@@ -454,6 +453,7 @@ export class PfPopover extends LitElement {
     });
     this._popover?.show();
     this.dispatchEvent(new PopoverShownEvent());
+    PfPopover.instances.add(this);
   }
 
   /**
@@ -464,6 +464,7 @@ export class PfPopover extends LitElement {
     await this.#float.hide();
     this._popover?.close();
     this.dispatchEvent(new PopoverHiddenEvent());
+    PfPopover.instances.delete(this);
   }
 }
 


### PR DESCRIPTION
fix(popover): add outsideClick event on popover show

We were adding outsideClick event in the connectedCallback lifecycle method. It adds for all popovers present on the page. It was not removed when we closed the popover.
Now I have changed the logic. We will add an outsideClick event when we show the popover and remove it on the hide popover.


fixes - https://github.com/patternfly/patternfly-elements/issues/2513