### PR TITLE
fix(create-element): add prepack script to build before publish

### DIFF
--- a/.changeset/fix-create-element.md
+++ b/.changeset/fix-create-element.md
@@ -1,0 +1,5 @@
+---
+"@patternfly/create-element": patch
+---
+
+Fixed missing entry point in published package.

--- a/tools/create-element/package.json
+++ b/tools/create-element/package.json
@@ -34,6 +34,7 @@
     "templates/**/*"
   ],
   "scripts": {
+    "prepack": "tsc -b .",
     "test": "echo 'unit tests for PFE generator not written yet'"
   },
   "bugs": {


### PR DESCRIPTION
## Summary

Add `prepack` script to `@patternfly/create-element` so TypeScript
is compiled before publishing, ensuring `main.js` is present.

Closes #2967

## Test plan

- [ ] `npm run new` works downstream