### PR TITLE
chore: update commitlint.yml

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,12 +8,6 @@ on:
       - edited
       - synchronize
       - reopened
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
 
   pull_request_review:
     types:


### PR DESCRIPTION
the pull_request_target event runs in the base context, e.g. the main branch, not in the pr branch

therefore this fails for new elements, because the commitlint script can't find the element name for an element which doesn't exist yet on main

## What I did

1. remove pull request target event from prlint workflow
