### PR TITLE
fix(jump-links): add aria-label to nav landmark

### DIFF
--- a/.changeset/fix-jump-links-nav.md
+++ b/.changeset/fix-jump-links-nav.md
@@ -2,6 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-jump-links`: the shadow root `<nav>` element now has a default
-`aria-label` of "Page section navigation". Set the `label` attribute
-to customize it.
+`<pf-jump-links>`: added the `accessible-label` attribute for the navigation element, defaulting to "Page section navigation".

--- a/.changeset/fix-jump-links-nav.md
+++ b/.changeset/fix-jump-links-nav.md
@@ -1,0 +1,7 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-jump-links`: the shadow root `<nav>` element now has a default
+`aria-label` of "Page section navigation". Set the `label` attribute
+to customize it.

--- a/elements/pf-jump-links/pf-jump-links.ts
+++ b/elements/pf-jump-links/pf-jump-links.ts
@@ -84,7 +84,7 @@ export class PfJumpLinks extends LitElement {
 
   render(): TemplateResult<1> {
     return html`
-      <nav id="container">${this.expandable ? html`
+      <nav id="container" aria-label="${this.label || 'Page section navigation'}">${this.expandable ? html`
         <details ?open="${this.expanded}" @toggle="${this.#onToggle}">
           <summary>
             <pf-icon icon="chevron-right"></pf-icon>


### PR DESCRIPTION
## Summary

Adds `aria-label` to the shadow root `<nav>` in `pf-jump-links`,
defaulting to "Page section navigation". Set the `label` attribute
to customize it.

Closes #2860

## Test plan

- [ ] Verify `<nav>` has `aria-label="Page section navigation"` by default
- [ ] Verify custom `label` attribute overrides the aria-label
- [ ] Run axe on a page with `pf-jump-links` alongside another `<nav>`