### PR TITLE
fix(accordion): removing base accordion styles

### DIFF
--- a/elements/pf-accordion/BaseAccordion.ts
+++ b/elements/pf-accordion/BaseAccordion.ts
@@ -30,8 +30,6 @@ export class AccordionCollapseEvent extends ComposedEvent {
 }
 
 export abstract class BaseAccordion extends LitElement {
-  static readonly styles = [];
-
   static isAccordion(target: EventTarget | null): target is BaseAccordion {
     return target instanceof BaseAccordion;
   }

--- a/elements/pf-accordion/pf-accordion.ts
+++ b/elements/pf-accordion/pf-accordion.ts
@@ -28,7 +28,7 @@ import style from './pf-accordion.css';
  */
 @customElement('pf-accordion')
 export class PfAccordion extends BaseAccordion {
-  static readonly styles = [...BaseAccordion.styles, style];
+  static readonly styles = [style];
 
   /** When true, only one accordion panel may be expanded at a time */
   @property({ reflect: true, type: Boolean }) single = false;


### PR DESCRIPTION
#2642 

## What I did

1.  Remove `static styles` from base accordion, removed import for pf-accordion.

The pipeline should be fixed with this commit.  Base accordion does not contain any style files 
