### PR TITLE
2813: Fix table accessibility issue

### DIFF
--- a/elements/pf-table/pf-th.ts
+++ b/elements/pf-table/pf-th.ts
@@ -51,7 +51,7 @@ export class PfTh extends LitElement {
     const closestThead = this.closest('pf-thead');
     const closestTable = this.closest('pf-table');
     const isChildOfThead = !!closestThead && !!closestTable?.contains(closestThead);
-    const role = isChildOfThead ? 'colheader' : 'rowheader';
+    const role = isChildOfThead ? 'columnheader' : 'rowheader';
     this.setAttribute('role', role);
   }
 

--- a/elements/pf-table/pf-tr.ts
+++ b/elements/pf-table/pf-tr.ts
@@ -110,6 +110,8 @@ export class PfTr extends LitElement {
           <pf-button id="toggle-button"
                      aria-expanded=${String(this.expanded) as 'true' | 'false'}
                      plain
+                     role="button"
+                     aria-label="Expand Button"
                      @click=${this.#onClick}>
             <pf-icon id="toggle-icon"
                      icon="angle-right"


### PR DESCRIPTION
## What I did

- Fixed issues mentioned in the [issue]( https://github.com/patternfly/patternfly-elements/issues/2813).
- Improved accessibility  score of pf-table (Table, Expandable Rows Compound, Sortable) from **91** to **100** 

**Before**:
![Screenshot from 2024-12-06 12-11-29](https://github.com/user-attachments/assets/2f15868c-8f03-4397-8507-dfe5c51e0cca)
![Screenshot from 2024-12-06 12-11-53](https://github.com/user-attachments/assets/b9a08e98-0004-4996-b617-0c5d11a4efe7)
![Screenshot from 2024-12-06 12-12-17](https://github.com/user-attachments/assets/ebc0b35d-c6c3-467e-8757-645d85eb3be9)

**After**:
![Screenshot from 2024-12-06 12-08-09](https://github.com/user-attachments/assets/cef7ba43-2a38-488b-9822-834a9b084625)
![Screenshot from 2024-12-06 12-09-16](https://github.com/user-attachments/assets/c998a5d0-a02a-4e40-8d1f-3a8e90916801)
![Screenshot from 2024-12-06 12-09-40](https://github.com/user-attachments/assets/15f38ee9-0ed8-4850-bcf6-f08a780f0f60)

---------------------------------------------------------------------------------


- Improved accessibility score of pf-table (Expandable Rows) improved from **81** to **90**.

**Before**:
![Screenshot from 2024-12-06 12-12-55](https://github.com/user-attachments/assets/b74b1c6e-2df6-4314-ad74-56aadf95f126)

**After**:
![Screenshot from 2024-12-06 12-10-17](https://github.com/user-attachments/assets/213269ba-9470-4a42-8096-36f4a21ffcf3)

