### PR TITLE
feat: move converter to pfe core

### DIFF
--- a/core/pfe-core/core.ts
+++ b/core/pfe-core/core.ts
@@ -44,6 +44,12 @@ function makeConverter<T>(f: (x: string, type?: unknown) => T): ComplexAttribute
   };
 }
 
+export const BooleanStringConverter: ComplexAttributeConverter = {
+  fromAttribute(value) {
+    return !value || value === 'true';
+  },
+};
+
 /**
  * A LitElement property converter which represents a list of numbers as a comma separated string
  * @see https://lit.dev/docs/components/properties/#conversion-converter
@@ -57,6 +63,7 @@ export const NumberListConverter =
  */
 export const StringListConverter =
   makeConverter(x => x.trim());
+
 
 /**
  * A composed, bubbling event for UI interactions

--- a/elements/pf-timestamp/pf-timestamp.ts
+++ b/elements/pf-timestamp/pf-timestamp.ts
@@ -1,4 +1,4 @@
-import type { ComplexAttributeConverter, PropertyValues } from 'lit';
+import type { PropertyValues } from 'lit';
 
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
@@ -8,14 +8,9 @@ import {
   TimestampController,
   type DateTimeFormat,
 } from '@patternfly/pfe-core/controllers/timestamp-controller.js';
+import { BooleanStringConverter } from '@patternfly/pfe-core';
 
 import style from './pf-timestamp.css';
-
-const BooleanStringConverter: ComplexAttributeConverter = {
-  fromAttribute(value) {
-    return !value || value === 'true';
-  },
-};
 
 /**
  * A **timestamp** provides consistent formats for displaying date and time values.


### PR DESCRIPTION
## What I did

1. Moved the boolean string converter to pfe-core so that `rh-timestamp` can reference as well

## Testing Instructions

1.

## Notes to Reviewers

1.
