### PR TITLE
fix(select): replace RH color tokens with PF v4 global tokens

### DIFF
--- a/.changeset/fix-select-tokens.md
+++ b/.changeset/fix-select-tokens.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-select`: replaced Red Hat Design System color tokens with
+PatternFly v4 global tokens.

--- a/.changeset/fix-select-tokens.md
+++ b/.changeset/fix-select-tokens.md
@@ -2,5 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-select`: replaced Red Hat Design System color tokens with
-PatternFly v4 global tokens.
+`<pf-select>`: replaced Red Hat Design System color tokens with PatternFly v4 global tokens.

--- a/elements/pf-select/pf-option.css
+++ b/elements/pf-select/pf-option.css
@@ -15,7 +15,7 @@
 :host(:focus) #outer,
 :host(:hover) #outer,
 #outer.selected {
-  background-color: var(--_pf-option-selected-background-color, var(--rh-color-gray-20, #e0e0e0));
+  background-color: var(--_pf-option-selected-background-color, var(--pf-global--BackgroundColor--200, #e0e0e0));
 }
 
 #outer {

--- a/elements/pf-select/pf-select.css
+++ b/elements/pf-select/pf-select.css
@@ -5,7 +5,7 @@
 	color: var(--pf-global--Color--100, #151515);
   --_pf-option-checkboxes-display: none;
   --_pf-option-svg-display: block;
-	--_pf-option-selected-background-color: var(--rh-color-gray-20, #e0e0e0);
+	--_pf-option-selected-background-color: var(--pf-global--BackgroundColor--200, #e0e0e0);
 	/** Select toggle top padding */
 	--pf-c-select__toggle--PaddingTop: var(--pf-global--spacer--form-element, 0.375rem);
 	/** Select toggle right padding */


### PR DESCRIPTION
## Summary

Replace `--rh-color-gray-20` with `--pf-global--BackgroundColor--200` in
`pf-select.css` and `pf-option.css`. Same fallback value (#e0e0e0), no
visual change.

Closes #2954

## Test plan

- [ ] Selected option background color unchanged visually