### PR TITLE
fix(core): overflow controller resize loop

### DIFF
--- a/.changeset/fluffy-bananas-remember.md
+++ b/.changeset/fluffy-bananas-remember.md
@@ -1,5 +1,5 @@
 ---
-"@patternfly/pfe-core": major
+"@patternfly/pfe-core": patch
 ---
 
 `OverflowController`: corrected sideeffects of resize event to occur after browser paint

--- a/.changeset/fluffy-bananas-remember.md
+++ b/.changeset/fluffy-bananas-remember.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": major
+---
+
+`OverflowController`: corrected sideeffects of resize event to occur after browser paint

--- a/.changeset/fluffy-bananas-remember.md
+++ b/.changeset/fluffy-bananas-remember.md
@@ -2,4 +2,4 @@
 "@patternfly/pfe-core": patch
 ---
 
-`OverflowController`: corrected sideeffects of resize event to occur after browser paint
+`OverflowController`: prevent browser from locking up in some scenarios

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -44,11 +44,8 @@ export class OverflowController implements ReactiveController {
     }
   });
 
-  #ro = new ResizeObserver((entries: ResizeObserverEntry[]) => {
-    window.requestAnimationFrame((): void => {
-      if (!Array.isArray(entries) || !entries.length) {
-        return;
-      }
+  #ro = new ResizeObserver(() => {
+    requestAnimationFrame(() => {
       this.#setOverflowState();
     });
   });

--- a/core/pfe-core/controllers/overflow-controller.ts
+++ b/core/pfe-core/controllers/overflow-controller.ts
@@ -44,8 +44,13 @@ export class OverflowController implements ReactiveController {
     }
   });
 
-  #ro = new ResizeObserver(() => {
-    this.#setOverflowState();
+  #ro = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+    window.requestAnimationFrame((): void => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return;
+      }
+      this.#setOverflowState();
+    });
   });
 
   showScrollButtons = false;

--- a/elements/pf-tabs/test/pf-tabs.spec.ts
+++ b/elements/pf-tabs/test/pf-tabs.spec.ts
@@ -199,10 +199,9 @@ describe('<pf-tabs>', function() {
       });
 
       beforeEach(nextFrame);
-      beforeEach(updateComplete);
+      beforeEach(nextFrame);
       beforeEach(nextFrame);
       beforeEach(updateComplete);
-
 
       it('should have visible scroll buttons if overflowed', function() {
         // Note: overflow buttons are not included in the accessibility tree otherwise we'd test


### PR DESCRIPTION
Downstream issue:

>  ❌ <rh-tabs> > on small screen > reversed right to left language overflow actions > previousTab should be disabled
      Error: ResizeObserver loop completed with undelivered notifications. (http://localhost:8003/?wtr-session-id=E_xerQsq1EQq2yny1h-Ga:0)

> If you want to prevent these errors, the solution depends on what your intended effect is. If you actually intend to have an infinite loop, you just need to defer the resizing code in your ResizeObserver callback to after the browser repaints. You can put it into a [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame) callback.

[Documentation Reference](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors)

## What I did

1. Await browser repaint before triggering overflow side effects

## Testing Instructions

1.

## Notes to Reviewers

1.
