### PR TITLE
fix(accordion): panel checkbox collapsing panel on check

### DIFF
--- a/.changeset/neat-colts-jam.md
+++ b/.changeset/neat-colts-jam.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-accordion`: fixed issue related to panel collapsing when an internal element is clicked.  Removing deprecated code now handled by RovingTabIndex controller.
+`<pf-accordion>`: fixed bug which would collapse a panel if it contained a checkbox which got toggled.

--- a/.changeset/neat-colts-jam.md
+++ b/.changeset/neat-colts-jam.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-accordion`: fixed issue related to panel collapsing when an internal element is clicked
+`pf-accordion`: fixed issue related to panel collapsing when an internal element is clicked.  Removing deprecated code now handled by RovingTabIndex controller.

--- a/.changeset/neat-colts-jam.md
+++ b/.changeset/neat-colts-jam.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-accordion`: fixed issue related to panel collapsing when an internal element is clicked

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -265,11 +265,11 @@ export abstract class BaseAccordion extends LitElement {
   }
 
   #onChange(event: AccordionHeaderChangeEvent) {
-    if (this.classList.contains('animating')) {
+    if (this.classList.contains('animating') || !(event.target instanceof BaseAccordionHeader || event.target instanceof BaseAccordionPanel)) {
       return;
     }
 
-    const index = this.#getIndex(event.target as Element);
+    const index = this.#getIndex(event.target as BaseAccordionHeader | BaseAccordionPanel);
 
     if (event.expanded) {
       this.expand(index, event.accordion);
@@ -278,66 +278,12 @@ export abstract class BaseAccordion extends LitElement {
     }
   }
 
-  /**
-   * @see https://www.w3.org/TR/wai-aria-practices/#accordion
-   */
-  async #onKeydown(evt: KeyboardEvent) {
-    const currentHeader = evt.target as Element;
-
-    if (!BaseAccordion.isHeader(currentHeader)) {
-      return;
-    }
-
-    let newHeader: BaseAccordionHeader | undefined;
-
-    switch (evt.key) {
-      case 'ArrowDown':
-        evt.preventDefault();
-        newHeader = this.#nextHeader();
-        break;
-      case 'ArrowUp':
-        evt.preventDefault();
-        newHeader = this.#previousHeader();
-        break;
-      case 'Home':
-        evt.preventDefault();
-        newHeader = this.#firstHeader();
-        break;
-      case 'End':
-        evt.preventDefault();
-        newHeader = this.#lastHeader();
-        break;
-    }
-
-    newHeader?.focus?.();
-  }
-
   #allHeaders(accordion: BaseAccordion = this): BaseAccordionHeader[] {
     return Array.from(accordion.children).filter(BaseAccordion.isHeader);
   }
 
   #allPanels(accordion: BaseAccordion = this): BaseAccordionPanel[] {
     return Array.from(accordion.children).filter(BaseAccordion.isPanel);
-  }
-
-  #previousHeader() {
-    const { headers } = this;
-    const newIndex = headers.findIndex(header => header.matches(':focus,:focus-within')) - 1;
-    return headers[(newIndex + headers.length) % headers.length];
-  }
-
-  #nextHeader() {
-    const { headers } = this;
-    const newIndex = headers.findIndex(header => header.matches(':focus,:focus-within')) + 1;
-    return headers[newIndex % headers.length];
-  }
-
-  #firstHeader() {
-    return this.headers.at(0);
-  }
-
-  #lastHeader() {
-    return this.headers.at(-1);
   }
 
   #getIndex(el: Element | null) {
@@ -386,10 +332,6 @@ export abstract class BaseAccordion extends LitElement {
    * Accepts an optional parent accordion to search for headers and panels.
    */
   public async expand(index: number, parentAccordion?: BaseAccordion) {
-    if (index === -1) {
-      return;
-    }
-
     const allHeaders: Array<BaseAccordionHeader> = this.#allHeaders(parentAccordion);
 
     const header = allHeaders[index];
@@ -426,9 +368,6 @@ export abstract class BaseAccordion extends LitElement {
    * Accepts a 0-based index value (integer) for the set of accordion items to collapse.
    */
   public async collapse(index: number) {
-    if (index === -1) {
-      return;
-    }
     const header = this.headers.at(index);
     const panel = this.panels.at(index);
 

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -48,6 +48,10 @@ export abstract class BaseAccordion extends LitElement {
     return target instanceof BaseAccordionPanel;
   }
 
+  static isAccordionChangeEvent(event: Event): event is AccordionHeaderChangeEvent {
+    return event instanceof AccordionHeaderChangeEvent;
+  }
+
   #headerIndex = new RovingTabindexController<BaseAccordionHeader>(this);
 
   #expandedIndex: number[] = [];
@@ -265,11 +269,11 @@ export abstract class BaseAccordion extends LitElement {
   }
 
   #onChange(event: AccordionHeaderChangeEvent) {
-    if (this.classList.contains('animating') || !(event.target instanceof BaseAccordionHeader || event.target instanceof BaseAccordionPanel)) {
+    if (!BaseAccordion.isAccordionChangeEvent(event) || this.classList.contains('animating')) {
       return;
     }
 
-    const index = this.#getIndex(event.target as BaseAccordionHeader | BaseAccordionPanel);
+    const index = this.#getIndex(event.target);
 
     if (event.expanded) {
       this.expand(index, event.accordion);

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -48,7 +48,7 @@ export abstract class BaseAccordion extends LitElement {
     return target instanceof BaseAccordionPanel;
   }
 
-  static isAccordionChangeEvent(event: Event): event is AccordionHeaderChangeEvent {
+  static #isAccordionChangeEvent(event: Event): event is AccordionHeaderChangeEvent {
     return event instanceof AccordionHeaderChangeEvent;
   }
 
@@ -269,16 +269,13 @@ export abstract class BaseAccordion extends LitElement {
   }
 
   #onChange(event: AccordionHeaderChangeEvent) {
-    if (!BaseAccordion.isAccordionChangeEvent(event) || this.classList.contains('animating')) {
-      return;
-    }
-
-    const index = this.#getIndex(event.target);
-
-    if (event.expanded) {
-      this.expand(index, event.accordion);
-    } else {
-      this.collapse(index);
+    if (BaseAccordion.#isAccordionChangeEvent(event) && !this.classList.contains('animating')) {
+      const index = this.#getIndex(event.target);
+      if (event.expanded) {
+        this.expand(index, event.accordion);
+      } else {
+        this.collapse(index);
+      }
     }
   }
 

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -426,6 +426,9 @@ export abstract class BaseAccordion extends LitElement {
    * Accepts a 0-based index value (integer) for the set of accordion items to collapse.
    */
   public async collapse(index: number) {
+    if (index === -1) {
+      return;
+    }
     const header = this.headers.at(index);
     const panel = this.panels.at(index);
 

--- a/elements/pf-accordion/BaseAccordionHeader.ts
+++ b/elements/pf-accordion/BaseAccordionHeader.ts
@@ -15,6 +15,7 @@ const isPorHeader =
     el instanceof HTMLElement && !!el.tagName.match(/P|^H[1-6]/);
 
 export class AccordionHeaderChangeEvent extends ComposedEvent {
+  declare target: BaseAccordionHeader;
   constructor(
     public expanded: boolean,
     public toggle: BaseAccordionHeader,

--- a/elements/pf-accordion/test/pf-accordion.spec.ts
+++ b/elements/pf-accordion/test/pf-accordion.spec.ts
@@ -1,11 +1,10 @@
-import type { ReactiveElement } from 'lit';
-
 import { expect, html, aTimeout, nextFrame } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 
 // Import the element we're testing.
 import { PfAccordion, PfAccordionPanel, PfAccordionHeader } from '@patternfly/elements/pf-accordion/pf-accordion.js';
+import { PfSwitch } from '@patternfly/elements/pf-switch/pf-switch.js';
 
 import { Logger } from '@patternfly/pfe-core/controllers/logger.js';
 
@@ -1322,64 +1321,53 @@ describe('<pf-accordion>', function() {
     });
   });
 
-  describe('with a single header and panel', function() {
+  describe('with a single expanded header and panel containing a checkbox and a switch', function() {
+    let element: PfAccordion;
+    let headers: NodeListOf<PfAccordionHeader>;
+    let panels: NodeListOf<PfAccordionPanel>;
+    let checkbox: HTMLInputElement;
+    let pfswitch: PfSwitch;
     let accordionPanelOne: PfAccordionPanel;
 
-    describe('with a checkbox input inside the panel and the first header is expanded', function() {
-      beforeEach(async function() {
-        await createFixture<HTMLElement>(html`
-        <div>
+    beforeEach(async function() {
+      element = await createFixture<PfAccordion>(html`
           <pf-accordion>
             <pf-accordion-header expanded id="header-1-1" data-index="0"></pf-accordion-header>
-            <pf-accordion-panel id="panel-1-1" data-index="0"></pf-accordion-panel>
+            <pf-accordion-panel id="panel-1-1" data-index="0">
+              <pf-switch></pf-switch>
+              <input type="checkbox">
+            </pf-accordion-panel>
           </pf-accordion>
-        </div>
         `);
-        document.getElementById('header-1-1') as PfAccordionHeader;
+      headers = document.querySelectorAll('pf-accordion-header');
+      panels = document.querySelectorAll('pf-accordion-panel');
+      checkbox = element.querySelector('input')!;
+      pfswitch = element.querySelector('pf-switch')!;
+      expect(checkbox).to.be.ok;
+      expect(pfswitch).to.be.ok;
+      [accordionPanelOne] = panels;
+    });
 
