### PR TITLE
2566: Create pf-radio component

### DIFF
--- a/elements/package.json
+++ b/elements/package.json
@@ -36,6 +36,7 @@
     "./pf-jump-links/pf-jump-links-list.js": "./pf-jump-links/pf-jump-links-list.js",
     "./pf-jump-links/pf-jump-links.js": "./pf-jump-links/pf-jump-links.js",
     "./pf-label/pf-label.js": "./pf-label/pf-label.js",
+    "./pf-radio/pf-radio.js": "./pf-radio/pf-radio.js",
     "./pf-select/pf-select.js": "./pf-select/pf-select.js",
     "./pf-select/pf-listbox.js": "./pf-select/pf-listbox.js",
     "./pf-select/pf-option-group.js": "./pf-select/pf-option-group.js",

--- a/elements/pf-radio/README.md
+++ b/elements/pf-radio/README.md
@@ -1,0 +1,11 @@
+# Radio
+Add a description of the component here.
+
+## Usage
+Describe how best to use this web component along with best practices.
+
+```html
+<pf-radio>
+
+</pf-radio>
+```

--- a/elements/pf-radio/demo/pf-radio.html
+++ b/elements/pf-radio/demo/pf-radio.html
@@ -1,12 +1,36 @@
-<pf-radio></pf-radio>
+<section class='container'>
+  <p> Select a title </p>
+  <div class='radio-group'>
+    <pf-radio id="title-mr" label="Mr" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-miss" label="Miss" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-mrs" label="Mrs" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-ms" label="Ms" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-dr" label="Dr" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-other" label="Other" name="title" checked=${false}></pf-radio>
+  </div>
+  <pf-button> Submit</pf-button>
+</section>
 
 <script type="module">
   import '@patternfly/elements/pf-radio/pf-radio.js';
+  import '@patternfly/elements/pf-button/pf-button.js';
 </script>
 
 <style>
