### PR TITLE
fix(clipboard-copy): copy button height

### DIFF
--- a/.changeset/upset-birds-mix.md
+++ b/.changeset/upset-birds-mix.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/elements": patch
+---
+`<pf-clipboard-copy>`: corrected size of copy button

--- a/elements/pf-clipboard-copy/pf-clipboard-copy.css
+++ b/elements/pf-clipboard-copy/pf-clipboard-copy.css
@@ -128,6 +128,10 @@ textarea {
   height: 100%;
 }
 
+#copy-button {
+  height: calc(100% - var(--pf-c-button--PaddingTop) - var(--pf-c-button--PaddingBottom));
+}
+
 .container:is(.compact, .inline) #input-group {
   display: contents;
 }


### PR DESCRIPTION
Fixes #2741

## What I did

1. apply negative padding to the button height

## Testing Instructions

1. [check the dp](https://deploy-preview-2761--patternfly-elements.netlify.app/components/clipboard-copy/demo/)