### PR TITLE
fix(switch): add static accessible label

### DIFF
--- a/.changeset/fix-switch-a11y.md
+++ b/.changeset/fix-switch-a11y.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-switch`: the switch now has a proper static accessible label
+independent of its on/off state text.

--- a/.changeset/fix-switch-a11y.md
+++ b/.changeset/fix-switch-a11y.md
@@ -2,5 +2,5 @@
 "@patternfly/elements": patch
 ---
 
-`pf-switch`: the switch now has a proper static accessible label
+`<pf-switch>`: the switch now has a proper static accessible label
 independent of its on/off state text.

--- a/elements/pf-switch/demo/without-label.html
+++ b/elements/pf-switch/demo/without-label.html
@@ -2,7 +2,7 @@
   <form>
     <fieldset>
       <legend>Without label</legend>
-      <pf-switch checked></pf-switch>
+      <pf-switch accessible-label="Toggle option" checked></pf-switch>
     </fieldset>
   </form>
 </section>

--- a/elements/pf-switch/pf-switch.ts
+++ b/elements/pf-switch/pf-switch.ts
@@ -24,8 +24,8 @@ export class PfSwitch extends LitElement {
 
   #internals = InternalsController.of(this, { role: 'switch' });
 
-  /** Accessible label text for the switch */
-  @property({ reflect: true }) label?: string;
+  /** Accessible label for the switch when there is no associated `<label>` element. */
+  @property({ reflect: true, attribute: 'accessible-label' }) accessibleLabel?: string;
 
   /** Flag to show if the switch has a check icon. */
   @property({ reflect: true, type: Boolean, attribute: 'show-check-icon' }) showCheckIcon = false;
@@ -57,6 +57,7 @@ export class PfSwitch extends LitElement {
   override willUpdate(): void {
     this.#internals.ariaChecked = String(!!this.checked);
     this.#internals.ariaDisabled = String(!!this.disabled);
+    this.#internals.ariaLabel = this.accessibleLabel || null;
   }
 
   override render(): TemplateResult<1> {

--- a/elements/pf-switch/pf-switch.ts
+++ b/elements/pf-switch/pf-switch.ts
@@ -24,7 +24,14 @@ export class PfSwitch extends LitElement {
 
   #internals = InternalsController.of(this, { role: 'switch' });
 
-  /** Accessible label for the switch when there is no associated `<label>` element. */
+  /** @deprecated use `accessible-label` instead */
+  @property({ reflect: true }) label?: string;
+
+  /**
+   * Accessible label for the switch when there is no associated `<label>` element.
+   * Update this value based on the checked state to communicate the meaning of
+   * each state to assistive technology users, e.g. "Wi-Fi on" / "Wi-Fi off".
+   */
   @property({ reflect: true, attribute: 'accessible-label' }) accessibleLabel?: string;
 
   /** Flag to show if the switch has a check icon. */
@@ -57,7 +64,7 @@ export class PfSwitch extends LitElement {
   override willUpdate(): void {
     this.#internals.ariaChecked = String(!!this.checked);
     this.#internals.ariaDisabled = String(!!this.disabled);
-    this.#internals.ariaLabel = this.accessibleLabel || null;
+    this.#internals.ariaLabel = this.accessibleLabel || this.label || null;
   }
 
   override render(): TemplateResult<1> {

--- a/elements/pf-switch/test/pf-switch.spec.ts
+++ b/elements/pf-switch/test/pf-switch.spec.ts
@@ -43,6 +43,27 @@ describe('<pf-switch>', function() {
     });
   });
 
+  describe('with accessible-label attribute', function() {
+    let element: PfSwitch;
+    let snapshot: A11yTreeSnapshot;
+    beforeEach(async function() {
+      element = await createFixture<PfSwitch>(html`
+        <pf-switch accessible-label="Dark Mode"></pf-switch>
+      `);
+      snapshot = await a11ySnapshot({ selector: 'pf-switch' });
+    });
+    it('has an accessible name from accessible-label', function() {
+      expect(snapshot.name).to.equal('Dark Mode');
+    });
+    it('keeps the same accessible name regardless of checked state', async function() {
+      element.click();
+      await element.updateComplete;
+      await nextFrame();
+      snapshot = await a11ySnapshot({ selector: 'pf-switch' });
+      expect(snapshot.name).to.equal('Dark Mode');
+    });
+  });
+
   describe('with labels for on and off state', function() {
     let element: PfSwitch;
     let snapshot: A11yTreeSnapshot;


### PR DESCRIPTION
## Summary

- Rename `label` property to `accessibleLabel` (`accessible-label` attribute)
- Wire to `ariaLabel` on ElementInternals for a proper static accessible name
- Updated "without label" demo to use `accessible-label`
- Added tests for accessible label behavior

Closes #2754

## Test plan

- [ ] Verify switch has accessible name when `accessible-label` is set
- [ ] Verify accessible name is static regardless of checked state
- [ ] Run tests: `npx wtr elements/pf-switch/test/pf-switch.spec.ts`