### PR TITLE
[progress]: updating changeset attr from title to description

### DIFF
--- a/.changeset/rich-kangaroos-brake.md
+++ b/.changeset/rich-kangaroos-brake.md
@@ -5,5 +5,5 @@
 ✨ Added `<pf-progress>`
 
 ```html
-<pf-progress title="Default" value="33"></pf-progress>
+<pf-progress description="Default" value="33"></pf-progress>
 ```


### PR DESCRIPTION
## What I did

1.  Updating the changeset for the release to have the attribute `description` instead of `title` as title does not exist on pf-progress elements. 
