### PR TITLE
fix(tools): cem demo paths and dev server

### DIFF
--- a/elements/.config/cem.yaml
+++ b/elements/.config/cem.yaml
@@ -9,6 +9,6 @@ generate:
   output: custom-elements.json
   noDefaultExcludes: false
   demoDiscovery:
-    fileGlob: ./*/demo/*.html
-    urlPattern: (?P<tag>[\\w-]+)/demo/(?P<demo>[\\w-]+).html
-    urlTemplate: https://patternflyelements.org/components/{tag}/{demo}/
+    fileGlob: '*/demo/*.html'
+    urlPattern: pf-(?P<tag>[\w-]+)/demo/(?P<demo>[\w-]+).html
+    urlTemplate: https://patternflyelements.org/components/{tag}/demo/{demo}/

--- a/tools/pfe-tools/dev-server/config.ts
+++ b/tools/pfe-tools/dev-server/config.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 const replace = fromRollup(rollupReplace);
 
 type BaseConfig = DevServerConfig & PfeConfig;
+
 export interface PfeDevServerConfigOptions extends BaseConfig {
   hostname?: string;
   litcssOptions?: LitCSSOptions;

--- a/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
+++ b/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
@@ -36,7 +36,8 @@ async function getDemos(config: PfeDevServerInternalConfig) {
         manifest
             .getTagNames()
             .flatMap(tagName =>
-              manifest.getDemoMetadata(tagName, config as PfeDevServerInternalConfig)));
+              manifest.getDemoMetadata(tagName, config as PfeDevServerInternalConfig)
+                  .filter(demo => demo.filePath?.includes(tagName))));
 }
 
 async function getTemplateContent(demo?: DemoRecord) {
@@ -76,5 +77,3 @@ export function pfeDevServerTemplateMiddleware(config: PfeDevServerInternalConfi
     return next();
   };
 }
-
-

--- a/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
+++ b/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
@@ -37,7 +37,17 @@ async function getDemos(config: PfeDevServerInternalConfig) {
             .getTagNames()
             .flatMap(tagName =>
               manifest.getDemoMetadata(tagName, config as PfeDevServerInternalConfig)
-                  .filter(demo => demo.filePath?.includes(tagName))));
+                  .filter(demo => demo.filePath?.includes(tagName))
+                  .map(demo => {
+                    if (demo.filePath?.endsWith(`${tagName}.html`) || demo.filePath?.endsWith('index.html')) {
+                      return {
+                        ...demo,
+                        permalink: dirname(demo.permalink),
+                      };
+                    } else {
+                      return demo;
+                    }
+                  })));
 }
 
 async function getTemplateContent(demo?: DemoRecord) {


### PR DESCRIPTION
## What I did

1. new cem includes all demos in which a given tag name appears.
2. this change filters those demos in the dev server so only those defined inthe element's demo dir appear in the element's listing
3. it also modifies the permalink

We'll have to fix the manifest later on, but that can wait
