### PR TITLE
fix(core): scroll-spy for non-contiguous regions

### DIFF
--- a/.changeset/every-maps-itch.md
+++ b/.changeset/every-maps-itch.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/pfe-core": patch
+---
+`ScrollSpyController`: improve responsiveness of scroll spy
+


### PR DESCRIPTION
See https://github.com/RedHat-UX/red-hat-design-system/pull/2471

## What I did

1. Simplify the scroll-spy logic, and reconcile scroll-spy active link on scroll

## Testing Instructions

1. Check out existing jump-links elements

## Notes to Reviewers

1. There might be serious perf problems with the approach taken here so it should be validated against realworld pages
