### PR TITLE
fix: npm run start with existing build artifacts

### DIFF
--- a/.changeset/fix-start-build-artifacts.md
+++ b/.changeset/fix-start-build-artifacts.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/elements": patch
+---
+
+`npm run start` no longer fails when TypeScript build artifacts
+are present in the working tree.

--- a/tsconfig.esbuild.json
+++ b/tsconfig.esbuild.json
@@ -9,7 +9,16 @@
     "**/demo/*.d.ts",
     "**/_temp/**/*",
     "**/*.story.*",
-    "**/test/*_e2e*"
+    "**/test/*_e2e*",
+    "elements/**/*.js",
+    "elements/**/*.d.ts",
+    "elements/**/*.js.map",
+    "core/**/*.js",
+    "core/**/*.d.ts",
+    "core/**/*.js.map",
+    "tools/**/*.js",
+    "tools/**/*.d.ts",
+    "tools/**/*.js.map"
   ],
   "compilerOptions": {
     "allowJs": true,


### PR DESCRIPTION
## Summary

Exclude build output files from `tsconfig.esbuild.json` so
`npm run start` doesn't fail with "Cannot write file because
it would overwrite input file" when build artifacts are present.

Closes #2712

## Test plan

- [x] Build the project, then run `npm run start`