### PR TITLE
docs: deploy v3 as netlify redirect

### DIFF
--- a/docs/_data/versions.json
+++ b/docs/_data/versions.json
@@ -1,9 +1,15 @@
 [
   {
+    "version": "v4.0.0",
+    "slug": "v4",
+    "label": "v4",
+    "current": true
+  },
+  {
     "version": "v3.0.0",
     "slug": "v3",
     "label": "v3",
-    "current": true
+    "current": false
   },
   {
     "version": "v2.0.0",

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,9 @@
   to = 'https://release-v2--patternfly-elements.netlify.app/:splat'
   status = 200
   force = true
+
+[[redirects]]
+  from = '/v3/*'
+  to = 'https://release-v3--patternfly-elements.netlify.app/:splat'
+  status = 200
+  force = true


### PR DESCRIPTION
## What I did

1.  Deployed `release/v3` branch, deployed to netlify
2. Configured netlify.toml to point at new netlify endpoint for v3 release
3. Added v4 as current release version to version.json

## Testing Instructions

1.  View [Deploy Preview](https://deploy-preview-2875--patternfly-elements.netlify.app/) ensure v3 in dropdown redirects

## Notes to Reviewers

1.
