### PR TITLE
feat(text-input): placeholder

### DIFF
--- a/.changeset/pf-text-input-placeholder.md
+++ b/.changeset/pf-text-input-placeholder.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/elements": minor
+---
+`<pf-text-input>`: added `placeholder` attribute

--- a/elements/pf-text-input/pf-text-input.ts
+++ b/elements/pf-text-input/pf-text-input.ts
@@ -188,6 +188,9 @@ export class PfTextInput extends LitElement {
   /** Flag to show if the input is read only. */
   @property({ type: Boolean, reflect: true }) readonly = false;
 
+  /** Input placeholder. */
+  @property() placeholder?: string;
+
   /** Value of the input. */
   @property() value = '';
 
@@ -217,6 +220,7 @@ export class PfTextInput extends LitElement {
              ?readonly="${this.readonly}"
              ?required="${this.required}"
              aria-label="${this.#derivedLabel}"
+             placeholder="${ifDefined(this.placeholder)}"
              type="${ifDefined(this.type)}"
              .value="${this.value}"
              style="${ifDefined(this.customIconUrl && styleMap({


### PR DESCRIPTION
Closes #2594

## What I did

1. add `placeholder` attr/prop pair which forwards to input.

## Testing Instructions

1. Load Deploy preview input demo, set placeholder DOM property, add placeholder attribute
https://deploy-preview-2595--patternfly-elements.netlify.app/components/text-input/demo/
```js
document.querySelector('pf-text-input').placeholder = "world"

document.querySelector('pf-text-input').setAttribute('placeholder', 'hello')
```
## Notes to Reviewers

1. This api doesn't exist on the react component, but makes sense for the custom element.
3. please check that styles are congruent with upstream
