### PR TITLE
fix(card): make slotted styles !important

### DIFF
--- a/.changeset/pf-card-heading-specificity.md
+++ b/.changeset/pf-card-heading-specificity.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/elements": patch
+---
+`<pf-card>`: ensure that slotted content's layout always follows design specs

--- a/elements/pf-card/BaseCard.css
+++ b/elements/pf-card/BaseCard.css
@@ -17,11 +17,11 @@ article {
 }
 
 [part=body] ::slotted(:not([slot]):first-of-type) {
-  margin-block-start: 0;
+  margin-block-start: 0 !important;
 }
 
 [part=body] ::slotted(:not([slot]):last-of-type) {
-  margin-block-end: 0;
+  margin-block-end: 0 !important;
 }
 
 [part=footer] {

--- a/elements/pf-card/pf-card.css
+++ b/elements/pf-card/pf-card.css
@@ -60,10 +60,10 @@ header {
 }
 
 header ::slotted(*) {
-  font-family: var(--pf-c-card__title--FontFamily, var(--pf-global--FontFamily--heading--sans-serif, "RedHatDisplayUpdated", helvetica, arial, sans-serif));
-  font-size: var(--pf-c-card__title--FontSize, var(--pf-global--FontSize--md, 1rem));
-  font-weight: var(--pf-c-card__title--FontWeight, var(--pf-global--FontWeight--bold, 700));
-  margin-block: 0;
+  font-family: var(--pf-c-card__title--FontFamily, var(--pf-global--FontFamily--heading--sans-serif, "RedHatDisplayUpdated", helvetica, arial, sans-serif)) !important;
+  font-size: var(--pf-c-card__title--FontSize, var(--pf-global--FontSize--md, 1rem)) !important;
+  font-weight: var(--pf-c-card__title--FontWeight, var(--pf-global--FontWeight--bold, 700)) !important;
+  margin-block: 0 !important;
 }
 
 [part="footer"] {


### PR DESCRIPTION
## What I did

1. make slotted styles in card `!important`

## Testing Instructions

1. try with this page:

```html
<style>
:is(h1, h2, h3, h4, h5, h6) {
  font-family: var(--rh-font-family-heading);
  margin-block: var(--rh-space-xl);
  line-height: 1;
}
</style>
<pf-card>
  <h3 slot=header>Haha broke your styles!</h3>
</pf-card>
```

## Notes to Reviewers

1. `!important` isn't great but these are design system tokens so I feel it's justified. You could argue that the margin values should not be important, but I think in this case they're specified so it's ok.
