### PR TITLE
fix(tools): import css from bare specifiers

### DIFF
--- a/.changeset/funny-teeth-rhyme.md
+++ b/.changeset/funny-teeth-rhyme.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/pfe-tools": patch
+---
+TypeScript CSS Import Transforms: allow importing from bare specifiers


### PR DESCRIPTION
## What I did

1. let the typescript css transforms function import from bare specifier e.g. `@rhds/tokens/css/color-context-consumer.css`;
