### PR TITLE
fix(create-element): inline demo subresources

### DIFF
--- a/.changeset/shaky-cats-share.md
+++ b/.changeset/shaky-cats-share.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/create-element": patch
+---
+Element generator now generates demo files with inlined script and styles

--- a/tools/create-element/generator/element.ts
+++ b/tools/create-element/generator/element.ts
@@ -29,8 +29,6 @@ const $$ = $({ stderr: 'inherit' });
 enum FileKey {
   component = 'component',
   demo = 'demo',
-  demoCss = 'demoCss',
-  demoScript = 'demoScript',
   docs = 'docs',
   readme = 'readme',
   style = 'style',
@@ -63,8 +61,6 @@ const getFilePathsRelativeToPackageDir =
   memoize((options: GenerateElementOptions): Record<FileKey, string> => ({
     component: `${options.tagName}.ts`,
     demo: `demo/${options.tagName}.html`,
-    demoCss: `demo/demo.css`,
-    demoScript: `demo/${options.tagName}.js`,
     docs: `docs/${options.tagName}.md`,
     readme: 'README.md',
     style: `${options.tagName}.${options.css === 'postcss' ? '.postcss.css' : options.css}`,

--- a/tools/create-element/templates/element/demo/demo.css
+++ b/tools/create-element/templates/element/demo/demo.css
@@ -1,3 +1,0 @@
-<%= tagName %> {
-  /* insert demo styles */
-}

--- a/tools/create-element/templates/element/demo/element.html
+++ b/tools/create-element/templates/element/demo/element.html
@@ -1,4 +1,12 @@
-<link rel="stylesheet" href="demo.css">
-<script type="module" src="<%= tagName %>.js"></script>
-
 <<%= tagName %>></<%= tagName %>>
+
+<script type="module">
+  import '<%= importSpecifier %>';
+</script>
+
+<style>
+<%= tagName %> {
+  /* insert demo styles */
+}
+</style>
+

--- a/tools/create-element/templates/element/demo/element.js
+++ b/tools/create-element/templates/element/demo/element.js
@@ -1,1 +1,0 @@
-import '<%= importSpecifier %>';


### PR DESCRIPTION
## What I did

1. update the generator's demo templates, removing the `demo.css` and `${elementName}.js` subresources, and inlining them to the HTML instead.