-pf-radio {
-  /* insert demo styles */
+.container{
+  padding: 3rem;
+}
+.container p {
+  font-size: 1.5rem;
+  margin-block-end: 0.5rem;
+}
+.radio-group{
+  display: flex;
+  justify-content: flex-start;
+  padding-bottom: 1rem;
+}
+.radio-group pf-radio{
+  padding-right: 1rem;
 }
 </style>
 

--- a/elements/pf-radio/demo/pf-radio.html
+++ b/elements/pf-radio/demo/pf-radio.html
@@ -1,0 +1,12 @@
+<pf-radio></pf-radio>
+
+<script type="module">
+  import '@patternfly/elements/pf-radio/pf-radio.js';
+</script>
+
+<style>
+pf-radio {
+  /* insert demo styles */
+}
+</style>
+

--- a/elements/pf-radio/demo/pf-radio.html
+++ b/elements/pf-radio/demo/pf-radio.html
@@ -1,12 +1,12 @@
 <section class='container'>
   <p> Select a title </p>
   <div class='radio-group'>
-    <pf-radio id="title-mr" label="Mr" name="title" checked=${false}></pf-radio>
-    <pf-radio id="title-miss" label="Miss" name="title" checked=${false}></pf-radio>
-    <pf-radio id="title-mrs" label="Mrs" name="title" checked=${false}></pf-radio>
-    <pf-radio id="title-ms" label="Ms" name="title" checked=${false}></pf-radio>
-    <pf-radio id="title-dr" label="Dr" name="title" checked=${false}></pf-radio>
-    <pf-radio id="title-other" label="Other" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-mr" value='mr' label="Mr" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-miss" value='miss' label="Miss" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-mrs" value='mrs' label="Mrs" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-ms" value='ms' label="Ms" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-dr" value='dr' label="Dr" name="title" checked=${false}></pf-radio>
+    <pf-radio id="title-other" value='other' label="Other" name="title" checked=${false}></pf-radio>
   </div>
   <pf-button> Submit</pf-button>
 </section>

--- a/elements/pf-radio/docs/pf-radio.md
+++ b/elements/pf-radio/docs/pf-radio.md
@@ -1,0 +1,17 @@
+{% renderOverview %}
+  <pf-radio></pf-radio>
+{% endrenderOverview %}
+
+{% band header="Usage" %}{% endband %}
+
+{% renderSlots %}{% endrenderSlots %}
+
+{% renderAttributes %}{% endrenderAttributes %}
+
+{% renderMethods %}{% endrenderMethods %}
+
+{% renderEvents %}{% endrenderEvents %}
+
+{% renderCssCustomProperties %}{% endrenderCssCustomProperties %}
+
+{% renderCssParts %}{% endrenderCssParts %}

--- a/elements/pf-radio/pf-radio.css
+++ b/elements/pf-radio/pf-radio.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -30,6 +30,7 @@ export class PfRadio extends LitElement {
   @property({ reflect: true }) name = 'radio-test';
   @property({ reflect: true }) label?: string;
   @property({ reflect: true }) value = '';
+  @property({ reflect: true }) id = '';
 
   constructor() {
     super();
@@ -37,9 +38,11 @@ export class PfRadio extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    this.addEventListener('keydown', this.#onKeydown);
+    document.addEventListener('keydown', this.#onKeyPress);
   }
 
-  #onRadioButtonClick(event: Event) {
+  #onRadioButtonClick() {
     if (!this.checked) {
       const root: Node = this.getRootNode();
       let radioGroup: NodeListOf<PfRadio>;
@@ -54,12 +57,121 @@ export class PfRadio extends LitElement {
     }
   }
 
+  #onKeyPress = (event: KeyboardEvent) => {
+    const root: Node = this.getRootNode();
+    let radioGroup: NodeListOf<PfRadio>;
+    if (root instanceof Document || root instanceof ShadowRoot) {
+      radioGroup = root.querySelectorAll('pf-radio');
+      if (!event.shiftKey && event.key === 'Tab') {
+        radioGroup.forEach((radio, index) => {
+          const input = radio.shadowRoot?.querySelector('input') as HTMLInputElement;
+          // input.tabIndex = -1;
+          // if(radio.id === this.shadowRoot?.activeElement?.id){
+          //   //input.tabIndex = -1;
+          //   //event.preventDefault();
+          //   //root.focusOut()
+          // }else{
+          //   //input.tabIndex = 0;
+          // }
+          if (radio.checked === true) {
+            input.tabIndex = 0;
+          } else if (index === 0) {
+            input.tabIndex = 0;
+          } else {
+            input.tabIndex = -1;
+          }
+        });
+      }
+
+      if (event.shiftKey && event.key === 'Tab') {
+        radioGroup.forEach((radio, index) => {
+          const input = radio.shadowRoot?.querySelector('input') as HTMLInputElement;
+          // input.tabIndex = 0;
+          // input.tabIndex = 0;
+          // if(radio.id === this.shadowRoot?.activeElement?.id){
+          //   input.tabIndex = 0;
+          //   //event.preventDefault();
+          //   //root.focusOut()
+          // }else{
+          //   //input.tabIndex = 0;
+          // }
+          if (radio.checked === true) {
+            input.tabIndex = 0;
+            input.focus();
+          } else if (index === (radioGroup.length - 1)) {
+            input.tabIndex = 0;
+          } else {
+            input.tabIndex = -1;
+          }
+        });
+      }
+    }
+  };
+
+  #onKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'ArrowDown'
+      || event.key === 'ArrowRight'
+      || event.key === 'ArrowUp'
+      || event.key === 'ArrowLeft') {
+      const root: Node = this.getRootNode();
+      let radioGroup: NodeListOf<PfRadio>;
+      if (root instanceof Document || root instanceof ShadowRoot) {
+        radioGroup = root.querySelectorAll('pf-radio');
+        radioGroup.forEach((radio, index) => {
+          const element: HTMLElement = radio as HTMLElement;
+          element?.removeAttribute('checked');
+          this.checked = false;
+          if (radioGroup[index] === event.target ) {
+            if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+              if ((radioGroup.length - 1) === index) {
+                radioGroup[0].focus();
+                radioGroup[0].checked = true;
+              } else {
+                radioGroup[index + 1].focus();
+                radioGroup[index + 1].checked = true;
+              }
+            } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+              if (index === 0) {
+                radioGroup[radioGroup.length - 1].focus();
+                radioGroup[radioGroup.length - 1].checked = true;
+              } else {
+                radioGroup[index - 1].focus();
+                radioGroup[index - 1].checked = true;
+              }
+            }
+          }
+        });
+      }
+    }
+  };
+
+
+  // #onKeydown1 = (event: KeyboardEvent) => {
+  //   switch (event.key) {
+  //     case "ArrowDown":
+  //       //this.#onArrowDown(event);
+  //       // Do something for "down arrow" key press.
+  //       break;
+  //     case "ArrowUp":
+  //       // Do something for "up arrow" key press.
+  //       break;
+  //     case "ArrowLeft":
+  //       // Do something for "left arrow" key press.
+  //       break;
+  //     case "ArrowRight":
+  //       // Do something for "right arrow" key press.
+  //       break;
+  //       default:
+  //         return; // Quit when this doesn't handle the key event.
+  //   }
+  // };
+
   render(): TemplateResult<1> {
     return html`
       <label for='input'>${this.label}</label>
       <input
-        @click=${(e: Event) => this.#onRadioButtonClick(e)}
-        id='input'
+        @click=${this.#onRadioButtonClick}
+        id=${this.id}
         .name=${this.name}
         type='radio'
         .checked='${this.checked}'

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -169,7 +169,7 @@ export class PfRadio extends LitElement {
 
   render(): TemplateResult<1> {
     return html`
-      <label for='input'>${this.label}</label>
+      <label for=${this.id}>${this.label}</label>
       <input
         @click=${this.#onRadioButtonClick}
         id=${this.id}

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -11,10 +11,25 @@ import { property } from 'lit/decorators/property.js';
 @customElement('pf-radio')
 export class PfRadio extends LitElement {
   static readonly styles: CSSStyleSheet[] = [styles];
-  @property() checked = false;
+  static formAssociated = true;
+  static shadowRootOptions: ShadowRootInit = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
+  @property({
+    type: Boolean,
+    // attribute: 'inline-filter',
+    converter: {
+      fromAttribute: value => value === 'true',
+    },
+    reflect: true,
+  })
+  checked = false;
+
   @property({ reflect: true }) name = 'radio-test';
   @property({ reflect: true }) label?: string;
-  // #input:any
+  @property({ reflect: true }) value = '';
 
   constructor() {
     super();
@@ -22,19 +37,33 @@ export class PfRadio extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+  }
 
-    const root = this.getRootNode();
-    if (root instanceof Document || root instanceof ShadowRoot) {
-      const group = root.querySelectorAll(`pf-radio`);
-      // console.log("------------- the group is", group);
+  #onRadioButtonClick(event: Event) {
+    if (!this.checked) {
+      const root: Node = this.getRootNode();
+      let radioGroup: NodeListOf<PfRadio>;
+      if (root instanceof Document || root instanceof ShadowRoot) {
+        radioGroup = root.querySelectorAll('pf-radio');
+        radioGroup.forEach(radio => {
+          const element: HTMLElement = radio as HTMLElement;
+          element?.removeAttribute('checked');
+        });
+        this.checked = true;
+      }
     }
   }
 
-
   render(): TemplateResult<1> {
     return html`
-      <label for=input>${this.label}</label>
-      <input id=input class="pf-radio" .name=${this.name} type="radio" .checked="${this.checked}">
+      <label for='input'>${this.label}</label>
+      <input
+        @click=${(e: Event) => this.#onRadioButtonClick(e)}
+        id='input'
+        .name=${this.name}
+        type='radio'
+        .checked='${this.checked}'
+      />
     `;
   }
 }

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -24,7 +24,8 @@ export class PfRadio extends LitElement {
       fromAttribute: value => value === 'true',
     },
     reflect: true,
-  }) checked = false;
+  })
+  checked = false;
 
   @property({
     type: Boolean,
@@ -33,14 +34,14 @@ export class PfRadio extends LitElement {
       fromAttribute: value => value === 'true',
     },
     reflect: true,
-  }) disabled = false;
+  })
+  disabled = false;
 
