### PR TITLE
fix: downlevel output files to es2020

### DIFF
--- a/.changeset/downlevel-es2020.md
+++ b/.changeset/downlevel-es2020.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/element": patch
+---
+Supports Safari 16.3 (compiles element outputs to es2020)

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -29,7 +29,7 @@
     "rootDir": ".",
     "sourceMap": true,
     "strict": true,
-    "target": "es2022",
+    "target": "es2020",
     "useDefineForClassFields": false,
     "typeRoots": [
       "./node_modules/@types",


### PR DESCRIPTION
fixes #1157

## What I did

1. downlevel element output to es2020

## Testing Instructions

1. compile, ripgrep for `static ?\{` in js files

