### PR TITLE
fix: remove color theme token, replace with PFv4 tokens

### DIFF
--- a/elements/pf-background-image/demo/sibling-content.html
+++ b/elements/pf-background-image/demo/sibling-content.html
@@ -1,4 +1,3 @@
-<script type="module" src="pf-background-image.js"></script>
 
 <pf-background-image
   src="/components/background-image/demo/pfbg.jpg"
@@ -20,7 +19,12 @@
     background-color: transparent;
   }
   section {
-    color: var(--pf-theme--color--ui-base--text, #fff);
+    color: var(--pf-global--palette--white, #fff);
     padding: var(--pf-global--spacer--xl, 2rem);
   }
 </style>
+
+
+<script type="module">
+  import '@patternfly/elements/pf-background-image/pf-background-image.js';
+</script>

--- a/elements/pf-chip/pf-chip.css
+++ b/elements/pf-chip/pf-chip.css
@@ -85,7 +85,7 @@
 }
 
 :host([readonly]) .chip-content {
-  color: var(--pf-theme--color--ui-base, #6a6e73);
+  color: var(--pf-global--Color--200, #6a6e73);
 }
 
 #close-button {

--- a/elements/pf-dropdown/pf-dropdown.css
+++ b/elements/pf-dropdown/pf-dropdown.css
@@ -80,7 +80,7 @@ pf-dropdown-menu.show {
 
 pf-button.disabled::part(button),
 :host([disabled]) ::slotted([slot="trigger"]) {
-  color: var(--pf-theme--color--ui-base, #6a6e73) !important;
+  color: var(---pf-c-dropdown__menu-item--disabled--Color, #6a6e73) !important;
   background-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   border-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
 }

--- a/elements/pf-select/pf-listbox.css
+++ b/elements/pf-select/pf-listbox.css
@@ -16,11 +16,11 @@ slot {
 }
 
 slot.disabled {
-  color: var(--pf-theme--color--ui-base, #6a6e73) !important;
+  color: var(--pf-c-list__item-icon--Color, #6a6e73) !important;
   background-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   border-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   pointer-events: none;
   cursor: not-allowed;;
   --_active-descendant-color: transparent;
-  --_svg-color: var(--pf-theme--color--ui-base, #6a6e73) !important;
+  --_svg-color: var(--pf-c-list__item-icon--Color, #6a6e73) !important;
 }

--- a/elements/pf-select/pf-option-group.css
+++ b/elements/pf-select/pf-option-group.css
@@ -10,7 +10,7 @@
   background-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   border-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   --_active-descendant-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
-  --_svg-color: var(--pf-global--Color--2000, #6a6e73) !important;
+  --_svg-color: var(--pf-global--Color--200, #6a6e73) !important;
 }
 
 slot {

--- a/elements/pf-select/pf-option-group.css
+++ b/elements/pf-select/pf-option-group.css
@@ -6,11 +6,11 @@
 :host([disabled]) {
   pointer-events: none;
   cursor: not-allowed;
-  color: var(--pf-global--Color--dark-200, #6a6e73) !important;
+  color: var(--pf-global--Color--200, #6a6e73) !important;
   background-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   border-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   --_active-descendant-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
-  --_svg-color: var(--pf-global--Color--dark-200, #6a6e73) !important;
+  --_svg-color: var(--pf-global--Color--2000, #6a6e73) !important;
 }
 
 slot {

--- a/elements/pf-select/pf-option-group.css
+++ b/elements/pf-select/pf-option-group.css
@@ -6,11 +6,11 @@
 :host([disabled]) {
   pointer-events: none;
   cursor: not-allowed;
-  color: var(--pf-theme--color--ui-base, #6a6e73) !important;
+  color: var(--pf-global--Color--dark-200, #6a6e73) !important;
   background-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   border-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
   --_active-descendant-color: var(--pf-theme--color--surface--lighter, #f0f0f0) !important;
-  --_svg-color: var(--pf-theme--color--ui-base, #6a6e73) !important;
+  --_svg-color: var(--pf-global--Color--dark-200, #6a6e73) !important;
 }
 
 slot {


### PR DESCRIPTION
## What I did

1.  Remove color theme token, replace with PFv4 tokens in a best guess.  

Closes #2660

## Testing Instructions

1.

## Notes to Reviewers

1.  If I could find one that seemed to fit the use case I swapped it otherwise used the global version.   Not ideal but don't think our use cases always match perfect.  PTAL, correct my mistakes were plausible.
