### PR TITLE
fix(tools): restore accidentally deleted cem utilities

### DIFF
--- a/.changeset/honest-carrots-shout.md
+++ b/.changeset/honest-carrots-shout.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/pfe-tools": patch
+---
+Restored `custom-elements-manifest/custom-elements-manifest.js` export, which was mistakenly removed

--- a/tools/pfe-tools/custom-elements-manifest/custom-elements-manifest.ts
+++ b/tools/pfe-tools/custom-elements-manifest/custom-elements-manifest.ts
@@ -1,0 +1,11 @@
+import { Manifest } from './lib/Manifest.js';
+
+/**
+ * Get all package manifests in the working dir
+ * @param rootDir defaults to cwd
+ */
+export function getAllManifests(rootDir?: string): Manifest[] {
+  return Manifest.getAll(rootDir);
+}
+
+export type { DemoRecord } from './lib/Manifest.js';

--- a/tools/pfe-tools/package.json
+++ b/tools/pfe-tools/package.json
@@ -21,6 +21,7 @@
   },
   "exports": {
     "./config.js": "./config.js",
+    "./custom-elements-manifest/custom-elements-manifest.js": "./custom-elements-manifest/custom-elements-manifest.js",
     "./dev-server/config.js": "./dev-server/config.js",
     "./dev-server/demo.js": "./dev-server/demo.js",
     "./environment.js": "./environment.js",


### PR DESCRIPTION
## What I did

1. restored the custom elements manifest utilities that are not related to the old cem/a analyzer
