### PR TITLE
fix(tools): react wrapper syntax errors

### DIFF
--- a/.changeset/rich-sloths-reply.md
+++ b/.changeset/rich-sloths-reply.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-tools": patch
+---
+
+**React**: corrected syntax error in some generated modules

--- a/tools/pfe-tools/react/generate-wrappers.ts
+++ b/tools/pfe-tools/react/generate-wrappers.ts
@@ -80,7 +80,7 @@ function genJavascriptModule(module: CEM.Module, pkgName: string, data: ReactWra
   return javascript`// ${module.path}
 import { createComponent } from '@lit/react';
 import react from 'react';${data.map(x => javascript`
-import { ${x.Class} as elementClass } from '${pkgName}/${module.path}';`)}${data.map(x => javascript`
+import { ${x.Class} as elementClass } from '${pkgName}/${module.path}';`).join('')}${data.map(x => javascript`
 export const ${x.reactComponentName} = createComponent({
   tagName: '${x.tagName}',
   elementClass,
@@ -93,8 +93,8 @@ export const ${x.reactComponentName} = createComponent({
 function genTypescriptModule(module: CEM.Module, pkgName: string, data: ReactWrapperData[]) {
   return typescript`// ${module.path}
 import type { ReactWebComponent } from '@lit/react';${data.map(x => typescript`
-import type { ${x.Class} } from '${pkgName}/${module.path}';`)}${data.map(x => typescript`
-export const ${x.reactComponentName}: ReactWebComponent<${x.Class}, ${x.eventsInterface}>;`)}
+import type { ${x.Class} } from '${pkgName}/${module.path}';`).join('')}${data.map(x => typescript`
+export const ${x.reactComponentName}: ReactWebComponent<${x.Class}, ${x.eventsInterface}>;`).join('\n')}
   `;
 }
 


### PR DESCRIPTION
## What I did

1. remove extraneous `,` from generated react wrapper modules when there is more than one element exported.

## Testing Instructions

1. run the build on rhds and confirm that `rh-navigation-secondary-dropdown.js` does not include the pattern `/;,$/`

## Notes to Reviewers

1. See https://github.com/jspm/project/issues/336#issuecomment-2171057720
2. With many thanks to the inimitable @guybedford 