### PR TITLE
feat(core): expose element internals to a11y tools

### DIFF
--- a/.changeset/two-moose-cough.md
+++ b/.changeset/two-moose-cough.md
@@ -1,0 +1,4 @@
+---
+"@patternfly/pfe-core": patch
+---
+`InternalsController`: allows accessibility auditing tools to access element internals.

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -4,20 +4,22 @@ import {
   type ReactiveControllerHost,
 } from 'lit';
 
-function isARIAMixinProp(key: string): key is keyof ARIAMixin {
-  return key === 'role' || key.startsWith('aria');
-}
-
 type FACE = HTMLElement & {
   formDisabledCallback?(disabled: boolean): void;
 };
+
+interface InternalsControllerOptions extends Partial<ARIAMixin> {
+  getHTMLElement?(): HTMLElement;
+}
 
 const protos = new WeakMap();
 
 let constructingAllowed = false;
 
-interface InternalsControllerOptions extends Partial<ARIAMixin> {
-  getHTMLElement?(): HTMLElement;
+globalThis._elementInternals ??= new WeakMap<Element, ElementInternals>();
+
+function isARIAMixinProp(key: string): key is keyof ARIAMixin {
+  return key === 'role' || key.startsWith('aria');
 }
 
 /**
@@ -264,7 +266,6 @@ export class InternalsController implements ReactiveController, ARIAMixin {
     InternalsController.instances.set(host, this);
     this.#polyfillDisabledPseudo();
     // Expose internals to aXe Core
-    globalThis._elementInternals ??= new WeakMap<Element, ElementInternals>();
     globalThis._elementInternals.set(this.host, this.internals);
   }
 

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -264,9 +264,8 @@ export class InternalsController implements ReactiveController, ARIAMixin {
     InternalsController.instances.set(host, this);
     this.#polyfillDisabledPseudo();
     // Expose internals to aXe Core
-    // https://github.com/webcomponents-cg/community-protocols/pull/75
     globalThis._elementInternals ??= new WeakMap<Element, ElementInternals>();
-    globalThis._elementInternasl.set(this.host, this.internals);
+    globalThis._elementInternals.set(this.host, this.internals);
   }
 
   /**
@@ -339,6 +338,8 @@ export class InternalsController implements ReactiveController, ARIAMixin {
 
 /** @see https://w3c.github.io/aria/#ref-for-dom-ariamixin-ariaactivedescendantelement-1 */
 declare global {
+  // https://github.com/webcomponents-cg/community-protocols/pull/75
+  var _elementInternals: WeakMap<Element, ElementInternals>; // eslint-disable-line no-var
   interface ARIAMixin {
     ariaActiveDescendantElement: Element | null;
     ariaControlsElements: readonly Element[] | null;

--- a/core/pfe-core/controllers/internals-controller.ts
+++ b/core/pfe-core/controllers/internals-controller.ts
@@ -263,6 +263,10 @@ export class InternalsController implements ReactiveController, ARIAMixin {
     this.initializeOptions(options);
     InternalsController.instances.set(host, this);
     this.#polyfillDisabledPseudo();
+    // Expose internals to aXe Core
+    // https://github.com/webcomponents-cg/community-protocols/pull/75
+    globalThis._elementInternals ??= new WeakMap<Element, ElementInternals>();
+    globalThis._elementInternasl.set(this.host, this.internals);
   }
 
   /**


### PR DESCRIPTION
## What I did

1. add `globalThis._elementInternals` to `InternalsController`

When this is merged and released, a PR will be opened against RHDS to integrate it.

cc @adamjohnson @hellogreg @wilcofiers
