### PR TITLE
fix(tools): add `PfeDemoPage.js` to `package.json` exports

### DIFF
--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -37,6 +37,7 @@
     "./test/create-fixture.js": "./test/create-fixture.js",
     "./test/get-composed-text.js": "./test/get-composed-text.js",
     "./test/hex-to-rgb.js": "./test/hex-to-rgb.js",
+    "./test/playwright/PfeDemoPage.js": "./test/playwright/PfeDemoPage.js",
     "./test/render-to-string.js": "./test/render-to-string.js",
     "./test/stub-logger.js": "./test/stub-logger.js",
     "./test/utils.js": "./test/utils.js",


### PR DESCRIPTION
## What I did

1. adds `PfeDemoPage.js` to `package.json` exports
2. This file is used in RHDS E2E testing and needs to be exported.
3. See https://github.com/RedHat-UX/red-hat-design-system/pull/2473 for more info.

## Testing Instructions

1. View `packapge.json` file from pfe-tools, verify things look okay.
2. Verify if any other files in that directory need to be added to the exports list.

## Notes to Reviewers

Looks like there are some pfe-search-input commits in here. Feel free to change the base branch if applicable. 