### PR TITLE
fix: unminify css when bundling

### DIFF
--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -100,6 +100,7 @@ module.exports = async function() {
   for (const file of pfeCoreImports) {
     map.imports[path.join('@patternfly/pfe-core', file)] = '/pfe.min.js';
   }
+
   map.imports['@patternfly/pfe-core/decorators.js'] = '/pfe.min.js';
   map.imports['@patternfly/pfe-core'] = '/pfe.min.js';
 
@@ -108,12 +109,13 @@ module.exports = async function() {
     const elementPath = path.join(elementsPath, tagName);
     if (fs.statSync(elementPath).isDirectory()) {
       for (const fileName of fs.readdirSync(elementPath)) {
-        if (fileName.endsWith('.ts') && fileName.replace('.ts', '') !== tagName) {
+        if (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')) {
           map.imports[`@patternfly/elements/${tagName}/${fileName.replace('.ts', '')}.js`] = `/pfe.min.js`;
         }
       }
     }
   }
+
   map.imports['@patternfly/pfe-tools/environment.js'] = '/tools/environment.js';
 
 

--- a/docs/_data/importMap.cjs
+++ b/docs/_data/importMap.cjs
@@ -103,8 +103,16 @@ module.exports = async function() {
   map.imports['@patternfly/pfe-core/decorators.js'] = '/pfe.min.js';
   map.imports['@patternfly/pfe-core'] = '/pfe.min.js';
 
-  for (const tagName of fs.readdirSync(path.join(__dirname, '..', '..', 'elements'))) {
-    map.imports[`@patternfly/elements/${tagName}/${tagName}.js`] = `/pfe.min.js`;
+  const elementsPath = path.join(__dirname, '..', '..', 'elements');
+  for (const tagName of fs.readdirSync(elementsPath)) {
+    const elementPath = path.join(elementsPath, tagName);
+    if (fs.statSync(elementPath).isDirectory()) {
+      for (const fileName of fs.readdirSync(elementPath)) {
+        if (fileName.endsWith('.ts') && fileName.replace('.ts', '') !== tagName) {
+          map.imports[`@patternfly/elements/${tagName}/${fileName.replace('.ts', '')}.js`] = `/pfe.min.js`;
+        }
+      }
+    }
   }
   map.imports['@patternfly/pfe-tools/environment.js'] = '/tools/environment.js';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "leasot": "^13.3.0",
         "lit": "^3.1.2",
         "nunjucks": "^3.2.4",
+        "postcss-nesting": "^12.1.0",
         "prompts": "^2.4.2",
         "wireit": "^0.14.4",
         "zero-md": "^2.5.3"
@@ -1695,10 +1696,32 @@
         "@csstools/css-tokenizer": "^2.2.3"
       }
     },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
+      "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
     "node_modules/@csstools/selector-specificity": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz",
-      "integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.2.tgz",
+      "integrity": "sha512-RpHaZ1h9LE7aALeQXmXrJkRG84ZxIsctEN2biEUmFyKpzFM3zZ35eUMcIzZFsw/2olQE6v69+esEqU2f1MKycg==",
       "dev": true,
       "funding": [
         {
@@ -11918,6 +11941,33 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-nesting": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.0.tgz",
+      "integrity": "sha512-QOYnosaZ+mlP6plQrAxFw09UUp2Sgtxj1BVHN+rSVbtV0Yx48zRt9/9F/ZOoxOKBBEsaJk2MYhhVRjeRRw5yuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^1.1.0",
+        "@csstools/selector-specificity": "^3.0.2",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-normalize-charset": {

--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "leasot": "^13.3.0",
     "lit": "^3.1.2",
     "nunjucks": "^3.2.4",
+    "postcss-nesting": "^12.1.0",
     "prompts": "^2.4.2",
     "wireit": "^0.14.4",
     "zero-md": "^2.5.3"

--- a/tsconfig.esbuild.json
+++ b/tsconfig.esbuild.json
@@ -44,8 +44,7 @@
     "plugins": [
       {
         "transform": "@patternfly/pfe-tools/typescript/transformers/css-imports.cjs",
-        "inline": true,
-        "minify": true
+        "inline": true
       },
       {
         "name": "typescript-lit-html-plugin"

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -38,8 +38,7 @@
     "plugins": [
       {
         "transform": "@patternfly/pfe-tools/typescript/transformers/css-imports.cjs",
-        "inline": true,
-        "minify": true
+        "inline": true
       },
       {
         "name": "typescript-lit-html-plugin"


### PR DESCRIPTION
## What I did

1. unminify the shadow css when bundling

## Testing Instructions

1. on the [DP chip group demo page](https://deploy-preview-2710--patternfly-elements.netlify.app/components/chip/demo/chip-group-with-visible-category-name/), chip close buttons should be vertically centered, as normal. If this PR is broken, they will appear below the vertical center line. 

![Screenshot 2024-03-20 at 8 00 43](https://github.com/patternfly/patternfly-elements/assets/1466420/2e7a8f84-ab78-4d1d-9ff5-5e3cbd81512e)
