### PR TITLE
fix(jump-links): fix missing comma throwing off chrome css parser

### DIFF
--- a/.changeset/fresh-donuts-count.md
+++ b/.changeset/fresh-donuts-count.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": major
+---
+
+`<pf-jump-links>`: corrected incorrect styles

--- a/.changeset/fresh-donuts-count.md
+++ b/.changeset/fresh-donuts-count.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": major
 ---
 
-`<pf-jump-links>`: corrected incorrect styles
+`<pf-jump-links>`: corrected a layout bug which occurred when the `centered` attribute applied

--- a/elements/pf-jump-links/pf-jump-links.css
+++ b/elements/pf-jump-links/pf-jump-links.css
@@ -46,18 +46,29 @@ slot::before {
 }
 
 :host([vertical]) #container {
-  --pf-c-jump-links__list--PaddingTop: var(--pf-c-jump-links--m-vertical__list--PaddingTop,
-    var(--pf-global--spacer--md, 1rem));
-  --pf-c-jump-links__list--PaddingRight: var(--pf-c-jump-links--m-vertical__list--PaddingRight, 0);
-  --pf-c-jump-links__list--PaddingBottom: var(--pf-c-jump-links--m-vertical__list--PaddingBottom
-    var(--pf-global--spacer--md, 1rem));
-  --pf-c-jump-links__list--PaddingLeft: var(--pf-c-jump-links--m-vertical__list--PaddingLeft, 0);
-  --pf-c-jump-links__list--before--BorderTopWidth: var(--pf-c-jump-links--m-vertical__list--before--BorderTopWidth, 0);
-  --pf-c-jump-links__list--before--BorderLeftWidth: var(--pf-c-jump-links--m-vertical__list--before--BorderLeftWidth, 
+  --pf-c-jump-links__list--PaddingTop:
+    var(--pf-c-jump-links--m-vertical__list--PaddingTop,
+      var(--pf-global--spacer--md, 1rem)
+    );
+  --pf-c-jump-links__list--PaddingRight:
+    var(--pf-c-jump-links--m-vertical__list--PaddingRight,0);
+  --pf-c-jump-links__list--PaddingBottom:
+    var(--pf-c-jump-links--m-vertical__list--PaddingBottom,
+      var(--pf-global--spacer--md, 1rem)
+    );
+  --pf-c-jump-links__list--PaddingLeft:
+    var(--pf-c-jump-links--m-vertical__list--PaddingLeft, 0);
+  --pf-c-jump-links__list--before--BorderTopWidth:
+    var(--pf-c-jump-links--m-vertical__list--before--BorderTopWidth, 0);
+  --pf-c-jump-links__list--before--BorderLeftWidth:
+    var(--pf-c-jump-links--m-vertical__list--before--BorderLeftWidth,
     var(--pf-global--BorderWidth--sm, 1px));
-  --pf-c-jump-links__item--m-current__link--before--BorderTopWidth: var(--pf-c-jump-links--m-vertical__item--m-current__link--before--BorderTopWidth, 0);
-  --pf-c-jump-links__item--m-current__link--before--BorderLeftWidth: var(--pf-c-jump-links--m-vertical__item--m-current__link--before--BorderLeftWidth,
-    var(--pf-global--BorderWidth--lg, 3px));
+  --pf-c-jump-links__item--m-current__link--before--BorderTopWidth:
+    var(--pf-c-jump-links--m-vertical__item--m-current__link--before--BorderTopWidth, 0);
+  --pf-c-jump-links__item--m-current__link--before--BorderLeftWidth:
+    var(--pf-c-jump-links--m-vertical__item--m-current__link--before--BorderLeftWidth,
+      var(--pf-global--BorderWidth--lg, 3px)
+    );
   --pf-c-jump-links__list--FlexDirection: var(--pf-c-jump-links--m-vertical__list--FlexDirection, column);
 }
 


### PR DESCRIPTION

> Centered and Vertical were being incorrectly rendered due to a parsing issue cause by the missing comma in the CSS vars.  

## What I did

1. Reformatted CSS block, added [previously missing comma](https://github.com/patternfly/patternfly-elements/blob/366d21d835de41f0be0fdf9bbeb5cf881ba9cbe9/elements/pf-jump-links/pf-jump-links.css#L52) which was throwing off Chrome 129 CSS parser.


Thanks @rmscampos for the report

## Testing Instructions

1. View the Deploy Preview

## Notes to Reviewers

1.  
