### PR TITLE
fix(label): only thicken border on link hover, not close button

### DIFF
--- a/elements/pf-label/pf-label.css
+++ b/elements/pf-label/pf-label.css
@@ -305,15 +305,8 @@ pf-button {
   cursor: pointer;
 }
 
-:host(:hover) #link ~ *,
-:host(:focus-within) #link ~ *,
-#link:hover,
-#link:focus {
-  cursor: pointer;
-}
-
-:host(:hover) #container:has(#link)::before,
-:host(:focus-within) #container:has(#link)::before {
+#container:has(#link:hover)::before,
+#container:has(#link:focus)::before {
   border-width: var(--pf-c-label__content--link--hover--before--BorderWidth, 2px);
   border-color: var(--_label-link-hover-border-color);
 }

--- a/elements/pf-label/pf-label.css
+++ b/elements/pf-label/pf-label.css
@@ -21,7 +21,7 @@ pf-icon, ::slotted(pf-icon) {
 
 #container {
   overflow: clip;
-  overflow-clip-margin: 3px;
+  overflow-clip-margin: 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
   border-width: 0;

--- a/elements/pf-label/pf-label.css
+++ b/elements/pf-label/pf-label.css
@@ -20,7 +20,8 @@ pf-icon, ::slotted(pf-icon) {
 }
 
 #container {
-  overflow: hidden;
+  overflow: clip;
+  overflow-clip-margin: 3px;
   text-overflow: ellipsis;
   white-space: nowrap;
   border-width: 0;


### PR DESCRIPTION
## Summary

Use `#container:has(#link:hover)` instead of `:host(:hover)` so the
border only thickens when hovering the link text, not the close button.
Matches PFv4 behavior per @adamjohnson's review on #3095.

## Test plan

- [x] Hover link text: border thickens to 2px
- [x] Hover close button: border stays 1px
- [x] Compare with https://v4-archive.patternfly.org/v4/components/label/react/router-link/