### PR TITLE
fix(button): prevent default behavior for spacebar

### DIFF
--- a/elements/pf-button/pf-button.ts
+++ b/elements/pf-button/pf-button.ts
@@ -287,6 +287,12 @@ export class PfButton extends LitElement {
   #onKeydown(event: KeyboardEvent) {
     switch (event.key) {
       case ' ':
+        event.preventDefault();
+        event.stopPropagation();
+        if (this.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }))) {
+          this.#onClick();
+        }
+        break;
       case 'Enter':
         if (this.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }))) {
           this.#onClick();


### PR DESCRIPTION
## What I did

1. Prevented default behavior on spacebar keydown

## Testing Instructions

1. Go to [Button docs on DP](https://deploy-preview-2716--patternfly-elements.netlify.app/components/button/)
2. Press <kbd>Tab</kbd> to navigate to any button.
3. Press spacebar.
4. Browser window scrolls.
