### PR TITLE
docs: fix v2 pficon getIconUrl override

### DIFF
--- a/docs/main.mjs
+++ b/docs/main.mjs
@@ -1,3 +1,12 @@
 import '@rhds/elements/rh-footer/rh-global-footer.js';
 import 'element-internals-polyfill';
-import '@patternfly/elements/pf-icon/pf-icon.js';
+import { PfIcon } from '@patternfly/elements/pf-icon/pf-icon.js';
+
+// if `/v2/` path load icons from static directory
+if (document.location.href.includes('/v2/')) {
+  // Workaround for bundled pf-icon: make icon imports absolute, instead of relative to the bundle
+  PfIcon.getIconUrl = (set, icon) => {
+    const url = new URL(`/v2/components/icon/icons/${set}/${icon}.js`, import.meta.url);
+    return url;
+  };
+}


### PR DESCRIPTION
## What I did

1. Fix missing override for `/v2` path pf-icons

Closes #2792

## Testing Instructions

1.

## Notes to Reviewers

1.
