### PR TITLE
bug: accordion and roving tabindex controller

### DIFF
--- a/.changeset/late-actors-give.md
+++ b/.changeset/late-actors-give.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-accordion`: fixed issue with focus event triggering incorrect tabindex

--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -97,7 +97,7 @@ export abstract class BaseAccordion extends LitElement {
   get #activeHeader() {
     const { headers } = this;
     const index = headers.findIndex(header => header.matches(':focus,:focus-within'));
-    return headers.at(index);
+    return index > -1 ? headers.at(index) : undefined;
   }
 
   protected expandedSets = new Set<number>();
@@ -162,7 +162,7 @@ export abstract class BaseAccordion extends LitElement {
     this.updateAccessibility();
   }
 
-  #updateActiveHeader() {
+  #updateActiveHeader(event: FocusEvent) {
     if (this.#activeHeader) {
       this.#headerIndex.updateActiveItem(this.#activeHeader);
     }

--- a/elements/pf-accordion/test/pf-accordion.spec.ts
+++ b/elements/pf-accordion/test/pf-accordion.spec.ts
@@ -386,7 +386,6 @@ describe('<pf-accordion>', function() {
           });
         });
 
-
         describe('Shift+Tab', function() {
           beforeEach(press('Shift+Tab'));
           it('moves focus to the body', function() {
@@ -614,7 +613,7 @@ describe('<pf-accordion>', function() {
             describe('Tab', function() {
               beforeEach(press('Tab'));
               it('moves focus to the body', function() {
-                expect(document.activeElement).to.equal(header3);
+                expect(document.activeElement).to.equal(document.body);
               });
               describe('Shift+Tab', function() {
                 beforeEach(press('Shift+Tab'));
@@ -1189,7 +1188,7 @@ describe('<pf-accordion>', function() {
 
         describe('Navigating from parent to child accordion', function() {
           describe('Opening the panel containing the nested accordion and pressing TAB', function() {
-            beforeEach(press(' '));
+            beforeEach(press('Space'));
             beforeEach(press('Tab'));
             it('moves focus to the nested accordion header', function() {
               expect(document.activeElement).to.equal(nestedHeaderOne);
@@ -1225,8 +1224,8 @@ describe('<pf-accordion>', function() {
 
             describe('Tab', function() {
               beforeEach(press('Tab'));
-              it('should move focus back to the parent accordion', function() {
-                expect(document.activeElement).to.equal(topLevelHeaderThree);
+              it('should move focus back to the body', function() {
+                expect(document.activeElement).to.equal(document.body);
               });
             });
           });


### PR DESCRIPTION
## What I did

1. Determined that #2496 was an issue with `BaseAccordion`'s use of `roving-tabindex-controller` rather than the controller itself.
2. Modified `BaseAccordion`'s `get #activeHeader` so that if no active header is found, the active header is returned as `undefined`.
3. Fixed issues with testing. (When focus is in the accordion panel and tab is pressed, focus should go to the body.)

## Testing Instructions

1. Go to the [Fixed Panel demo in DP](https://deploy-preview-2555--patternfly-elements.netlify.app/components/accordion/demo/)
2. Expand Item three.
4. Tab to Focus on me!
5. Use arrow keys.
6. The focus **_should not_** change.