### PR TITLE
fix(core): fix SlotController.isEmpty()

### DIFF
--- a/.changeset/shaky-things-beg.md
+++ b/.changeset/shaky-things-beg.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+`SlotController`: correctly report the state of the default slot in `isEmpty()` calls with no arguments
+  

--- a/core/pfe-core/controllers/slot-controller-server.ts
+++ b/core/pfe-core/controllers/slot-controller-server.ts
@@ -26,7 +26,7 @@ export class SlotController implements SlotControllerPublicAPI {
         .map(x => x.trim());
   }
 
-  getSlotted<T extends Element = Element>(..._: string[]): T[] {
+  getSlotted<T extends Element = Element>(..._: (string | null)[]): T[] {
     return [];
   }
 
@@ -34,6 +34,9 @@ export class SlotController implements SlotControllerPublicAPI {
     const attr = this.host.getAttribute(SlotController.attribute);
     const anon = this.host.hasAttribute(SlotController.anonymousAttribute);
     const hints = new Set(this.fromAttribute(attr));
+    if (!names.length) {
+      names.push(null);
+    }
     return names.every(x => x === null ? anon : hints.has(x));
   }
 

--- a/core/pfe-core/controllers/test/slot-controller.spec.ts
+++ b/core/pfe-core/controllers/test/slot-controller.spec.ts
@@ -1,17 +1,28 @@
-import { expect, fixture, nextFrame } from '@open-wc/testing';
+import { expect, fixture } from '@open-wc/testing';
 
 import { customElement } from 'lit/decorators/custom-element.js';
 import { LitElement, html, type TemplateResult } from 'lit';
 
 import { SlotController } from '../slot-controller.js';
+import { SlotController as SlotControllerServer } from '../slot-controller-server.js';
 
-@customElement('test-slot-controller-with-named-and-anonymous')
-class TestSlotControllerWithNamedAndAnonymous extends LitElement {
+@customElement('test-slot-controller')
+class TestSlotController extends LitElement {
   controller = new SlotController(this, 'a', null);
   render(): TemplateResult {
     return html`
       <slot name="a"></slot>
-      <slot name="b"></slot>
+      <slot></slot>
+    `;
+  }
+}
+
+@customElement('test-slot-controller-server')
+class TestSlotControllerServer extends LitElement {
+  controller = new SlotControllerServer(this, 'a', null);
+  render(): TemplateResult {
+    return html`
+      <slot name="a"></slot>
       <slot></slot>
     `;
   }
@@ -20,10 +31,10 @@ class TestSlotControllerWithNamedAndAnonymous extends LitElement {
 describe('SlotController', function() {
   describe('with named and anonymous slots', function() {
     describe('with no content', function() {
-      let element: TestSlotControllerWithNamedAndAnonymous;
+      let element: TestSlotController;
       beforeEach(async function() {
         element = await fixture(html`
-          <test-slot-controller-with-named-and-anonymous></test-slot-controller-with-named-and-anonymous>
+          <test-slot-controller></test-slot-controller>
         `);
       });
       it('reports empty named slots', function() {
@@ -50,12 +61,12 @@ describe('SlotController', function() {
     });
 
     describe('with element content in default slot', function() {
-      let element: TestSlotControllerWithNamedAndAnonymous;
+      let element: TestSlotController;
       beforeEach(async function() {
         element = await fixture(html`
-          <test-slot-controller-with-named-and-anonymous>
+          <test-slot-controller>
             <p>element</p>
-          </test-slot-controller-with-named-and-anonymous>
+          </test-slot-controller>
         `);
       });
       it('reports empty named slots', function() {
@@ -82,12 +93,12 @@ describe('SlotController', function() {
     });
 
     describe('with element content in named slot', function() {
-      let element: TestSlotControllerWithNamedAndAnonymous;
+      let element: TestSlotController;
       beforeEach(async function() {
         element = await fixture(html`
-          <test-slot-controller-with-named-and-anonymous>
+          <test-slot-controller>
             <p slot="a">element</p>
-          </test-slot-controller-with-named-and-anonymous>
+          </test-slot-controller>
         `);
       });
       it('reports non-empty named slots', function() {
@@ -114,12 +125,12 @@ describe('SlotController', function() {
     });
 
     describe('with text content in default slot', function() {
-      let element: TestSlotControllerWithNamedAndAnonymous;
+      let element: TestSlotController;
       beforeEach(async function() {
         element = await fixture(html`
-          <test-slot-controller-with-named-and-anonymous>
+          <test-slot-controller>
             text
-          </test-slot-controller-with-named-and-anonymous>
+          </test-slot-controller>
         `);
       });
       it('reports empty named slots', function() {
@@ -137,10 +148,204 @@ describe('SlotController', function() {
       it('returns empty list for getSlotted("a")', function() {
         expect(element.controller.getSlotted('a')).to.be.empty;
       });
-      it('returns lengthy list for getSlotted(null)', function() {
+      it('returns empty list for getSlotted(null)', function() {
         expect(element.controller.getSlotted(null)).to.be.empty;
       });
-      it('returns lengthy list for getSlotted()', function() {
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+
+    describe('with white space in default slot', function() {
+      let element: TestSlotController;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server>
+
+          </test-slot-controller-server>
+        `);
+      });
+      it('reports empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.false;
+        expect(element.controller.isEmpty('a')).to.be.true;
+      });
+      it('reports empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.false;
+        expect(element.controller.isEmpty(null)).to.be.true;
+      });
+      it('reports empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.false;
+        expect(element.controller.isEmpty()).to.be.true;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+  });
+});
+
+describe('SlotController (server)', function() {
+  describe('with named and anonymous slots', function() {
+    describe('with no ssr hint attrs', function() {
+      let element: TestSlotControllerServer;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server></test-slot-controller-server>
+        `);
+      });
+      it('reports empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.false;
+        expect(element.controller.isEmpty('a')).to.be.true;
+      });
+      it('reports empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.false;
+        expect(element.controller.isEmpty(null)).to.be.true;
+      });
+      it('reports empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.false;
+        expect(element.controller.isEmpty()).to.be.true;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+
+    describe('with ssr-hint-has-slotted-default attr', function() {
+      let element: TestSlotController;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server ssr-hint-has-slotted-default>
+            <p>element</p>
+          </test-slot-controller-server>
+        `);
+      });
+      it('reports empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.false;
+        expect(element.controller.isEmpty('a')).to.be.true;
+      });
+      it('reports non-empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.true;
+        expect(element.controller.isEmpty(null)).to.be.false;
+      });
+      it('reports non-empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.true;
+        expect(element.controller.isEmpty()).to.be.false;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+
+    describe('with ssr-hint-has-slotted="a" attr', function() {
+      let element: TestSlotController;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server ssr-hint-has-slotted="a">
+            <p slot="a">element</p>
+          </test-slot-controller-server>
+        `);
+      });
+      it('reports non-empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.true;
+        expect(element.controller.isEmpty('a')).to.be.false;
+      });
+      it('reports empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.false;
+        expect(element.controller.isEmpty(null)).to.be.true;
+      });
+      it('reports empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.false;
+        expect(element.controller.isEmpty()).to.be.true;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+
+    describe('with ssr-hint-has-slotted-default attr (text node)', function() {
+      let element: TestSlotController;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server ssr-hint-has-slotted-default>
+            text
+          </test-slot-controller-server>
+        `);
+      });
+      it('reports empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.false;
+        expect(element.controller.isEmpty('a')).to.be.true;
+      });
+      it('reports non-empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.true;
+        expect(element.controller.isEmpty(null)).to.be.false;
+      });
+      it('reports non-empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.true;
+        expect(element.controller.isEmpty()).to.be.false;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
+        expect(element.controller.getSlotted()).to.be.empty;
+      });
+    });
+
+    describe('with no ssr hint attrs (white space text node)', function() {
+      let element: TestSlotController;
+      beforeEach(async function() {
+        element = await fixture(html`
+          <test-slot-controller-server>
+
+          </test-slot-controller-server>
+        `);
+      });
+      it('reports empty named slots', function() {
+        expect(element.controller.hasSlotted('a')).to.be.false;
+        expect(element.controller.isEmpty('a')).to.be.true;
+      });
+      it('reports empty default slot', function() {
+        expect(element.controller.hasSlotted(null)).to.be.false;
+        expect(element.controller.isEmpty(null)).to.be.true;
+      });
+      it('reports empty default slot with no arguments', function() {
+        expect(element.controller.hasSlotted()).to.be.false;
+        expect(element.controller.isEmpty()).to.be.true;
+      });
+      it('returns empty list for getSlotted("a")', function() {
+        expect(element.controller.getSlotted('a')).to.be.empty;
+      });
+      it('returns empty list for getSlotted(null)', function() {
+        expect(element.controller.getSlotted(null)).to.be.empty;
+      });
+      it('returns empty list for getSlotted()', function() {
         expect(element.controller.getSlotted()).to.be.empty;
       });
     });


### PR DESCRIPTION
## What I did

1. fix the server-side slot controller's hasSlotted and isEmpty methods
2. adds unit tests for the server-side slot controller

## Testing Instructions

1. ideally this should be tested in RHDS, as we don't yet do SSR on pfe-dot-org

## Notes to Reviewers

1. This is one part of a two-part fix for https://github.com/RedHat-UX/red-hat-design-system/pull/2336
