### PR TITLE
fix(tools): correct lightdom css routing, improve trailing slash beha…

### DIFF
--- a/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
+++ b/tools/pfe-tools/dev-server/plugins/dev-server-templates.ts
@@ -69,7 +69,14 @@ export function pfeDevServerTemplateMiddleware(config: PfeDevServerInternalConfi
     if (config.loadDemo && !(method !== 'HEAD' && method !== 'GET' || path.includes('.'))) {
       const url = new URL(ctx.request.url, `http://${ctx.request.headers.host}`);
       const demos = await getDemos(config);
-      const demo = demos.find(x => x.permalink === url.pathname);
+      // const demo = demos.find(x => x.permalink === url.pathname);
+      let demo = demos.find(x => x.permalink === url.pathname);
+      // Handle case where URL ends with /demo/ but permalink was shortened to just /
+      // e.g., request for /compoennts/jazz-hands/demo/ should match demo with permalink /components/jazz-hands/
+      if (!demo && url.pathname.endsWith('/demo/')) {
+        const alternativePathname = url.pathname.replace('/demo/', '/');
+        demo = demos.find(x => x.permalink === alternativePathname);
+      }
       const manifest = demo?.manifest;
       const templateContent = await getTemplateContent(demo);
       ctx.cwd = process.cwd();


### PR DESCRIPTION
## What I did

1.  Corrected lightdom(-shim).css routing in dev server
2. Improved trailing slash behavior in dev server

## Testing Instructions

1.  Open dev server, add `-lightdom.css` to a component and link in a demo.  Ensure lightdom css is properly linked.

## Notes to Reviewers

1.
