### PR TITLE
fix(jump-links): landmark label

### DIFF
--- a/.changeset/grumpy-lemons-like.md
+++ b/.changeset/grumpy-lemons-like.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/elements": patch
+---
+`<pf-jump-links>`: improve screen reader accessibility by labeling the navigation landmark element

--- a/elements/pf-jump-links/pf-jump-links.ts
+++ b/elements/pf-jump-links/pf-jump-links.ts
@@ -121,7 +121,7 @@ export class PfJumpLinks extends LitElement {
 
   render(): TemplateResult<1> {
     return html`
-      <nav id="container">${this.expandable ? html`
+      <nav id="container" aria-labelledby="label">${this.expandable ? html`
         <details ?open="${this.expanded}" @toggle="${this.#onToggle}">
           <summary>
             <pf-icon icon="chevron-right"></pf-icon>


### PR DESCRIPTION
Closes #2860

## What I did

1. add `aria-labelledby="label"` to the nav landmark element

## Testing Instructions

1. confirm that screen readers read the page correctly

## Notes to Reviewers

1. Note that the listbox is already labelled by the same element.
