### PR TITLE
fix(back-to-top): change background color on hover and focus

### DIFF
--- a/.changeset/fix-back-to-top-hover.md
+++ b/.changeset/fix-back-to-top-hover.md
@@ -2,4 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-back-to-top`: background color now changes on hover and focus.
+`<pf-back-to-top>`: fixed background color during hover and focus.

--- a/.changeset/fix-back-to-top-hover.md
+++ b/.changeset/fix-back-to-top-hover.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-back-to-top`: background color now changes on hover and focus.

--- a/elements/pf-back-to-top/pf-back-to-top.css
+++ b/elements/pf-back-to-top/pf-back-to-top.css
@@ -41,14 +41,16 @@ a {
   gap: var(--pf-c-button__icon--m-end--MarginLeft, var(--pf-global--spacer--xs, 0.25rem));
 }
 
-a:hover {
+a:hover,
+a:focus {
   --pf-c-button--m-primary--Color: var(--pf-c-button--m-primary--hover--Color, var(--pf-global--Color--light-100, #fff));
   --pf-c-button--m-primary--BackgroundColor: var(--pf-c-button--m-primary--hover--BackgroundColor, var(--pf-global--primary-color--200, #004080));
 }
 
-a:focus {
-  --pf-c-button--m-primary--Color: var(--pf-c-button--m-primary--hover--Color, var(--pf-global--Color--light-100,#fff));
+[part="trigger"]:is(pf-button):hover,
+[part="trigger"]:is(pf-button):focus-within {
   --pf-c-button--m-primary--BackgroundColor: var(--pf-c-button--m-primary--hover--BackgroundColor, var(--pf-global--primary-color--200, #004080));
+  --pf-c-button--m-primary--Color: var(--pf-c-button--m-primary--hover--Color, var(--pf-global--Color--light-100, #fff));
 }
 
 [part="trigger"][hidden] {


### PR DESCRIPTION
## Summary

Apply hover/focus background color directly on the `<a>` element rather
than through CSS custom property overrides that don't cascade into
`pf-button`'s shadow DOM. Also adds `pf-button` hover/focus-within styles.

Closes #2743

## Test plan

- [ ] Verify back-to-top button changes background on hover
- [ ] Verify back-to-top button changes background on focus