### PR TITLE
fix(core): activate scroll spy link on connect

### DIFF
--- a/core/pfe-core/controllers/scroll-spy-controller.ts
+++ b/core/pfe-core/controllers/scroll-spy-controller.ts
@@ -23,6 +23,10 @@ export interface ScrollSpyControllerOptions extends IntersectionObserverInit {
    * @default el => el.getAttribute('href');
    */
   getHash?: (el: Element) => string | null;
+  /**
+   * Optional callback for when an intersection occurs
+   */
+  onIntersection?(): void;
 }
 
 export class ScrollSpyController implements ReactiveController {
@@ -47,6 +51,7 @@ export class ScrollSpyController implements ReactiveController {
 
   #getRootNode: () => Node;
   #getHash: (el: Element) => string | null;
+  #onIntersection?: () => void;
 
   get #linkChildren(): Element[] {
     return Array.from(this.host.querySelectorAll(this.#tagNames.join(',')))
@@ -95,6 +100,7 @@ export class ScrollSpyController implements ReactiveController {
     this.#threshold = options.threshold ?? 0.85;
     this.#getRootNode = () => options.rootNode ?? host.getRootNode();
     this.#getHash = options?.getHash ?? ((el: Element) => el.getAttribute('href'));
+    this.#onIntersection = options?.onIntersection;
   }
 
   hostConnected(): void {
@@ -172,6 +178,7 @@ export class ScrollSpyController implements ReactiveController {
       }
       this.#initializing = false;
     }
+    this.#onIntersection?.();
   }
 
   /**

--- a/core/pfe-core/controllers/scroll-spy-controller.ts
+++ b/core/pfe-core/controllers/scroll-spy-controller.ts
@@ -30,6 +30,18 @@ export interface ScrollSpyControllerOptions extends IntersectionObserverInit {
 }
 
 export class ScrollSpyController implements ReactiveController {
+  static #instances = new Set<ScrollSpyController>;
+
+  static {
+    addEventListener('scroll', () => {
+      if (Math.round(window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
+        this.#instances.forEach(ssc => {
+          ssc.#setActive(ssc.#linkChildren.at(-1));
+        });
+      }
+    }, { passive: true });
+  }
+
   #tagNames: string[];
   #activeAttribute: string;
 
@@ -104,7 +116,13 @@ export class ScrollSpyController implements ReactiveController {
   }
 
   hostConnected(): void {
+    ScrollSpyController.#instances.add(this);
     this.#initIo();
+  }
+
+  hostDisconnected(): void {
+    ScrollSpyController.#instances.delete(this);
+    this.#io?.disconnect();
   }
 
   #initializing = true;


### PR DESCRIPTION
## What I did

1. activate the url hash jump link item on page load

## Testing Instructions

1. copy to rhds node_modules
2. load up the rh-jump-links demos
3. click on a jump link (hash)
4. reload the page
5. BEHOLD: hashed item is active

