### PR TITLE
chore: commitlint scopes for versioned elements

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ const normalizeWorkspace = async x => {
   const ents = await readdir(fileURLToPath(new URL(x, import.meta.url)), { withFileTypes: true });
   return ents
       .filter(ent => ent.isDirectory())
-      .map(ent => ent.name.replace('pf-', ''));
+      .map(ent => ent.name.replace(/^pf-(?:v\d+-)?/, ''));
 };
 
 


### PR DESCRIPTION
## What I did

1. fix commitlint scopes for `pf-v*` prefixes

## Testing Instructions

1. `git commit --allow-empty --message "fix(tooltip): test commit"`