-        accordionPanelOne = document.getElementById('panel-1-1') as PfAccordionPanel;
+    describe('clicking the checkbox', function() {
+      beforeEach(async function() {
+        checkbox.click();
+        await element.updateComplete;
       });
-
-      describe('when the checkbox is checked', function() {
-        it('does not collapse the panel', async function() {
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          accordionPanelOne.appendChild(checkbox);
-          checkbox.click();
-          await nextFrame();
-          expect(accordionPanelOne.expanded).to.be.true;
-        });
+      it('does not collapse the panel', function() {
+        expect(accordionPanelOne.expanded).to.be.true;
       });
     });
-  });
 
-  describe('with a single header and panel', function() {
-    let accordionPanelOne: PfAccordionPanel;
-
-    describe('with a checkbox input inside the panel and the first header is expanded', function() {
+    describe('clicking the switch', function() {
       beforeEach(async function() {
-        await createFixture<HTMLElement>(html`
-        <div>
-          <pf-accordion>
-            <pf-accordion-header expanded id="header-1-1" data-index="0"></pf-accordion-header>
-            <pf-accordion-panel id="panel-1-1" data-index="0"></pf-accordion-panel>
-          </pf-accordion>
-        </div>
-        `);
-        document.getElementById('header-1-1') as PfAccordionHeader;
-
-        accordionPanelOne = document.getElementById('panel-1-1') as PfAccordionPanel;
+        const { checked } = pfswitch;
+        pfswitch.click();
+        await element.updateComplete;
+        await pfswitch.updateComplete;
+        expect(pfswitch.checked).to.not.equal(checked);
       });
-
-      describe('when the checkbox is checked', function() {
-        it('does not collapse the panel', async function() {
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          accordionPanelOne.appendChild(checkbox);
-          checkbox.click();
-          await nextFrame();
-          expect(accordionPanelOne.expanded).to.be.true;
-        });
+      it('does not collapse the panel', function() {
+        expect(accordionPanelOne.expanded).to.be.true;
       });
     });
   });

--- a/elements/pf-accordion/test/pf-accordion.spec.ts
+++ b/elements/pf-accordion/test/pf-accordion.spec.ts
@@ -1321,4 +1321,66 @@ describe('<pf-accordion>', function() {
       });
     });
   });
