### PR TITLE
fix(popover): outsideClick should not fire on already-hidden popovers

### DIFF
--- a/.changeset/fix-popover-click.md
+++ b/.changeset/fix-popover-click.md
@@ -1,0 +1,6 @@
+---
+"@patternfly/elements": patch
+---
+
+`pf-popover`: clicking outside a popover no longer fires spurious
+hide events on other closed popovers.

--- a/.changeset/fix-popover-click.md
+++ b/.changeset/fix-popover-click.md
@@ -2,5 +2,5 @@
 "@patternfly/elements": patch
 ---
 
-`pf-popover`: clicking outside a popover no longer fires spurious
+`<pf-popover>`: clicking outside a popover no longer fires spurious
 hide events on other closed popovers.

--- a/elements/pf-popover/pf-popover.ts
+++ b/elements/pf-popover/pf-popover.ts
@@ -351,6 +351,9 @@ export class PfPopover extends LitElement {
   };
 
   #outsideClick(event: MouseEvent) {
+    if (this.#hideDialog) {
+      return;
+    }
     const path = event.composedPath();
     if (!path.includes(this) && !path.includes(this.#referenceTrigger as HTMLElement)) {
       this.hide();


### PR DESCRIPTION
## Summary

Guard the `#outsideClick` handler to skip popovers that are already
hidden. Previously, clicking anywhere on the page would dispatch
`hide` and `hidden` events on ALL popover instances, even closed ones.

Closes #2513

## Test plan

- [ ] Open popover A, click outside, verify it closes
- [ ] With popovers A and B, open A, click outside, verify only A fires hide events
- [ ] Verify no hide events fire on closed popovers when clicking the page