### PR TITLE
fix(tabs): style regression when no icon is present

### DIFF
--- a/.changeset/few-hotels-punch.md
+++ b/.changeset/few-hotels-punch.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`<pf-tabs>`: fixed style regression on tab when no icon is present
+`<pf-tabs>`: fixed style regression on tab when a slotted icon is not present

--- a/.changeset/few-hotels-punch.md
+++ b/.changeset/few-hotels-punch.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-tabs>`: fixed style regression on tab when no icon is present

--- a/elements/pf-tabs/pf-tab.css
+++ b/elements/pf-tabs/pf-tab.css
@@ -127,6 +127,10 @@ button:active {
   display: flex !important;
 }
 
+[part="icon"][hidden] {
+  display: none !important;
+}
+
 :host([disabled][border-bottom="false"]) button,
 :host([aria-disabled="true"][border-bottom="false"]) button {
   --pf-c-tabs__link--before--BorderBottomWidth: 0;


### PR DESCRIPTION
## What I did

1. Fixed style regression on tabs when a slotted icon is not present

## Testing Instructions

1.  View [Deploy preview](https://deploy-preview-2519--patternfly-elements.netlify.app/components/tabs/)

## Notes to Reviewers

1.  Tabs without icons should not have extra space, the icon slot should be hidden 