-  @property({ attribute: 'name', reflect: true }) name = 'radio-test';
+  @property({ attribute: 'name', reflect: true }) name = '';
   @property({ attribute: 'label', reflect: true }) label?: string;
   @property({ attribute: 'value', reflect: true }) value = '';
   @property({ attribute: 'id', reflect: true }) id = '';
   @property({ attribute: 'tabindex', reflect: true }) tabIndex = -1;
-
 
   constructor() {
     super();
@@ -58,7 +59,7 @@ export class PfRadio extends LitElement {
       let radioGroup: NodeListOf<PfRadio>;
       if (root instanceof Document || root instanceof ShadowRoot) {
         radioGroup = root.querySelectorAll('pf-radio');
-        radioGroup.forEach(radio => {
+        radioGroup.forEach((radio: PfRadio) => {
           const element: HTMLElement = radio as HTMLElement;
           element?.removeAttribute('checked');
           element.tabIndex = -1;
@@ -69,103 +70,60 @@ export class PfRadio extends LitElement {
     }
   }
 
+  // Function to handle tab key navigation
   #onKeyPress = (event: KeyboardEvent) => {
     const root: Node = this.getRootNode();
-    let radioGroup: NodeListOf<PfRadio>;
-    let isRadioChecked = false;
     if (root instanceof Document || root instanceof ShadowRoot) {
-      radioGroup = root.querySelectorAll('pf-radio');
+      const radioGroup: NodeListOf<PfRadio> = root.querySelectorAll('pf-radio');
+      const isRadioChecked: boolean = Array.from(radioGroup).some(
+        (radio: PfRadio) => radio.checked
+      );
       if (event.key === 'Tab') {
-        radioGroup.forEach((radio, index) => {
-          radio.tabIndex = -1;
-          if (radio.checked === true) {
-            radio.tabIndex = 0;
-            isRadioChecked = true;
-          }
+        radioGroup.forEach((radio: PfRadio) => {
+          radio.tabIndex = radio.checked ? 0 : -1;
         });
         if (!isRadioChecked) {
-          if (event.key === 'Tab') {
-            radioGroup.forEach((radio, index) => {
-              radio.tabIndex = -1;
-              if ( event.shiftKey ) {
-                if (index === (radioGroup.length - 1)) {
-                  radio.tabIndex = 0;
-                } else {
-                  radio.tabIndex = -1;
-                }
+          radioGroup.forEach((radio: PfRadio, index: number) => {
+            radio.tabIndex = -1;
+            if (event.shiftKey) {
+              if (index === radioGroup.length - 1) {
+                radio.tabIndex = 0;
               }
-              if (!event.shiftKey) {
-                if (index === 0) {
-                  radio.tabIndex = 0;
-                } else {
-                  radio.tabIndex = -1;
-                }
-              }
-            });
-          }
+            } else if (index === 0) {
+              radio.tabIndex = 0;
+            }
+          });
         }
       }
     }
   };
 
+  // Function to handle keyboard navigation
   #onKeydown = (event: KeyboardEvent) => {
-    if (event.key === 'ArrowDown'
-      || event.key === 'ArrowRight'
-      || event.key === 'ArrowUp'
-      || event.key === 'ArrowLeft') {
+    const arrowKeys: string[] = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft'];
+    if (arrowKeys.includes(event.key)) {
       const root: Node = this.getRootNode();
-      let radioGroup: NodeListOf<PfRadio>;
       if (root instanceof Document || root instanceof ShadowRoot) {
-        radioGroup = root.querySelectorAll('pf-radio');
-        radioGroup.forEach((radio, index) => {
-          const element: HTMLElement = radio as HTMLElement;
-          element?.removeAttribute('checked');
+        const radioGroup: NodeListOf<PfRadio> = root.querySelectorAll('pf-radio');
+        radioGroup.forEach((radio: PfRadio, index: number) => {
           this.checked = false;
-          radio.tabIndex = 0;
-          if (radioGroup[index] === event.target ) {
-            if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-              if ((radioGroup.length - 1) === index) {
-                radioGroup[0].focus();
-                radioGroup[0].checked = true;
-              } else {
-                radioGroup[index + 1].focus();
-                radioGroup[index + 1].checked = true;
-              }
-            } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-              if (index === 0) {
-                radioGroup[radioGroup.length - 1].focus();
-                radioGroup[radioGroup.length - 1].checked = true;
-              } else {
-                radioGroup[index - 1].focus();
-                radioGroup[index - 1].checked = true;
-              }
+          this.tabIndex = 0;
+
+          if (radio === event.target) {
+            const isArrowDownOrRight: boolean = ['ArrowDown', 'ArrowRight'].includes(event.key);
+            const isArrowUpOrLeft: boolean = ['ArrowUp', 'ArrowLeft'].includes(event.key);
+            const direction: 1 | 0 | -1 = isArrowDownOrRight ? 1 : isArrowUpOrLeft ? -1 : 0;
+            if (direction === 0) {
+              return;
             }
+            const nextIndex: number = (index + direction + radioGroup.length) % radioGroup.length;
+            radioGroup[nextIndex].focus();
+            radioGroup[nextIndex].checked = true;
           }
         });
       }
     }
   };
-
-
-  // #onKeydown1 = (event: KeyboardEvent) => {
-  //   switch (event.key) {
-  //     case "ArrowDown":
-  //       //this.#onArrowDown(event);
-  //       // Do something for "down arrow" key press.
-  //       break;
-  //     case "ArrowUp":
-  //       // Do something for "up arrow" key press.
-  //       break;
-  //     case "ArrowLeft":
-  //       // Do something for "left arrow" key press.
-  //       break;
-  //     case "ArrowRight":
-  //       // Do something for "right arrow" key press.
-  //       break;
-  //       default:
-  //         return; // Quit when this doesn't handle the key event.
-  //   }
-  // };
 
   render(): TemplateResult<1> {
     return html`

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -1,0 +1,46 @@
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators/custom-element.js';
+
+import styles from './pf-radio.css';
+import { property } from 'lit/decorators/property.js';
+
+/**
+ * Radio
+ * @slot - Place element content here
+ */
+@customElement('pf-radio')
+export class PfRadio extends LitElement {
+  static readonly styles: CSSStyleSheet[] = [styles];
+  @property() checked = false;
+  @property({ reflect: true }) name = 'radio-test';
+  @property({ reflect: true }) label?: string;
+  // #input:any
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    const root = this.getRootNode();
+    if (root instanceof Document || root instanceof ShadowRoot) {
+      const group = root.querySelectorAll(`pf-radio`);
+      // console.log("------------- the group is", group);
+    }
+  }
+
+
+  render(): TemplateResult<1> {
+    return html`
+      <label for=input>${this.label}</label>
+      <input id=input class="pf-radio" .name=${this.name} type="radio" .checked="${this.checked}">
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'pf-radio': PfRadio;
+  }
+}

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -19,18 +19,28 @@ export class PfRadio extends LitElement {
 
   @property({
     type: Boolean,
-    // attribute: 'inline-filter',
+    attribute: 'checked',
     converter: {
       fromAttribute: value => value === 'true',
     },
     reflect: true,
-  })
-  checked = false;
+  }) checked = false;
 
-  @property({ reflect: true }) name = 'radio-test';
-  @property({ reflect: true }) label?: string;
-  @property({ reflect: true }) value = '';
-  @property({ reflect: true }) id = '';
+  @property({
+    type: Boolean,
+    attribute: 'disabled',
+    converter: {
+      fromAttribute: value => value === 'true',
+    },
+    reflect: true,
+  }) disabled = false;
+
+  @property({ attribute: 'name', reflect: true }) name = 'radio-test';
+  @property({ attribute: 'label', reflect: true }) label?: string;
+  @property({ attribute: 'value', reflect: true }) value = '';
+  @property({ attribute: 'id', reflect: true }) id = '';
+  @property({ attribute: 'tabindex', reflect: true }) tabIndex = -1;
+
 
   constructor() {
     super();
@@ -51,8 +61,10 @@ export class PfRadio extends LitElement {
         radioGroup.forEach(radio => {
           const element: HTMLElement = radio as HTMLElement;
           element?.removeAttribute('checked');
+          element.tabIndex = -1;
         });
         this.checked = true;
+        this.tabIndex = 0;
       }
     }
   }
@@ -60,50 +72,38 @@ export class PfRadio extends LitElement {
   #onKeyPress = (event: KeyboardEvent) => {
     const root: Node = this.getRootNode();
     let radioGroup: NodeListOf<PfRadio>;
+    let isRadioChecked = false;
     if (root instanceof Document || root instanceof ShadowRoot) {
       radioGroup = root.querySelectorAll('pf-radio');
-      if (!event.shiftKey && event.key === 'Tab') {
+      if (event.key === 'Tab') {
         radioGroup.forEach((radio, index) => {
-          const input = radio.shadowRoot?.querySelector('input') as HTMLInputElement;
-          // input.tabIndex = -1;
-          // if(radio.id === this.shadowRoot?.activeElement?.id){
-          //   //input.tabIndex = -1;
-          //   //event.preventDefault();
-          //   //root.focusOut()
-          // }else{
-          //   //input.tabIndex = 0;
-          // }
+          radio.tabIndex = -1;
           if (radio.checked === true) {
-            input.tabIndex = 0;
-          } else if (index === 0) {
-            input.tabIndex = 0;
-          } else {
-            input.tabIndex = -1;
+            radio.tabIndex = 0;
+            isRadioChecked = true;
           }
         });
-      }
-
-      if (event.shiftKey && event.key === 'Tab') {
-        radioGroup.forEach((radio, index) => {
-          const input = radio.shadowRoot?.querySelector('input') as HTMLInputElement;
-          // input.tabIndex = 0;
-          // input.tabIndex = 0;
-          // if(radio.id === this.shadowRoot?.activeElement?.id){
-          //   input.tabIndex = 0;
-          //   //event.preventDefault();
-          //   //root.focusOut()
-          // }else{
-          //   //input.tabIndex = 0;
-          // }
-          if (radio.checked === true) {
-            input.tabIndex = 0;
-            input.focus();
-          } else if (index === (radioGroup.length - 1)) {
-            input.tabIndex = 0;
-          } else {
-            input.tabIndex = -1;
+        if (!isRadioChecked) {
+          if (event.key === 'Tab') {
+            radioGroup.forEach((radio, index) => {
+              radio.tabIndex = -1;
+              if ( event.shiftKey ) {
+                if (index === (radioGroup.length - 1)) {
+                  radio.tabIndex = 0;
+                } else {
+                  radio.tabIndex = -1;
+                }
+              }
+              if (!event.shiftKey) {
+                if (index === 0) {
+                  radio.tabIndex = 0;
+                } else {
+                  radio.tabIndex = -1;
+                }
+              }
+            });
           }
-        });
+        }
       }
     }
   };
@@ -121,6 +121,7 @@ export class PfRadio extends LitElement {
           const element: HTMLElement = radio as HTMLElement;
           element?.removeAttribute('checked');
           this.checked = false;
+          radio.tabIndex = 0;
           if (radioGroup[index] === event.target ) {
             if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
               if ((radioGroup.length - 1) === index) {
@@ -174,6 +175,7 @@ export class PfRadio extends LitElement {
         id=${this.id}
         .name=${this.name}
         type='radio'
+        tabindex=${this.tabIndex}
         .checked='${this.checked}'
       />
     `;

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -3,6 +3,12 @@ import { customElement } from 'lit/decorators/custom-element.js';
 import styles from './pf-radio.css';
 import { property } from 'lit/decorators/property.js';
 
+export class PfRadioChangeEvent extends Event {
+  constructor(public event: Event, public value: string) {
+    super('change', { bubbles: true });
+  }
+}
+
 /**
  * Radio
  * @slot - Place element content here
@@ -52,7 +58,7 @@ export class PfRadio extends LitElement {
     document.addEventListener('keydown', this.#onKeyPress);
   }
 
-  #onRadioButtonClick() {
+  #onRadioButtonClick(event: Event) {
     if (!this.checked) {
       const root: Node = this.getRootNode();
       let radioGroup: NodeListOf<PfRadio>;
@@ -65,6 +71,7 @@ export class PfRadio extends LitElement {
         });
         this.checked = true;
         this.tabIndex = 0;
+        this.dispatchEvent(new PfRadioChangeEvent(event, this.value));
       }
     }
   }
@@ -118,6 +125,7 @@ export class PfRadio extends LitElement {
             const nextIndex: number = (index + direction + radioGroup.length) % radioGroup.length;
             radioGroup[nextIndex].focus();
             radioGroup[nextIndex].checked = true;
+            this.dispatchEvent(new PfRadioChangeEvent(event, radioGroup[nextIndex].value));
           }
         });
       }
@@ -131,6 +139,7 @@ export class PfRadio extends LitElement {
         id=${this.id}
         .name=${this.name}
         type='radio'
+        value=${this.value}
         tabindex=${this.tabIndex}
         .checked=${this.checked}
       />

--- a/elements/pf-radio/pf-radio.ts
+++ b/elements/pf-radio/pf-radio.ts
@@ -1,6 +1,5 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
-
 import styles from './pf-radio.css';
 import { property } from 'lit/decorators/property.js';
 
@@ -127,15 +126,15 @@ export class PfRadio extends LitElement {
 
   render(): TemplateResult<1> {
     return html`
-      <label for=${this.id}>${this.label}</label>
       <input
         @click=${this.#onRadioButtonClick}
         id=${this.id}
         .name=${this.name}
         type='radio'
         tabindex=${this.tabIndex}
-        .checked='${this.checked}'
+        .checked=${this.checked}
       />
+      <label for=${this.id}>${this.label}</label>
     `;
   }
 }

--- a/elements/pf-radio/test/pf-radio.e2e.ts
+++ b/elements/pf-radio/test/pf-radio.e2e.ts
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import { PfeDemoPage } from '@patternfly/pfe-tools/test/playwright/PfeDemoPage.js';
+import { SSRPage } from '@patternfly/pfe-tools/test/playwright/SSRPage.js';
+
+const tagName = 'pf-radio';
+
+test.describe(tagName, () => {
+  test('snapshot', async ({ page }) => {
+    const componentPage = new PfeDemoPage(page, tagName);
+    await componentPage.navigate();
+    await componentPage.snapshot();
+  });
+
+  test('ssr', async ({ browser }) => {
+    const fixture = new SSRPage({
+      tagName,
+      browser,
+      demoDir: new URL('../demo/', import.meta.url),
+      importSpecifiers: [
+        `@patternfly/elements/${tagName}/${tagName}.js`,
+      ],
+    });
+    await fixture.snapshots();
+  });
+});

--- a/elements/pf-radio/test/pf-radio.spec.ts
+++ b/elements/pf-radio/test/pf-radio.spec.ts
@@ -1,0 +1,21 @@
+import { expect, html } from '@open-wc/testing';
+import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
+import { PfRadio } from '@patternfly/elements/pf-radio/pf-radio.js';
+
+describe('<pf-radio>', function() {
+  describe('simply instantiating', function() {
+    let element: PfRadio;
+    it('imperatively instantiates', function() {
+      expect(document.createElement('pf-radio')).to.be.an.instanceof(PfRadio);
+    });
+
+    it('should upgrade', async function() {
+      element = await createFixture<PfRadio>(html`<pf-radio></pf-radio>`);
+      const klass = customElements.get('pf-radio');
+      expect(element)
+          .to.be.an.instanceOf(klass)
+          .and
+          .to.be.an.instanceOf(PfRadio);
+    });
+  });
+});


### PR DESCRIPTION
## What I did
Developed a custom `pf-radio` component utilizing the standard `<input type="radio" />` element for enhanced functionality and styling.
![Screenshot 2024-11-27 at 1 19 45 PM](https://github.com/user-attachments/assets/df0171d4-d3b9-4a33-84f3-9e07ef398ce2)

## Testing Instructions

**1. Mouse Interaction**

- [ ] **Single Click**: Clicking a radio button should select it.
- [ ]  **Subsequent Click**: Clicking an already selected radio button should not deselect it.
- [ ] **Group Selection**: When clicking a different radio button within the same group, the previously selected radio button should be deselected, and the new radio button should be selected.

**2. Keyboard Navigation**

- [ ] **Tab Key**(on page navigation): Pressing the Tab key should focus on the first radio button in the group. If a radio button is already selected, that selected button should be focused instead of the first one.
- [ ] **Shift + Tab**(on page navigation): Pressing Shift + Tab should focus on the last radio button in the group. If a radio button is already selected, that selected button should be focused instead of the last one.
- [ ] **Radio Selection**: A radio button can be selected using the **Space**, or **arrow keys**.
- [ ] **Arrow Keys**:
- **Arrow Down or Right**: Pressing the Down Arrow or Right Arrow should move the focus in a clockwise direction within the radio group.
- **Arrow Up or Left**: Pressing the Up Arrow or Left Arrow should move the focus in a counterclockwise direction within the radio group.


## Notes to Reviewers

Please note that the CSS variables, code comments, test cases, and updated documentation will be added asap.