### PR TITLE
fix(tools): restore missing files in create-element package

### DIFF
--- a/.changeset/fix-create-element-publish.md
+++ b/.changeset/fix-create-element-publish.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/create-element": patch
+---
+Fixed missing files in published package that prevented `npm run new` from working

--- a/tools/create-element/.npmignore
+++ b/tools/create-element/.npmignore
@@ -1,0 +1,4 @@
+# Override .gitignore so that compiled .js and .d.ts files
+# are included in the published package via the "files" field
+# in package.json. Without this, newer npm versions apply
+# .gitignore patterns as a filter even when "files" is set.


### PR DESCRIPTION
## Summary
- Adds an empty `.npmignore` to `tools/create-element/` so that the `files` field in `package.json` controls what gets published, rather than being filtered by `.gitignore`
- Newer npm versions apply `.gitignore` patterns even when `files` is set, which caused compiled output (`main.js`, `main.d.ts`, `generator/`) to be excluded from the 1.0.5 tarball

Closes #2967

## Test plan
- [ ] `cd tools/create-element && npm pack --dry-run` shows 17 files including `main.js`, `main.d.ts`, and `generator/*.js`
- [ ] `npm run new` works downstream after publishing