### PR TITLE
fix(core): add missing `ariaDescription` to InternalsController

### DIFF
--- a/.changeset/rare-news-drum.md
+++ b/.changeset/rare-news-drum.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+`InternalsController`: added missing `ariaDescription` defined by ARIAMixin

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -88,6 +88,7 @@ export class InternalsController implements ReactiveController, ARIAMixin {
   @aria ariaColIndexText: string | null = null;
   @aria ariaColSpan: string | null = null;
   @aria ariaCurrent: string | null = null;
+  @aria ariaDescription: string | null = null;
   @aria ariaDisabled: string | null = null;
   @aria ariaExpanded: string | null = null;
   @aria ariaHasPopup: string | null = null;


### PR DESCRIPTION
## What I did

1. Added `ariaDescription` to `InternalsController`

Closes #2726 

## Testing Instructions

1.

## Notes to Reviewers

1.