+
+  describe('with a single header and panel', function() {
+    let accordionPanelOne: PfAccordionPanel;
+
+    describe('with a checkbox input inside the panel and the first header is expanded', function() {
+      beforeEach(async function() {
+        await createFixture<HTMLElement>(html`
+        <div>
+          <pf-accordion>
+            <pf-accordion-header expanded id="header-1-1" data-index="0"></pf-accordion-header>
+            <pf-accordion-panel id="panel-1-1" data-index="0"></pf-accordion-panel>
+          </pf-accordion>
+        </div>
+        `);
+        document.getElementById('header-1-1') as PfAccordionHeader;
+
+        accordionPanelOne = document.getElementById('panel-1-1') as PfAccordionPanel;
+      });
+
+      describe('when the checkbox is checked', function() {
+        it('does not collapse the panel', async function() {
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          accordionPanelOne.appendChild(checkbox);
+          checkbox.click();
+          await nextFrame();
+          expect(accordionPanelOne.expanded).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('with a single header and panel', function() {
+    let accordionPanelOne: PfAccordionPanel;
+
+    describe('with a checkbox input inside the panel and the first header is expanded', function() {
+      beforeEach(async function() {
+        await createFixture<HTMLElement>(html`
+        <div>
+          <pf-accordion>
+            <pf-accordion-header expanded id="header-1-1" data-index="0"></pf-accordion-header>
+            <pf-accordion-panel id="panel-1-1" data-index="0"></pf-accordion-panel>
+          </pf-accordion>
+        </div>
+        `);
+        document.getElementById('header-1-1') as PfAccordionHeader;
+
+        accordionPanelOne = document.getElementById('panel-1-1') as PfAccordionPanel;
+      });
+
+      describe('when the checkbox is checked', function() {
+        it('does not collapse the panel', async function() {
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          accordionPanelOne.appendChild(checkbox);
+          checkbox.click();
+          await nextFrame();
+          expect(accordionPanelOne.expanded).to.be.true;
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
#2537 

## What I did

1.  Added an index check to the `collapse` function so that if the element that called the `change` event is not an `accordion-*` element it will not cause the panel to close.