### PR TITLE
fix(tools): fix type errors in create-element template

### DIFF
--- a/.changeset/dull-stingrays-film.md
+++ b/.changeset/dull-stingrays-film.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/create-element": patch
+---
+
+Fixed type errors in create-element template

--- a/tools/create-element/package.json
+++ b/tools/create-element/package.json
@@ -11,6 +11,9 @@
   "bin": {
     "create-app": "bin/main.js"
   },
+  "contributors": [
+    "Martin Pitt <mpitt@redhat.com>"
+  ],
   "keywords": [
     "custom elements",
     "custom-elements",

--- a/tools/create-element/templates/element/element.ts
+++ b/tools/create-element/templates/element/element.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 
 import styles from '<%= cssRelativePath %>';
@@ -9,9 +9,9 @@ import styles from '<%= cssRelativePath %>';
  */
 @customElement('<%= tagName %>')
 export class <%= className %> extends LitElement {
-  static readonly styles = [styles];
+  static readonly styles: CSSStyleSheet[] = [styles];
 
-  render() {
+  render(): TemplateResult<1> {
     return html`
       <slot></slot>
     `;


### PR DESCRIPTION
Commit c9bd577f3 enabled `isolatedDeclarations`, which introduced these errors in `npm new` generated components:

> TS9008: Method must have an explicit return type annotation with --isolatedDeclarations.
> render() {
>
> TS9017: Only const arrays can be inferred with --isolatedDeclarations.
> static readonly styles = [styles];

Fixes #2872

-----

## Testing Instructions

See #2872. Tested with

```
npm run new  # name it "pf-cool" or anything else
npm start
```