### PR TITLE
docs: remove skip link animation

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -42,19 +42,18 @@ p:empty {
   display: flex;
   padding-inline: var(--pf-global--spacer--md, 1rem);
   padding-block: var(--pf-global--spacer--xs, 0.25rem);
-  position: absolute;
-  transform: translateY(-101%);
-  transition: transform 0.2s;
+  position: fixed;
+  top: -200px;
   width: max-content;
   /* Header bar is set to z-index: 300 */
   z-index: 301;
 }
 
 .skip-to-content-link:focus {
-  transform: translateY(0%);
   position: fixed;
   top: 0;
 }
+
 
 .sr-only {
   position: absolute;


### PR DESCRIPTION
## What I did

1. Removed skip link animation so link doesn't animate at page load

Closes #2553 

## Testing Instructions

1.  View [Deploy Preview](https://deploy-preview-2554--patternfly-elements.netlify.app/)

## Notes to Reviewers

1.  If you view patternflyelements.org before this PR is merged you'll notice on page loads the skip link will animate that was unintended.  This PR removes the animation all together as it really isn't needed for the links main purpose.
