### PR TITLE
fix(core): prevent SlotController.getSlotted() returning empty array prior to initialization

### DIFF
--- a/.changeset/fix-slot-controller.md
+++ b/.changeset/fix-slot-controller.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/pfe-core": patch
+---
+
+`SlotController`: fixed `getSlotted()` returning empty arrays in
+certain timing scenarios.

--- a/core/pfe-core/controllers/slot-controller.ts
+++ b/core/pfe-core/controllers/slot-controller.ts
@@ -215,11 +215,24 @@ export class SlotController implements SlotControllerPublicAPI {
    */
   public getSlotted<T extends Element = Element>(...slotNames: string[] | [null]): T[] {
     if (!slotNames.length || slotNames.length === 1 && slotNames.at(0) === null) {
-      return (this.#slotRecords.get(SlotController.default)?.elements ?? []) as T[];
+      return (this.#getAssignedElements(SlotController.default)) as T[];
     } else {
       return slotNames.flatMap(slotName =>
-        this.#slotRecords.get(slotName ?? SlotController.default)?.elements ?? []) as T[];
+        this.#getAssignedElements(slotName ?? SlotController.default)) as T[];
     }
+  }
+
+  /**
+   * Returns the assigned elements for a given slot name, falling back to
+   * querying the slot element directly if the slot record hasn't been
+   * initialized yet.
+   */
+  #getAssignedElements(slotId: string | symbol): Element[] {
+    const record = this.#slotRecords.get(slotId);
+    if (record) {
+      return record.elements;
+    }
+    return this.#getSlotElement(slotId)?.assignedElements?.() ?? [];
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixed `getSlotted()` returning empty arrays when called before async
slot record initialization completes. Falls back to querying slot
elements directly when records aren't yet populated.

Closes #2946

## Test plan

- [ ] Existing slot-controller tests pass
- [ ] Verify `getSlotted()` returns correct elements in downstream consumers