### PR TITLE
perf(tabs): add passive scroll event listeners

### DIFF
--- a/.changeset/tabs-passive-scroll.md
+++ b/.changeset/tabs-passive-scroll.md
@@ -2,5 +2,4 @@
 "@patternfly/elements": patch
 ---
 
-`pf-tabs`: scroll event listeners are now passive for better
-scrolling performance.
+`<pf-tabs>`: scroll event listeners are now passive for better performance.

--- a/.changeset/tabs-passive-scroll.md
+++ b/.changeset/tabs-passive-scroll.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-tabs`: scroll event listeners are now passive for better
+scrolling performance.

--- a/elements/pf-tabs/pf-tabs.ts
+++ b/elements/pf-tabs/pf-tabs.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
+import { eventOptions } from 'lit/decorators/event-options.js';
 import { property } from 'lit/decorators/property.js';
 import { query } from 'lit/decorators/query.js';
 import { provide } from '@lit/context';
@@ -180,7 +181,7 @@ export class PfTabs extends LitElement {
           <!-- tablist -->
           <div id="tabs" part="tabs" role="tablist">
             <!-- Must contain one or more \`<pf-tab>\` -->
-            <slot name="tab" @slotchange="${this.#onSlotChange}" @scroll="${this.#overflow.onScroll}"></slot>
+            <slot name="tab" @slotchange="${this.#onSlotChange}" @scroll="${this.onScroll}"></slot>
           </div>
           ${!this.#overflow.showScrollButtons ? '' : html`
           <button id="nextTab" tabindex="-1"
@@ -199,6 +200,11 @@ export class PfTabs extends LitElement {
         <slot part="panels"></slot>
       </div>
     `;
+  }
+
+  @eventOptions({ passive: true })
+  private onScroll() {
+    this.#overflow.onScroll();
   }
 
   #scrollLeft() {


### PR DESCRIPTION
## Summary

Use Lit's `@eventOptions({ passive: true })` decorator for the scroll
listener in `pf-tabs`, avoiding blocking the main thread during scroll.

Closes #2600

## Test plan

- [ ] Verify tabs still scroll correctly
- [ ] Verify overflow scroll buttons still work