### PR TITLE
docs(tabs): fix typo in css rule in demo

### DIFF
--- a/elements/pf-tabs/demo/active-tab-disabled.html
+++ b/elements/pf-tabs/demo/active-tab-disabled.html
@@ -20,7 +20,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/active-tab-is-disabled.html
+++ b/elements/pf-tabs/demo/active-tab-is-disabled.html
@@ -20,7 +20,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/box.html
+++ b/elements/pf-tabs/demo/box.html
@@ -34,7 +34,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/dynamic-tabs.html
+++ b/elements/pf-tabs/demo/dynamic-tabs.html
@@ -58,7 +58,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/filled-with-icons.html
+++ b/elements/pf-tabs/demo/filled-with-icons.html
@@ -18,7 +18,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/filled.html
+++ b/elements/pf-tabs/demo/filled.html
@@ -17,7 +17,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/icons-and-text.html
+++ b/elements/pf-tabs/demo/icons-and-text.html
@@ -23,7 +23,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/inset.html
+++ b/elements/pf-tabs/demo/inset.html
@@ -38,7 +38,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/manual-activation.html
+++ b/elements/pf-tabs/demo/manual-activation.html
@@ -21,7 +21,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/nested.html
+++ b/elements/pf-tabs/demo/nested.html
@@ -31,7 +31,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/overflow.html
+++ b/elements/pf-tabs/demo/overflow.html
@@ -40,7 +40,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/pf-tabs.html
+++ b/elements/pf-tabs/demo/pf-tabs.html
@@ -20,7 +20,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/tabs-first-in-markup.html
+++ b/elements/pf-tabs/demo/tabs-first-in-markup.html
@@ -20,7 +20,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {

--- a/elements/pf-tabs/demo/vertical.html
+++ b/elements/pf-tabs/demo/vertical.html
@@ -38,7 +38,7 @@
 <style>
   main {
     display: block;
-    scroll-x: unset;
+    overflow-x: unset;
   }
 
   section {


### PR DESCRIPTION
## What I did

1.  Fixed a brain fart typo `scroll-x` should have been `overflow-x`

## Testing Instructions

1.

## Notes to Reviewers

1.
