### PR TITLE
chore: update wireit dep for cache v2 api

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,6 +22,9 @@ jobs:
       - name: POP Debug Info
         run: curl https://cachefly.cachefly.net/CacheFlyDebug
 
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@setup-github-actions-caching/v2  
+
       - run: npm ci --prefer-offline
       - run: npm run docs
       - run: cat _site/components/icon/demo/custom-icon-sets/index.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+      
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@setup-github-actions-caching/v2
 
       - run: npm ci --prefer-offline
       - run: npm run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install dependencies
         run: npm ci --prefer-offline
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           node-version: '20'
           cache: npm
+
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@setup-github-actions-caching/v2
+
       - run: npm ci --prefer-offline
 
       - name: Visual Regression Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "postcss-nesting": "^13.0.0",
         "prompts": "^2.4.2",
         "typescript": "^5.5.4",
-        "wireit": "^0.14.7",
+        "wireit": "^0.14.12",
         "zero-md": "^3.1.2"
       },
       "engines": {
@@ -53,7 +53,7 @@
     },
     "core/pfe-core": {
       "name": "@patternfly/pfe-core",
-      "version": "4.0.5",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.10",
@@ -63,12 +63,12 @@
     },
     "elements": {
       "name": "@patternfly/elements",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.2",
         "@patternfly/icons": "^1.0.3",
-        "@patternfly/pfe-core": "^4.0.1",
+        "@patternfly/pfe-core": "^5.0.0",
         "lit": "^3.2.1",
         "tslib": "^2.6.3"
       }
@@ -16540,9 +16540,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.9.tgz",
-      "integrity": "sha512-hFc96BgyslfO1WGSzQqOVYd5N3TB+4u9w70L9GHR/T7SYjvFmeznkYMsRIjMLhPcVabCEYPW1vV66wmIVDs+dQ==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.12.tgz",
+      "integrity": "sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -319,7 +319,7 @@
     "postcss-nesting": "^13.0.0",
     "prompts": "^2.4.2",
     "typescript": "^5.5.4",
-    "wireit": "^0.14.7",
+    "wireit": "^0.14.12",
     "zero-md": "^3.1.2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## What I did

1 . Updated the wireit dependency to 0.14.12

Ref: https://github.com/google/wireit/issues/1297

## Testing Instructions

1. Does the DP fail with cache issues?

## Notes to Reviewers

1.
