### PR TITLE
fix(core): slotController isEmpty respects text nodes

### DIFF
--- a/.changeset/olive-rivers-stick.md
+++ b/.changeset/olive-rivers-stick.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/pfe-core": patch
+---
+`SlotController`: `hasContent`/`isEmpty` now respects text nodes

--- a/core/pfe-core/controllers/slot-controller.ts
+++ b/core/pfe-core/controllers/slot-controller.ts
@@ -193,7 +193,8 @@ export class SlotController implements ReactiveController {
       ?? this.#getChildrenForSlot(name);
     const selector = slotName ? `slot[name="${slotName}"]` : 'slot:not([name])';
     const slot = this.host.shadowRoot?.querySelector?.<HTMLSlotElement>(selector) ?? null;
-    const hasContent = !!elements.length;
+    const nodes = slot?.assignedNodes?.();
+    const hasContent = !!elements.length || !!nodes?.filter(x => x.textContent?.trim()).length;
     this.#nodes.set(name, { elements, name: slotName ?? '', hasContent, slot });
     this.#logger.debug(slotName, hasContent);
   };


### PR DESCRIPTION
## What I did

1. make slotcontroller's hasContent/isEmpty consider text nodes

## Testing Instructions

1. patch contents into RHDS, and check that cards with text nodes in default slot but no wrapping element still display their contents

## Notes to Reviewers

1. see https://stackblitz.com/edit/stackblitz-starters-u2qbnw?file=index.html 
