### PR TITLE
fix(progress): fixing css selectors for variants

### DIFF
--- a/.changeset/new-maps-lick.md
+++ b/.changeset/new-maps-lick.md
@@ -1,5 +1,0 @@
----
-"@patternfly/elements": patch
----
-
-`<pf-progress>`: fixed css selectors for `variants` for background colors

--- a/.changeset/new-maps-lick.md
+++ b/.changeset/new-maps-lick.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`<pf-progress>`: fixed css selectors for `variants` for background colors

--- a/elements/pf-progress/docs/pf-progress.md
+++ b/elements/pf-progress/docs/pf-progress.md
@@ -4,7 +4,37 @@
     <pf-progress title="Default" value="33"></pf-progress>
 {% endrenderOverview %}
 
-{% band header="Usage" %}{% endband %}
+{% band header="Usage" %}
+
+   ### Success variant
+   {% htmlexample %}
+    <pf-progress variant="success" value="50"></pf-progress>
+   {% endhtmlexample %}
+
+   ### Inside measurement
+   {% htmlexample %}
+    <pf-progress value="24" measure-location="inside"></pf-progress>
+   {% endhtmlexample %}
+
+   ### Large size
+   {% htmlexample %}
+    <pf-progress value="24" size="lg"></pf-progress>
+   {% endhtmlexample %}
+
+   ### Inside measurement
+   {% htmlexample %}
+    <pf-progress value="24" measure-location="inside"></pf-progress>
+   {% endhtmlexample %}
+
+   ### Truncated Description
+   {% htmlexample %}
+    <pf-progress
+        value="29"
+        description-truncated
+        description="Very very very very very very very very very very very long description which should be truncated if it does not fit onto one line above the progress bar"
+    ></pf-progress>
+   {% endhtmlexample %}
+{% endband %}
 
 {% renderSlots %}{% endrenderSlots %}
 

--- a/elements/pf-progress/pf-progress.css
+++ b/elements/pf-progress/pf-progress.css
@@ -90,19 +90,19 @@
   grid-template-columns: 1fr fit-content(50%);
 }
 
-.success {
+#container.success {
   --pf-c-progress__bar--before--BackgroundColor: var(--pf-c-progress--m-success__bar--BackgroundColor);
   --_pf-c-progress__bar--before--BackgroundColorWithOpacity: var(--_pf-c-progress--m-success__bar--BackgroundColorWithOpacity);
   --pf-c-progress__status-icon--Color: var(--pf-c-progress--m-success__status-icon--Color);
 }
 
-.warning {
+#container.warning {
   --pf-c-progress__bar--before--BackgroundColor: var(--pf-c-progress--m-warning__bar--BackgroundColor);
   --_pf-c-progress__bar--before--BackgroundColorWithOpacity: var(--_pf-c-progress--m-warning__bar--BackgroundColorWithOpacity);
   --pf-c-progress__status-icon--Color: var(--pf-c-progress--m-warning__status-icon--Color);
 }
 
-.danger {
+#container.danger {
   --pf-c-progress__bar--before--BackgroundColor: var(--pf-c-progress--m-danger__bar--BackgroundColor);
   --_pf-c-progress__bar--before--BackgroundColorWithOpacity: var(--_pf-c-progress--m-danger__bar--BackgroundColorWithOpacity);
   --pf-c-progress__status-icon--Color: var(--pf-c-progress--m-danger__status-icon--Color);


### PR DESCRIPTION
## What I did

1.  Updated `success`, `warning`, and `danger` variant css to fix variant background color.
