### PR TITLE
fix(tooltip): make content inert when hidden

### DIFF
--- a/elements/pf-tooltip/pf-tooltip.ts
+++ b/elements/pf-tooltip/pf-tooltip.ts
@@ -189,7 +189,7 @@ export class PfTooltip extends LitElement {
              aria-labelledby="tooltip">
           <slot id="invoker" @slotchange="${this.#invokerChanged}"></slot>
         </div>
-        <div aria-hidden="${String(!open) as 'true' | 'false'}">
+        <div ?inert="${!open}">
           <slot id="tooltip" name="content">${this.content}</slot>
         </div>
       </div>


### PR DESCRIPTION
## What I did

1. make tooltip content inert when hidden. Fixes #2902 

## Testing Instructions

1. view repro instructions in linked issue

## Notes to Reviewers

1. Pay attention to a11y / SR use
