### PR TITLE
chore(docs): update docs scaffolding for v6 element names

### DIFF
--- a/docs/_includes/_nav.njk
+++ b/docs/_includes/_nav.njk
@@ -15,24 +15,24 @@
           </picture>
         </a>
       </div>
-      <pf-v5-dropdown id="docs-versions-dropdown">
-        <pf-v5-button slot="toggle"
+      <pf-v6-dropdown id="docs-versions-dropdown">
+        <pf-v6-button slot="toggle"
                    variant="control"
                    icon="caret-down"
-                   icon-set="fas">Versions</pf-v5-button>
-        <pf-v5-dropdown-menu slot="menu">
+                   icon-set="fas">Versions</pf-v6-button>
+        <pf-v6-dropdown-menu slot="menu">
           {% for version in versions %}
           {%- if version.current -%}
             {%- set prefix = '' -%}
           {%- else -%}
             {%- set prefix = '/' + version.slug -%}
           {%- endif %}
-          <pf-v5-dropdown-item href="{{ prefix }}{{ page.url }}" {{ 'disabled' if version.current }}>
+          <pf-v6-dropdown-item href="{{ prefix }}{{ page.url }}" {{ 'disabled' if version.current }}>
             {{ version.label }}
-          </pf-v5-dropdown-item>
+          </pf-v6-dropdown-item>
           {% endfor %}
-        </pf-v5-dropdown-menu>
-      </pf-v5-dropdown>
+        </pf-v6-dropdown-menu>
+      </pf-v6-dropdown>
     </div>
   </div>
 

--- a/docs/_includes/layout-blog-index.njk
+++ b/docs/_includes/layout-blog-index.njk
@@ -9,7 +9,7 @@ layout: layout-base.njk
 
   <div class="posts">
     {% for post in collections.blog | reverse %}
-      <pf-v5-card>
+      <pf-v6-card>
         <h2 slot="header">{{ post.data.title }}</h2>
         {% if post.data.tagline %}
           <p class="tagline"><a href="{{ post.data.page.url }}">{{ post.data.tagline }}</a></p>{% endif %}
@@ -18,7 +18,7 @@ layout: layout-base.njk
         {% endif %}
         <a slot="footer" class="cta" href="{{ post.data.page.url }}">Read Post</a>
         <time slot="footer" datetime="{{ post.data.page.date }}">{{ post.data.page.date | prettyDate }}</time>
-      </pf-v5-card>
+      </pf-v6-card>
     {% endfor %}
   </div>
 </main>
@@ -34,7 +34,7 @@ layout: layout-base.njk
     gap: 2rem;
   }
 
-  pf-v5-card::part(footer) {
+  pf-v6-card::part(footer) {
     justify-content: space-between;
     align-items: center;
   }

--- a/docs/_includes/layout-blog.njk
+++ b/docs/_includes/layout-blog.njk
@@ -28,13 +28,13 @@ layout: layout-base.njk
     {{ content | safe }}
   </section>
 
-  <pf-v5-back-to-top id="back-to-top-link">Back to Top</pf-v5-back-to-top>
+  <pf-v6-back-to-top id="back-to-top-link">Back to Top</pf-v6-back-to-top>
 </main>
 
 {% include '_foot.njk' %}
 
 <script type="module">
-  import '@patternfly/elements/pf-v5-back-to-top/pf-v5-back-to-top.js';
+  import '@patternfly/elements/pf-v6-back-to-top/pf-v6-back-to-top.js';
   const allTocLinks = document.querySelectorAll('nav.toc [href^="#"]')
 
   const activeLinks = document.querySelectorAll('nav.toc li.active');

--- a/docs/_snippets/accordion-html.md
+++ b/docs/_snippets/accordion-html.md
@@ -1,21 +1,21 @@
 ```html
 
 <script type="module">
-  import '@patternfly/elements/pf-v5-accordion/pf-v5-accordion.js';
+  import '@patternfly/elements/pf-v6-accordion/pf-v6-accordion.js';
 </script>
 
-<pf-v5-accordion>
-  <pf-v5-accordion-header expanded>
+<pf-v6-accordion>
+  <pf-v6-accordion-header expanded>
     <h3>Getting Started</h3>
-  </pf-v5-accordion-header>
-  <pf-v5-accordion-panel>
+  </pf-v6-accordion-header>
+  <pf-v6-accordion-panel>
     <p>Read our <a href="/get-started/">Getting started</a> page to learn how to install and use PatternFly Elements.</p>
-  </pf-v5-accordion-panel>
-  <pf-v5-accordion-header>
+  </pf-v6-accordion-panel>
+  <pf-v6-accordion-header>
     <h3>HTML APIs</h3>
-  </pf-v5-accordion-header>
-  <pf-v5-accordion-panel>
+  </pf-v6-accordion-header>
+  <pf-v6-accordion-panel>
     <p>For more information on how to use each PatternFly element, read the <a href="/components/">component docs</a>.</p>
-  </pf-v5-accordion-panel>
-</pf-v5-accordion>
+  </pf-v6-accordion-panel>
+</pf-v6-accordion>
 ```

--- a/docs/_snippets/accordion-jsx.md
+++ b/docs/_snippets/accordion-jsx.md
@@ -3,7 +3,7 @@ import {
   Accordion,
   AccordionPanel,
   AccordionHeader,
-} from "@patternfly/elements/react/pf-v5-accordion/pf-v5-accordion.js";
+} from "@patternfly/elements/react/pf-v6-accordion/pf-v6-accordion.js";
 
 export default function App() {
   const data = [

--- a/docs/_snippets/accordion-ng.md
+++ b/docs/_snippets/accordion-ng.md
@@ -1,22 +1,22 @@
 {%raw%}
 ```ts
-import "@patternfly/elements/pf-v5-accordion/pf-v5-accordion.js";
+import "@patternfly/elements/pf-v6-accordion/pf-v6-accordion.js";
 
 import { Component } from "@angular/core";
 
 @Component({
   selector: "app-root",
   template: `
-    <pf-v5-accordion>
+    <pf-v6-accordion>
       <ng-template ngFor let-item [ngForOf]="data">
-        <pf-v5-accordion-header>
+        <pf-v6-accordion-header>
           <h3>{{ item.header }}</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p>{{ item.panel }}</p>
-        </pf-v5-accordion-panel>
+        </pf-v6-accordion-panel>
       </ng-template>
-    </pf-v5-accordion>
+    </pf-v6-accordion>
   `,
 })
 export class AppComponent {

--- a/docs/_snippets/accordion-svelte.md
+++ b/docs/_snippets/accordion-svelte.md
@@ -1,18 +1,18 @@
 {%raw%}
 ```html
-<pf-v5-accordion>
+<pf-v6-accordion>
   {#each data as item}
-  <pf-v5-accordion-header>
+  <pf-v6-accordion-header>
     <h3>{item.header}</h3>
-  </pf-v5-accordion-header>
-  <pf-v5-accordion-panel>
+  </pf-v6-accordion-header>
+  <pf-v6-accordion-panel>
     <p>{item.panel}</p>
-  </pf-v5-accordion-panel>
+  </pf-v6-accordion-panel>
   {/each}
-</pf-v5-accordion>
+</pf-v6-accordion>
 
 <script>
-  import "@patternfly/elements/pf-v5-accordion/pf-v5-accordion.js";
+  import "@patternfly/elements/pf-v6-accordion/pf-v6-accordion.js";
 	let data = [
     { header: 'Heading 1', panel: 'Here is some content' },
     { header: 'Heading 2', panel: 'Here is some more content' },

--- a/docs/_snippets/accordion-vue.md
+++ b/docs/_snippets/accordion-vue.md
@@ -1,21 +1,21 @@
 {%raw%}
 ```html
 <template>
-  <pf-v5-accordion>
+  <pf-v6-accordion>
     <template v-for="{ header, panel } in data">
-      <pf-v5-accordion-header>
+      <pf-v6-accordion-header>
         <h3>{{ header }}</h3>
-      </pf-v5-accordion-header>
-      <pf-v5-accordion-panel>
+      </pf-v6-accordion-header>
+      <pf-v6-accordion-panel>
         <p>{{ panel }}</p>
-      </pf-v5-accordion-panel>
+      </pf-v6-accordion-panel>
     </template>
-  </pf-v5-accordion>
+  </pf-v6-accordion>
 </template>
 {%endraw%}
 
 <script>
-import "@patternfly/elements/pf-v5-accordion/pf-v5-accordion.js";
+import "@patternfly/elements/pf-v6-accordion/pf-v6-accordion.js";
 export default {
   name: 'App',
   data() {

--- a/docs/_snippets/card-html.md
+++ b/docs/_snippets/card-html.md
@@ -1,12 +1,12 @@
 ```html
-<script type="module" src="https://esm.sh/@patternfly/elements/pf-v5-card/pf-v5-card.js"></script>
+<script type="module" src="https://esm.sh/@patternfly/elements/pf-v6-card/pf-v6-card.js"></script>
 
-<pf-v5-card border>
+<pf-v6-card border>
   <h2 slot="header">Card component</h2>
   <p>PatternFly Elements are custom HTML elements that work everywhere.
     The Card element has <code>header</code> and <code>footer</code> slots for things like 
     titles and actions.
   </p>
-  <a class="cta" slot="footer" href="components/card">More about <code>pf-v5-card</code></a>
-</pf-v5-card>
+  <a class="cta" slot="footer" href="components/card">More about <code>pf-v6-card</code></a>
+</pf-v6-card>
 ```

--- a/docs/_snippets/pf-bar-html.md
+++ b/docs/_snippets/pf-bar-html.md
@@ -3,7 +3,7 @@
     PatternFly.org
   </a>
   <a href="https://github.com/patternfly/patternfly-elements" class="cta">
-    <pf-v5-icon size="md" icon="github" set="fab" aria-hidden="true"></pf-v5-icon>
+    <pf-v6-icon size="md" icon="github" set="fab" aria-hidden="true"></pf-v6-icon>
     Contribute on Github
   </a>
 </div>

--- a/docs/components.md
+++ b/docs/components.md
@@ -2,9 +2,9 @@
   const CLASS_KEY = 'html-lit-react-snippets';
   const LS_KEY = `${CLASS_KEY}-index`;
   document.addEventListener('expand', async function(event) {
-    const PfV5Tabs = await customElements.whenDefined('pf-v5-tabs');
-    if (PfV5Tabs.isExpandEvent(event)) {
-      const tabs = event.tab.closest('pf-v5-tabs');
+    const PfV6Tabs = await customElements.whenDefined('pf-v6-tabs');
+    if (PfV6Tabs.isExpandEvent(event)) {
+      const tabs = event.tab.closest('pf-v6-tabs');
       if (tabs.classList.contains(CLASS_KEY)) {
         await tabs.updateComplete;
         localStorage.setItem(LS_KEY, tabs.activeIndex);
@@ -13,7 +13,7 @@
     }
   });
   async function update() {
-    for (const tabs of document.querySelectorAll(`pf-v5-tabs.${CLASS_KEY}`)) {
+    for (const tabs of document.querySelectorAll(`pf-v6-tabs.${CLASS_KEY}`)) {
       await tabs.updateComplete;
       tabs.activeIndex = parseInt(localStorage.getItem(LS_KEY) ?? '0');
     }

--- a/docs/docs/develop/create.md
+++ b/docs/docs/develop/create.md
@@ -35,8 +35,8 @@ tags:
     * Your element's name should be lowercase and needs to contain at least 
       one hyphen. For rules on naming custom elements, refer to the W3C 
       [Custom Elements Working Draft](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name).
-    * As an example, we'll create `pf-v5-cool-element`.  
-    * PatternFly Elements should be prefixed with `pf-v5-`. However, prefix your 
+    * As an example, we'll create `pf-v6-cool-element`.  
+    * PatternFly Elements should be prefixed with `pf-v6-`. However, prefix your 
       elements with whatever fits your project if you are using the generator outside of this project.
 
 
@@ -45,18 +45,18 @@ tags:
   After answering, your new component will be created and bootstrapped in the repository.
 
   Once that's done, switch directories to the element you just created. We'll 
-  `cd` into the `pf-v5-cool-element` directory.
+  `cd` into the `pf-v6-cool-element` directory.
 
   ```bash
-  cd elements/pf-v5-cool-element
+  cd elements/pf-v6-cool-element
   ```
 
   Open your code editor to view the structure of the element.
   The element's source files are located directly in it's package root, in our 
   case:
 
-  * `pf-v5-cool-element.ts` - The element class declaration
-  * `pf-v5-cool-element.css` - The element's CSS style module
+  * `pf-v6-cool-element.ts` - The element class declaration
+  * `pf-v6-cool-element.css` - The element's CSS style module
 
   The `demo` directory contains an HTML partial that you can edit to provide an 
   interactive demo of your element.

--- a/docs/docs/develop/css.md
+++ b/docs/docs/develop/css.md
@@ -15,11 +15,11 @@ tags:
 
 {% band %}
 
-We want the `pf-v5-cool-element` to have a profile photo, a username, and a follow button.
+We want the `pf-v6-cool-element` to have a profile photo, a username, and a follow button.
 Right now, it only contains the HTML structure, but we can style our element by 
 updating our CSS to make it look the way we want.
 
-We'll be working in the `pf-v5-cool-element.css` file.
+We'll be working in the `pf-v6-cool-element.css` file.
 
 The boilerplate stylesheet has a `:host` selector that makes our element display 
 as a block element.
@@ -69,12 +69,12 @@ After saving and viewing our demo page, our profile element looks much better.
 
 A couple of things to note:
 
-1.  The `:host` selector sets the styles of the container element `<pf-v5-cool-element>`.
+1.  The `:host` selector sets the styles of the container element `<pf-v6-cool-element>`.
 2.  The `button` styles are encapsulated within this element and will not bleed out, meaning that there's no chance these styles will affect other buttons on the page. Feeling confident that your element will always look the same when it's distributed is one of the main advantages of the shadow DOM. Check out the Styling section of [Shadow DOM v1: Self-Contained Web Components](https://developers.google.com/web/fundamentals/web-components/shadowdom#styling) to learn what else you can do when applying styles to the shadow DOM.
 
-Now that our `pf-v5-cool-element` is more appealing, we'll add the follow button's interaction
+Now that our `pf-v6-cool-element` is more appealing, we'll add the follow button's interaction
 and fill in the profile photo.
-We can accomplish both of these tasks by updating the `pf-v5-cool-element.ts` file.
+We can accomplish both of these tasks by updating the `pf-v6-cool-element.ts` file.
 
 <a class="cta" href="{{ '../javascript' | url }}">Next up: Write your JavaScript</a>
 

--- a/docs/docs/develop/html.md
+++ b/docs/docs/develop/html.md
@@ -25,17 +25,17 @@ If you are unfamiliar with TypeScript, read their getting-started documentation,
 and feel free to reach out to the PatternFly Elements team on our social media 
 channels.
 
-We'll edit the `pf-v5-cool-element.ts` file to add some HTML to our element's 
+We'll edit the `pf-v6-cool-element.ts` file to add some HTML to our element's 
 template. LitElements define their template in the `render()` method.
 The `render()` method can return a string, a number, a DOM node, etc, but 
 usually it returns a `TemplateResult`, which is an `html`
 [tagged template 
 literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates).
 
-Let's turn `pf-v5-cool-element` into a profile element that has a profile photo, a 
+Let's turn `pf-v6-cool-element` into a profile element that has a profile photo, a 
 username, and a button to follow the user.
 
-Here's the updated `render()` method in `pf-v5-cool-element.ts`:
+Here's the updated `render()` method in `pf-v6-cool-element.ts`:
 
 ```ts
 render() {
@@ -50,15 +50,15 @@ render() {
 ```
 
 We'll also need to update `/demo/index.html`
-so that the user's name is passed into the slot that we added in `pf-v5-cool-element.ts`:
+so that the user's name is passed into the slot that we added in `pf-v6-cool-element.ts`:
 
 ```html
 <link rel="stylesheet" href="demo.css">
-<script type="module" src="pf-v5-cool-element.js"></script>
+<script type="module" src="pf-v6-cool-element.js"></script>
 
-<pf-v5-cool-element>
+<pf-v6-cool-element>
   Kyle Buchanan
-</pf-v5-cool-element>
+</pf-v6-cool-element>
 ```
 
 Slots take the HTML from the light DOM and project it into the shadow DOM at a given location.

--- a/docs/docs/develop/import-maps.md
+++ b/docs/docs/develop/import-maps.md
@@ -31,14 +31,14 @@ Example:
 <script type="importmap">
 {
   "imports": {
-    "@patternfly/elements/pf-v5-card/pf-v5-card.js": "path/to/pf-card.js"
+    "@patternfly/elements/pf-v6-card/pf-v6-card.js": "path/to/pf-card.js"
   }
 }
 </script>
 
 <!-- //  Bare module import specifier -->
 <script type="module">
-import '@patternfly/elements/pf-v5-card/pf-v5-card.js';
+import '@patternfly/elements/pf-v6-card/pf-v6-card.js';
 </script>
 ```
 
@@ -65,7 +65,7 @@ Once you've generated your import map and added it to your project, you can use 
 <script type="importmap">
 {
   "imports": {
-    "@patternfly/elements/pf-v5-card/pf-v5-card.js": "https://ga.jspm.io/npm:@patternfly/elements@2.5.0/pf-card/pf-card.js"
+    "@patternfly/elements/pf-v6-card/pf-v6-card.js": "https://ga.jspm.io/npm:@patternfly/elements@2.5.0/pf-card/pf-card.js"
   },
   "scopes": {
     "https://ga.jspm.io/": {
@@ -87,7 +87,7 @@ Once you've generated your import map and added it to your project, you can use 
 ```javascript
 <script type="module">
   // resolves to https://ga.jspm.io/npm:@patternfly/elements@2.5.0/pf-card/pf-card.js
-  import '@patternfly/elements/pf-v5-card/pf-v5-card.js';
+  import '@patternfly/elements/pf-v6-card/pf-v6-card.js';
 </script>
 ```
 

--- a/docs/docs/develop/javascript.md
+++ b/docs/docs/develop/javascript.md
@@ -48,7 +48,7 @@ Please note the TypeScript `#` character before the handlers' method name.
 This signals to the custom elements manifest analyzer to list this method as private,
 and marks it as such in the element's TypeScript definition file.
 This helps users of your element know which of its features are safe to use with confidence,
-and which are likely to change without notice. For example, a user of `<pf-v5-cool-element>` would think twice about directly calling it's
+and which are likely to change without notice. For example, a user of `<pf-v6-cool-element>` would think twice about directly calling it's
 `onClick()` method if it was marked as private.
 
 After saving your files, the demo page will refresh and you'll notice the start of your button interactivity.
@@ -71,7 +71,7 @@ import { property } from 'lit/decorators/property.js'
 Then define the `following` boolean attribute on the element.
 
 ```ts
-export class PfV5CoolElement extends LitElement {
+export class PfV6CoolElement extends LitElement {
   static readonly styles = [style];
 
   /** Whether the user follows this profile */
@@ -168,13 +168,13 @@ render() {
 Finally, we'll need to update our demo page (`/demo/index.html`) to include the `photo-url` attribute. Pass in an image URL to see that it's working.
 
 ```html
-<pf-v5-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
+<pf-v6-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
   Kyle Buchanan
-</pf-v5-cool-element>
+</pf-v6-cool-element>
 ```
 
-We can also modify `pf-v5-cool-element.css` to adjust the background-size property 
-on `.pf-v5-cool-element__profile`.
+We can also modify `pf-v6-cool-element.css` to adjust the background-size property 
+on `.pf-v6-cool-element__profile`.
 
 The final result should look like this:
 
@@ -186,7 +186,7 @@ That's all it takes, folks!
 To summarize, we built a web component that extends LitElement, then added an HTML template, custom styles, and interactivity.
 What's cool is that we've only scratched the surface of what's possible with custom elements and Lit.
 
-For your reference, here's the final Javascript code for `pf-v5-cool-element`:
+For your reference, here's the final Javascript code for `pf-v6-cool-element`:
 
 ```ts
 import { LitElement, html } from 'lit';
@@ -194,14 +194,14 @@ import { customElement } from 'lit/decorators/custom-element.js';
 import { property } from 'lit/decorators/property.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import styles from './pf-v5-cool-element.css';
+import styles from './pf-v6-cool-element.css';
 
 /**
  * Cool Element
  * @slot - Place element content here
  */
-@customElement('pf-v5-cool-element')
-export class PfV5CoolElement extends LitElement {
+@customElement('pf-v6-cool-element')
+export class PfV6CoolElement extends LitElement {
   static readonly styles = [styles];
 
   /** Whether the user follows this profile */
@@ -230,7 +230,7 @@ export class PfV5CoolElement extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'pf-v5-cool-element': PfV5CoolElement;
+    'pf-v6-cool-element': PfV6CoolElement;
   }
 }
 ```

--- a/docs/docs/develop/setup.md
+++ b/docs/docs/develop/setup.md
@@ -59,14 +59,14 @@ tags:
 | --------------------- | ------------------------------------------ | --------------------------------------------------------------- |
 | `--directory`         | Output directory                           | string [default: "/path/to/patternfly-elements"] |
 | `--silent`            | Do not log anything to stdout              | boolean [default: false]                                        |
-| `-n`, `--tagName`     | Custom element tag name. e.g. `pf-v5-button`  | string                                                          |
+| `-n`, `--tagName`     | Custom element tag name. e.g. `pf-v6-button`  | string                                                          |
 | `-p`, `--packageName` | NPM package scope. e.g. `@patternfly/elements`| string                                                   |
 | `--overwrite`         | Overwrite files without prompting          | boolean [default: false]                                        |
 | `--help`              | Show help                                  | boolean                                                         |
 
 Example
 ```bash
-npm run new -- --tagName pf-v5-cool-element
+npm run new -- --tagName pf-v6-cool-element
 ```
 
 
@@ -83,11 +83,11 @@ npm run new -- --tagName pf-v5-cool-element
   - A file to write your unit tests
   - An HTML demo where you can show off your element and add examples for your development workflow
 
-  You may also add light DOM styles which can be loaded prior to [element defined](https://developer.mozilla.org/en-US/docs/Web/CSS/:defined) `pf-v5-cool-element:not(:defined){...}`. An example use case would be to avoid above the fold layout shift.  
+  You may also add light DOM styles which can be loaded prior to [element defined](https://developer.mozilla.org/en-US/docs/Web/CSS/:defined) `pf-v6-cool-element:not(:defined){...}`. An example use case would be to avoid above the fold layout shift.  
 
   The light DOM CSS file uses a standard naming convention of: 
   `{scope}-{component-name}--lightdom.css` 
-  Example: `pf-v5-cool-element--lightdom.css`.
+  Example: `pf-v6-cool-element--lightdom.css`.
 {% endband %}
 
 <a id="compile-watch-and-preview"></a>
@@ -107,7 +107,7 @@ npm run new -- --tagName pf-v5-cool-element
   Running that command launches the demo app in a new browser tab, and refreshes the page on save.
 
   From there you can navigate to the demo page of the element you're working on.
-  For example, if you want to preview the `pf-v5-card` component, then navigate in the browser to `http://localhost:8000/demo/pf-v5-card/`.
+  For example, if you want to preview the `pf-v6-card` component, then navigate in the browser to `http://localhost:8000/demo/pf-v6-card/`.
 {% endband %}
 
 {% band header="Testing" %}
@@ -123,10 +123,10 @@ npm run new -- --tagName pf-v5-cool-element
 
   ```bash
   # Run a single test in watch mode.
-  npm run test:watch --files "./elements/pf-v5-button/test/pf-v5-button.spec.ts"
+  npm run test:watch --files "./elements/pf-v6-button/test/pf-v6-button.spec.ts"
 
   # Or multiple:
-  npm run test:watch --files "./elements/pf-v5-{avatar,card,tabs}/test/*.spec.ts"
+  npm run test:watch --files "./elements/pf-v6-{avatar,card,tabs}/test/*.spec.ts"
   ```
 
   You can also run tests with a specific framework wrapper using:

--- a/docs/docs/develop/structure.md
+++ b/docs/docs/develop/structure.md
@@ -44,20 +44,20 @@ Assuming the `npm run start` command started a server on port 8080, navigate to 
 
 You're off to a good start! You have a new custom element that extends the base LitElement class.
 
-Let's take a look at the `pf-v5-cool-element.ts` file to see what we have.
+Let's take a look at the `pf-v6-cool-element.ts` file to see what we have.
 
 ```ts
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators/custom-element.js';
 
-import styles from './pf-v5-cool-element.css';
+import styles from './pf-v6-cool-element.css';
 
 /**
  * Cool Element
  * @slot - Place element content here
  */
-@customElement('pf-v5-cool-element')
-export class PfV5CoolElement extends LitElement {
+@customElement('pf-v6-cool-element')
+export class PfV6CoolElement extends LitElement {
   static readonly styles = [styles];
 
   render() {
@@ -69,7 +69,7 @@ export class PfV5CoolElement extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'pf-v5-cool-element': PfV5CoolElement;
+    'pf-v6-cool-element': PfV6CoolElement;
   }
 }
 ```
@@ -90,7 +90,7 @@ Unlike PFE 1.0's `PFElement` base class, Lit template updates (i.e. renders) are
 For example, with `PFElement` we could handle the side-effects of our actions immediately:
 
 ```js
-const element = document.querySelector('pf-v5-tabs');
+const element = document.querySelector('pf-v6-tabs');
 // Select the 2nd Tab
 element.selectIndex(1);
 // Side effects happen immediately,
@@ -102,7 +102,7 @@ const active = element.querySelector('[aria-selected="true"]');
 With `LitElement`, we must wait for our changes to apply before continuing:
 
 ```diff-js
-  const element = document.querySelector('pf-v5-tabs');
+  const element = document.querySelector('pf-v6-tabs');
   // Select the 2nd Tab
   element.selectIndex(1);
 - // Side effects happen immediately,
@@ -125,13 +125,13 @@ Decorators are a [proposed JavaScript language feature](https://github.com/tc39/
 TypeScript implements an experimental version of the decorator language feature with a slightly different internal API.
 
 ```ts
-@customElement('pf-v5-cool-element')
+@customElement('pf-v6-cool-element')
 ```
 
 Third, we import an use our component's CSS styles
 
 ```ts
-import styles from './pf-v5-cool-element.css';
+import styles from './pf-v6-cool-element.css';
 ```
 
 ```ts

--- a/docs/docs/develop/testing.md
+++ b/docs/docs/develop/testing.md
@@ -14,7 +14,7 @@ tags:
 
 {% band %}
 
-Let's write tests for `pf-v5-cool-element`.
+Let's write tests for `pf-v6-cool-element`.
 
 We rely on a few tools to ensure our element is reliable in production:
 
@@ -27,7 +27,7 @@ If you followed the [Prerequisites](/docs/develop/setup/#prerequisites) in [Setu
 
 ### Test Setup
 
-In the root of the element, there's a `/test` directory with an `pf-v5-cool-element.spec.ts` file. This file will be where we add all of our tests.
+In the root of the element, there's a `/test` directory with an `pf-v6-cool-element.spec.ts` file. This file will be where we add all of our tests.
 
 Let's add four stubs for the functionality we need to test in our test file:
 
@@ -41,26 +41,26 @@ import { expect, html } from '@open-wc/testing/index-no-side-effects.js';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
 
 // Import the element we're testing.
-import { PfV5CoolElement } from '@patternfly/elements/pf-v5-cool-element/pf-v5-cool-element.js';
+import { PfV6CoolElement } from '@patternfly/elements/pf-v6-cool-element/pf-v6-cool-element.js';
 
 // One element template, defined here, is used
 // in multiple tests. It's torn down and recreated each time.
 const template = html`
-  <pf-v5-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
+  <pf-v6-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
     Kyle Buchanan
-  </pf-v5-cool-element>
+  </pf-v6-cool-element>
 `;
 
-describe('<pf-v5-cool-element>', function() {
+describe('<pf-v6-cool-element>', function() {
   describe('simply instantiating', function() {
-    let element: PfV5CoolElement;
+    let element: PfV6CoolElement;
     it('should upgrade', async function() {
-      element = await createFixture<PfV5CoolElement>(html`<pf-v5-cool-element></pf-v5-cool-element>`);
-      const klass = customElements.get('pf-v5-cool-element');
+      element = await createFixture<PfV6CoolElement>(html`<pf-v6-cool-element></pf-v6-cool-element>`);
+      const klass = customElements.get('pf-v6-cool-element');
       expect(element)
         .to.be.an.instanceOf(klass)
         .and
-        .to.be.an.instanceOf(PfV5CoolElement);
+        .to.be.an.instanceOf(PfV6CoolElement);
     });
   });
 
@@ -78,11 +78,11 @@ describe('<pf-v5-cool-element>', function() {
 });
 ```
 
-You'll notice the `createFixture<PfV5CoolElement>(element)` function. A [test fixture](https://open-wc.org/docs/testing/helpers/#test-fixtures)
+You'll notice the `createFixture<PfV6CoolElement>(element)` function. A [test fixture](https://open-wc.org/docs/testing/helpers/#test-fixtures)
 renders a piece of HTML and injects into the DOM so that you can test the behavior of your component.
 It returns the first DOM element from the template so that you can interact with it if needed.
 For example you can call functions, look up DOM nodes or inspect the rendered HTML.
-The `<PfV5CoolElement>` part signals to TypeScript that the result of calling this function is an instance of `PfV5CoolElement`;
+The `<PfV6CoolElement>` part signals to TypeScript that the result of calling this function is an instance of `PfV6CoolElement`;
 
 Test fixtures are async to ensure rendering is properly completed.
 
@@ -93,38 +93,38 @@ Now that our setup is complete, we can start building our tests.
 
 ### Test Cases
 
-Let's build out the 'pf-v5-cool-element' tests. We'll use fixtures and `querySelector` to grab our element and include DOM API methods to interact with what we're testing.
+Let's build out the 'pf-v6-cool-element' tests. We'll use fixtures and `querySelector` to grab our element and include DOM API methods to interact with what we're testing.
 
 Here is the full JavaScript code:
 
 ```ts
 import { expect, html } from '@open-wc/testing';
 import { createFixture } from '@patternfly/pfe-tools/test/create-fixture.js';
-import { PfV5CoolElement } from '@patternfly/elements/pf-v5-cool-element/pf-v5-cool-element.js';
+import { PfV6CoolElement } from '@patternfly/elements/pf-v6-cool-element/pf-v6-cool-element.js';
 
 // One element template, defined here, is used
 // in multiple tests. It's torn down and recreated each time.
 const template = html`
-  <pf-v5-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
+  <pf-v6-cool-element photo-url="https://avatars2.githubusercontent.com/u/330256?s=400&u=de56919e816dc9f821469c2f86174f29141a896e&v=4">
     Kyle Buchanan
-  </pf-v5-cool-element>
+  </pf-v6-cool-element>
 `;
 
-describe('<pf-v5-cool-element>', function() {
+describe('<pf-v6-cool-element>', function() {
   describe('simply instantiating', function() {
-    let element: PfV5CoolElement;
+    let element: PfV6CoolElement;
 
     it('should upgrade', async function() {
-      element = await createFixture<PfV5CoolElement>(html`<pf-v5-cool-element></pf-v5-cool-element>`);
-      const klass = customElements.get('pf-v5-cool-element');
+      element = await createFixture<PfV6CoolElement>(html`<pf-v6-cool-element></pf-v6-cool-element>`);
+      const klass = customElements.get('pf-v6-cool-element');
       expect(element)
         .to.be.an.instanceOf(klass)
         .and
-        .to.be.an.instanceOf(PfV5CoolElement);
+        .to.be.an.instanceOf(PfV6CoolElement);
     });
 
     it('should allow a user to follow a profile', async function() {
-      const el = await createFixture<PfV5CoolElement>(template);
+      const el = await createFixture<PfV6CoolElement>(template);
       const button = el.shadowRoot!.querySelector('button')!;
       // Click the button.
       button.click();
@@ -151,7 +151,7 @@ describe('<pf-v5-cool-element>', function() {
     });
 
     it('should set the state to follow if the following attribute is present', async function() {
-      const el = await createFixture<PfV5CoolElement>(template);
+      const el = await createFixture<PfV6CoolElement>(template);
       const button = el.shadowRoot!.querySelector('button')!;
 
       // Manually add the follow attribute.
@@ -178,7 +178,7 @@ describe('<pf-v5-cool-element>', function() {
     });
 
     it('should set a profile pic from the photo-url attribute', async function() {
-      const el = await createFixture<PfV5CoolElement>(template);
+      const el = await createFixture<PfV6CoolElement>(template);
 
       // Grab the `photo-url` attribute.
       const photoUrlAttribute = el.getAttribute('photo-url');
@@ -198,7 +198,7 @@ describe('<pf-v5-cool-element>', function() {
 You may notice we're accessing the `shadowRoot` here, available to our element by extending `LitElement` in the definition of our element.
 You can also access content in the `<slot></slot>` of your element by using the `assignedNodes()` method.
 
-We use a slot for the username in `pf-v5-cool-element`, making it available to us in the array returned by `assignedNodes()`.
+We use a slot for the username in `pf-v6-cool-element`, making it available to us in the array returned by `assignedNodes()`.
 
 ```javascript
 shadowRoot.querySelector('slot').assignedNodes()[0].textContent.trim();
@@ -206,10 +206,10 @@ shadowRoot.querySelector('slot').assignedNodes()[0].textContent.trim();
 
 ### Run the Test
 
-Lastly, we can run the test command below to see how we did. You can focus on this specific test so you're only running the tests for `pf-v5-cool-element`.
+Lastly, we can run the test command below to see how we did. You can focus on this specific test so you're only running the tests for `pf-v6-cool-element`.
 
 ```bash
-npm run test:watch -- --files elements/**/pf-v5-cool-element.spec.ts
+npm run test:watch -- --files elements/**/pf-v6-cool-element.spec.ts
 ```
 
 This command starts up web test runner and allows us to debug our test in the browser.
@@ -229,7 +229,7 @@ Debugging the test in the browser should give you the following:
 Tests can also be run manually in browser by running the following command:
 
 ```bash
-npm run test:watch -- --files elements/**/pf-v5-cool-element.spec.ts --open```
+npm run test:watch -- --files elements/**/pf-v6-cool-element.spec.ts --open```
 
 ### Testing against Vue and React
 
@@ -238,13 +238,13 @@ Now that our vanilla JavaScript tests are passing, let's use Vue and React wrapp
 Run the same tests within React by using:
 
 ```bash
-npm run test:react --files elements/**/pf-v5-cool-element.spec.ts
+npm run test:react --files elements/**/pf-v6-cool-element.spec.ts
 ```
 
 Run the same tests within Vue with:
 
 ```bash
-npm run test:vue --files elements/**/pf-v5-cool-element.spec.ts
+npm run test:vue --files elements/**/pf-v6-cool-element.spec.ts
 ```
 
 This works exactly the same as the normal `npm run test:watch` command, the only difference is the fixture will be wrapped with React or Vue.
@@ -256,7 +256,7 @@ Finally we can run the test "ci" command which will run the following:
 3. Those same tests with Vue wrappers.
 
 ```bash
-npm run test:ci --files elements/**/pf-v5-cool-element.spec.ts
+npm run test:ci --files elements/**/pf-v6-cool-element.spec.ts
 ```
 
 ![Final test output](/images/develop/develop-testing-ci.png)
@@ -265,7 +265,7 @@ Nice! All tests are working in Chrome and with React and Vue wrappers. 🎉
 
 A quick note about the framework testing—the Vue and React tests are meant to be an initial first pass in those frameworks just to make sure that the functionality is working and that the component renders properly.
 
-That's it for testing! Now that we've created our `pf-v5-cool-element` and all of our code passes, the final step is to submit a pull request to get this merged.
+That's it for testing! Now that we've created our `pf-v6-cool-element` and all of our code passes, the final step is to submit a pull request to get this merged.
 
 <a class="cta" href="../pull-request">Next up: Open a pull request</a>
 

--- a/docs/docs/develop/troubleshooting.md
+++ b/docs/docs/develop/troubleshooting.md
@@ -19,7 +19,7 @@ tags:
 If you experience issues when using or developing with PatternFly Elements, please open an issue on [GitHub](https://github.com/patternfly/patternfly-elements/issues/new/choose).
 
 <a class="cta secondary" href="https://github.com/patternfly/patternfly-elements/issues/new/choose">
-  <pf-v5-icon icon="github" set="fab" size="md"></pf-v5-icon>
+  <pf-v6-icon icon="github" set="fab" size="md"></pf-v6-icon>
   Open an issue
 </a>
 

--- a/docs/framework-integration/index.md
+++ b/docs/framework-integration/index.md
@@ -24,7 +24,7 @@ title: Framework integration
 </header>
 
 <section id="framework">
-  <pf-v5-card color-palette="lightest" border>
+  <pf-v6-card color-palette="lightest" border>
     <h3 slot="header" class="push-bottom">
       <a href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-react-app-fe079be262ed">Using
         PatternFly Elements in your React App</a>
@@ -32,8 +32,8 @@ title: Framework integration
     <p>To get web components to work with React it’s pretty easy and straightforward. If you’d like to follow
       along, go ahead and...</p>
     <a class="cta" slot="footer" href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-react-app-fe079be262ed">Read on Medium</a>
-  </pf-v5-card>
-  <pf-v5-card color-palette="lightest" border>
+  </pf-v6-card>
+  <pf-v6-card color-palette="lightest" border>
     <h3 slot="header" class="push-bottom">
       <a href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-vue-app-340fc9a9d7e5">Using
         PatternFly Elements in your Vue App</a>
@@ -41,8 +41,8 @@ title: Framework integration
     <p>To get web components to work with Vue, it’s pretty easy and straightforward. If you’d like to follow
       along, go ahead and...</p>
     <a class="cta" slot="footer" href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-vue-app-340fc9a9d7e5">Read on Medium</a>
-  </pf-v5-card>
-  <pf-v5-card color-palette="lightest" border>
+  </pf-v6-card>
+  <pf-v6-card color-palette="lightest" border>
     <h3 slot="header" class="push-bottom">
       <a href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-angular-app-4b18b1c9c363">Using
         PatternFly Elements in your Angular App</a>
@@ -50,6 +50,6 @@ title: Framework integration
     <p>To get web components to work with Angular, there are a few steps that we need to take. If you’d like to
       follow along, go ahead and...</p>
     <a class="cta" slot="footer" href="https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-angular-app-4b18b1c9c363">Read on Medium</a>
-  </pf-v5-card>
+  </pf-v6-card>
 </section>  
 

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -128,16 +128,16 @@ tags:
   ```js
   import { useState } from "react";
 
-  import { Button } from "@patternfly/elements/react/pf-v5-button/pf-v5-button.js";
-  import { Card } from "@patternfly/elements/react/pf-v5-card/pf-v5-card.js";
-  import { Switch } from "@patternfly/elements/react/pf-v5-switch/pf-v5-switch.js";
-  import { Popover } from "@patternfly/elements/react/pf-v5-popover/pf-v5-popover.js";
-  import { Tooltip } from "@patternfly/elements/react/pf-v5-tooltip/pf-v5-tooltip.js";
+  import { Button } from "@patternfly/elements/react/pf-v6-button/pf-v6-button.js";
+  import { Card } from "@patternfly/elements/react/pf-v6-card/pf-v6-card.js";
+  import { Switch } from "@patternfly/elements/react/pf-v6-switch/pf-v6-switch.js";
+  import { Popover } from "@patternfly/elements/react/pf-v6-popover/pf-v6-popover.js";
+  import { Tooltip } from "@patternfly/elements/react/pf-v6-tooltip/pf-v6-tooltip.js";
 
   import "./App.css";
   ```
 
-  Let’s use [`pf-v5-button`][pf-v5-button] and [`pf-v5-card`][pf-v5-card] component in the 
+  Let’s use [`pf-v6-button`][pf-v6-button] and [`pf-v6-card`][pf-v6-card] component in the 
   `App` function in the `App.tsx` file to see that our Card and Button are 
   working. We are updating the local state and showing it in the UI after 
   clicking the button.
@@ -160,7 +160,7 @@ tags:
 
   ### Switch
 
-  Now we have a card and a button component, let's add [`pf-v5-switch`][pf-v5-switch] 
+  Now we have a card and a button component, let's add [`pf-v6-switch`][pf-v6-switch] 
   web component in our app. We will enable/disable the decrement button by 
   clicking on the Switch button.
 
@@ -208,7 +208,7 @@ tags:
   ### Tooltip
 
   Now we have a card, button, and switch component, let's add 
-  [`pf-v5-tooltip`][pf-v5-tooltip] web component in our app. We will show the tooltip 
+  [`pf-v6-tooltip`][pf-v6-tooltip] web component in our app. We will show the tooltip 
   text on mouseover.
 
   ```js
@@ -245,10 +245,10 @@ tags:
 <section class="band">
 
   ## Interacting with web components' APIs
-  Now we will add the [`pf-v5-popover`][pf-v5-popover] web component and open the 
+  Now we will add the [`pf-v6-popover`][pf-v6-popover] web component and open the 
   popover on the mouse over of the button. We will programmatically use the 
   `show()` and `hide()` popover methods to show and hide the popover. **Note**
-  that these are methods on the `<pf-v5-popover>` DOM object. Because React apps do
+  that these are methods on the `<pf-v6-popover>` DOM object. Because React apps do
   not interact directly with the DOM, we will need to store a ref for the popover 
   element, and call our methods on it's current element.
 
@@ -353,10 +353,10 @@ tags:
 [ce-lifecycle]: https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks
 [react-lifecycle]: https://legacy.reactjs.org/docs/state-and-lifecycle.html
 [vite]: https://vitejs.dev/guide/#scaffolding-your-first-vite-project
-[pf-v5-button]: https://patternflyelements.org/components/button/
-[pf-v5-card]: https://patternflyelements.org/components/card/
-[pf-v5-switch]: https://patternflyelements.org/components/switch/
-[pf-v5-tooltip]: https://patternflyelements.org/components/tooltip/
-[pf-v5-popover]: https://patternflyelements.org/components/popover/
+[pf-v6-button]: https://patternflyelements.org/components/button/
+[pf-v6-card]: https://patternflyelements.org/components/card/
+[pf-v6-switch]: https://patternflyelements.org/components/switch/
+[pf-v6-tooltip]: https://patternflyelements.org/components/tooltip/
+[pf-v6-popover]: https://patternflyelements.org/components/popover/
 [inng]: https://medium.com/patternfly-elements/using-patternfly-elements-web-components-in-your-angular-app-4b18b1c9c363
 [invue]: https://patternflyelements.org/framework-integration/vue/

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -41,8 +41,8 @@ tags:
 {% band header="Adding PatternFly Elements" %}
   With the setup complete, let’s add a couple of PatternFly Elements web 
   components to our application to make sure everything is hooked up properly. 
-  We’re going to add a card ([pf-v5-card](/components/card)). Later, we’ll add an 
-  accordion ([pf-v5-accordion](/components/accordion)) and some CSS to help with 
+  We’re going to add a card ([pf-v6-card](/components/card)). Later, we’ll add an 
+  accordion ([pf-v6-accordion](/components/accordion)) and some CSS to help with 
   our layout.
 
   Once again, if we were building this app locally, we’d install our 
@@ -60,7 +60,7 @@ tags:
 
   ```html
   <script>
-    import "@patternfly/elements/pf-v5-card/pf-v5-card.js";
+    import "@patternfly/elements/pf-v6-card/pf-v6-card.js";
     export default {
       name: "HelloWorld",
       props: {
@@ -71,16 +71,16 @@ tags:
   ```
 
   Let’s add some simple markup in the `template` section of the 
-  `HellowWorld.vue` file to see that our pf-v5-card is working.
+  `HellowWorld.vue` file to see that our pf-v6-card is working.
 
   ```html
   <template>
     <div>
       <h1>PatternFly Elements with Vue</h1>
-      <pf-v5-card>
+      <pf-v6-card>
         <img alt="From https://picsum.photos/" src="https://picsum.photos/id/1019/300/200">
         <p>
-          This is the light pf-v5-card and
+          This is the light pf-v6-card and
           <a href="#">a link</a>.
         </p>
         <p>
@@ -93,8 +93,8 @@ tags:
           Organically grow the holistic world view of disruptive
           innovation via workplace diversity and empowerment.
         </p>
-        <pf-v5-button slot="footer" variant="link" href="#">Learn more</pf-v5-button>
-      </pf-v5-card>
+        <pf-v6-button slot="footer" variant="link" href="#">Learn more</pf-v6-button>
+      </pf-v6-card>
     </div>
   </template>
   ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -37,7 +37,7 @@ title: Get started
   [bare module specifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#importing_modules_as_bare_names) to import the components.
 
   ```javascript
-  import '@patternfly/elements/pf-v5-card/pf-v5-card.js';
+  import '@patternfly/elements/pf-v6-card/pf-v6-card.js';
   ```
 
   ### In HTML
@@ -55,7 +55,7 @@ title: Get started
   }
   </script>
   <script type="module">
-    import "@patternfly/elements/pf-v5-card/pf-v5-card.js";
+    import "@patternfly/elements/pf-v6-card/pf-v6-card.js";
   </script>
   ```
 
@@ -65,18 +65,18 @@ title: Get started
   When you have the import map script loaded on the page, you can add a [card component](/components/card) using html.
 
   ```html
-  <pf-v5-card>
+  <pf-v6-card>
     <h3 slot="header">Card header</h3>
-    <p>This is the pf-v5-card body.</p>
-    <pf-v5-button slot="footer">OK</pf-v5-button>
-  </pf-v5-card>
+    <p>This is the pf-v6-card body.</p>
+    <pf-v6-button slot="footer">OK</pf-v6-button>
+  </pf-v6-card>
   ```
 
-  <pf-v5-card>
+  <pf-v6-card>
     <h3 slot="header">Card header</h3>
-    <p>This is the pf-v5-card body.</p>
-    <pf-v5-button slot="footer">OK</pf-v5-button>
-  </pf-v5-card>
+    <p>This is the pf-v6-card body.</p>
+    <pf-v6-button slot="footer">OK</pf-v6-button>
+  </pf-v6-card>
 
 ### Importmap and Markup
 
@@ -91,18 +91,18 @@ Altogether your import map code could look something like this [Lit Playground D
   component to see which attributes are available.
 
   ```html
-  <pf-v5-card rounded>
+  <pf-v6-card rounded>
     <h3 slot="header">Card header</h3>
-    <p>This is the pf-v5-card body.</p>
-    <pf-v5-button slot="footer">OK</pf-v5-button>
-  </pf-v5-card>
+    <p>This is the pf-v6-card body.</p>
+    <pf-v6-button slot="footer">OK</pf-v6-button>
+  </pf-v6-card>
   ```
 
-  <pf-v5-card rounded>
+  <pf-v6-card rounded>
     <h3 slot="header">Card header</h3>
-    <p>This is the pf-v5-card body.</p>
-    <pf-v5-button slot="footer">OK</pf-v5-button>
-  </pf-v5-card>
+    <p>This is the pf-v6-card body.</p>
+    <pf-v6-button slot="footer">OK</pf-v6-button>
+  </pf-v6-card>
 {% endband %}
 
 {% band header="Use CSS variables to customize or theme your components" %}
@@ -116,14 +116,14 @@ Altogether your import map code could look something like this [Lit Playground D
   ```css
   /* your-page.css */
   :root {
-    --pf-v5-c-card--BackgroundColor: var(--pf-global--active-color--200, #bee1f4);
+    --pf-v6-c-card--BackgroundColor: var(--pf-global--active-color--200, #bee1f4);
   }
   ```
-  <pf-v5-card flat rounded style="--pf-v5-c-card--BackgroundColor: var(--pf-global--active-color--200, #bee1f4);">
+  <pf-v6-card flat rounded style="--pf-v6-c-card--BackgroundColor: var(--pf-global--active-color--200, #bee1f4);">
     <h3 slot="header">Card header</h3>
-    <p>This is the pf-v5-card body.</p>
-    <pf-v5-button slot="footer">OK</pf-v5-button>
-  </pf-v5-card>
+    <p>This is the pf-v6-card body.</p>
+    <pf-v6-button slot="footer">OK</pf-v6-button>
+  </pf-v6-card>
 {% endband %}
 
 {% band header="Avoiding the flash of unstyled content (FOUC)" %}
@@ -148,12 +148,12 @@ Altogether your import map code could look something like this [Lit Playground D
         --reveal-duration: 0.2s;
       }
 
-      pf-v5-card {
+      pf-v6-card {
         opacity: 1;
         transition: opacity var(--reveal-duration) ease var(--reveal-delay);
       }
 
-      pf-v5-card:not(:defined) {
+      pf-v6-card:not(:defined) {
         opacity: 0;
       }
     </style>
@@ -161,18 +161,18 @@ Altogether your import map code could look something like this [Lit Playground D
     <!-- Add noscript styles to immediately reveal content when JavaScript is disabled -->
     <noscript>
       <style>
-        pf-v5-card:not(:defined) {
+        pf-v6-card:not(:defined) {
           opacity: 1;
         }
       </style>
     </noscript>
-    <script type="module" src="https://jspm.dev/@patternfly/elements/pf-v5-card/pf-v5-card.js"></script>
+    <script type="module" src="https://jspm.dev/@patternfly/elements/pf-v6-card/pf-v6-card.js"></script>
   </head>
   <body>
-    <pf-v5-card>
+    <pf-v6-card>
       <h1 slot="header">No FOUC</h1>
       <p>Content will remain hidden until component definitions are loaded.</p>
-    </pf-v5-card>
+    </pf-v6-card>
   </body>
   </html>
   ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,27 +31,27 @@ description: A set of community-created web components based on PatternFly desig
 
       {% renderFile "./docs/_snippets/card-html.md" %}
 
-      <pf-v5-card border>
+      <pf-v6-card border>
         <h2 slot="header">Card component</h2>
         <p>PatternFly Elements are custom HTML elements that work everywhere.
           The Card element has <code>header</code> and <code>footer</code> slots for things like
           titles and actions.
         </p>
-        <a class="cta" slot="footer" href="components/card">More about <code>pf-v5-card</code></a>
-      </pf-v5-card>
+        <a class="cta" slot="footer" href="components/card">More about <code>pf-v6-card</code></a>
+      </pf-v6-card>
 
       <a class="cta" href="components/">View the rest of the components</a>
 
-      <pf-v5-progress-stepper vertical>
-        <pf-v5-progress-step description="Use NPM or load PatternFly Elements directly via CDN"
-                          variant="success">Install</pf-v5-progress-step>
-        <pf-v5-progress-step description="Craft pages and apps using our HTML, CSS, and JS APIs"
-                          variant="info">Build Your UI</pf-v5-progress-step>
-        <pf-v5-progress-step description="Ship performant, accessible products"
+      <pf-v6-progress-stepper vertical>
+        <pf-v6-progress-step description="Use NPM or load PatternFly Elements directly via CDN"
+                          variant="success">Install</pf-v6-progress-step>
+        <pf-v6-progress-step description="Craft pages and apps using our HTML, CSS, and JS APIs"
+                          variant="info">Build Your UI</pf-v6-progress-step>
+        <pf-v6-progress-step description="Ship performant, accessible products"
                           variant="success"
                           current
-                          icon="optimize" icon-set="patternfly">Ship!</pf-v5-progress-step>
-      </pf-v5-progress-stepper>
+                          icon="optimize" icon-set="patternfly">Ship!</pf-v6-progress-step>
+      </pf-v6-progress-stepper>
     </section>
 
     <section id="univ" class="band base">
@@ -60,43 +60,43 @@ description: A set of community-created web components based on PatternFly desig
         <header>
           <p class="tagline">Integrate PatternFly Elements with your framework of choice or use them by themselves.</p>
           <p>PatternFly Elements integrate seamlessly with multiple frontend frameworks. Just install it
-            with <pf-v5-clipboard-copy inline compact code>npm install @patternfly/elements</pf-v5-clipboard-copy>,
+            with <pf-v6-clipboard-copy inline compact code>npm install @patternfly/elements</pf-v6-clipboard-copy>,
             or use PatternFly Elements on their own without a framework.
             It's up to you and the needs of your project.</p>
         </header>
 
 
-        <pf-v5-tabs>
-          <pf-v5-tab slot="tab">HTML<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M108.4 0h23v22.8h21.2V0h23v69h-23V46h-21v23h-23.2M206 23h-20.3V0h63.7v23H229v46h-23m53.5-69h24.1l14.8 24.3L313.2 0h24.1v69h-23V34.8l-16.1 24.8-16.1-24.8V69h-22.6m89.2-69h23v46.2h32.6V69h-55.6"/><path fill="#e44d26" d="m107.6 471-33-370.4h362.8l-33 370.2L255.7 512"/><path fill="#f16529" d="M256 480.5V131h148.3L376 447"/><path fill="#ebebeb" d="M142 176.3h114v45.4h-64.2l4.2 46.5h60v45.3H154.4m2 22.8H202l3.2 36.3 50.8 13.6v47.4l-93.2-26"/><path fill="#fff" d="M369.6 176.3H255.8v45.4h109.6m-4.1 46.5H255.8v45.4h56l-5.3 59-50.7 13.6v47.2l93-25.8"/></svg></pf-v5-tab>
-          <pf-v5-tab-panel>{% renderFile "./docs/_snippets/accordion-html.md" %}</pf-v5-tab-panel>
+        <pf-v6-tabs>
+          <pf-v6-tab slot="tab">HTML<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M108.4 0h23v22.8h21.2V0h23v69h-23V46h-21v23h-23.2M206 23h-20.3V0h63.7v23H229v46h-23m53.5-69h24.1l14.8 24.3L313.2 0h24.1v69h-23V34.8l-16.1 24.8-16.1-24.8V69h-22.6m89.2-69h23v46.2h32.6V69h-55.6"/><path fill="#e44d26" d="m107.6 471-33-370.4h362.8l-33 370.2L255.7 512"/><path fill="#f16529" d="M256 480.5V131h148.3L376 447"/><path fill="#ebebeb" d="M142 176.3h114v45.4h-64.2l4.2 46.5h60v45.3H154.4m2 22.8H202l3.2 36.3 50.8 13.6v47.4l-93.2-26"/><path fill="#fff" d="M369.6 176.3H255.8v45.4h109.6m-4.1 46.5H255.8v45.4h56l-5.3 59-50.7 13.6v47.2l93-25.8"/></svg></pf-v6-tab>
+          <pf-v6-tab-panel>{% renderFile "./docs/_snippets/accordion-html.md" %}</pf-v6-tab-panel>
 
-          <pf-v5-tab slot="tab">React<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 841.9 595.3"><g fill="#61DAFB"><path d="M666.3 296.5c0-32.5-40.7-63.3-103.1-82.4 14.4-63.6 8-114.2-20.2-130.4-6.5-3.8-14.1-5.6-22.4-5.6v22.3c4.6 0 8.3.9 11.4 2.6 13.6 7.8 19.5 37.5 14.9 75.7-1.1 9.4-2.9 19.3-5.1 29.4-19.6-4.8-41-8.5-63.5-10.9-13.5-18.5-27.5-35.3-41.6-50 32.6-30.3 63.2-46.9 84-46.9V78c-27.5 0-63.5 19.6-99.9 53.6-36.4-33.8-72.4-53.2-99.9-53.2v22.3c20.7 0 51.4 16.5 84 46.6-14 14.7-28 31.4-41.3 49.9-22.6 2.4-44 6.1-63.6 11-2.3-10-4-19.7-5.2-29-4.7-38.2 1.1-67.9 14.6-75.8 3-1.8 6.9-2.6 11.5-2.6V78.5c-8.4 0-16 1.8-22.6 5.6-28.1 16.2-34.4 66.7-19.9 130.1-62.2 19.2-102.7 49.9-102.7 82.3 0 32.5 40.7 63.3 103.1 82.4-14.4 63.6-8 114.2 20.2 130.4 6.5 3.8 14.1 5.6 22.5 5.6 27.5 0 63.5-19.6 99.9-53.6 36.4 33.8 72.4 53.2 99.9 53.2 8.4 0 16-1.8 22.6-5.6 28.1-16.2 34.4-66.7 19.9-130.1 62-19.1 102.5-49.9 102.5-82.3zm-130.2-66.7c-3.7 12.9-8.3 26.2-13.5 39.5-4.1-8-8.4-16-13.1-24-4.6-8-9.5-15.8-14.4-23.4 14.2 2.1 27.9 4.7 41 7.9zm-45.8 106.5c-7.8 13.5-15.8 26.3-24.1 38.2-14.9 1.3-30 2-45.2 2-15.1 0-30.2-.7-45-1.9-8.3-11.9-16.4-24.6-24.2-38-7.6-13.1-14.5-26.4-20.8-39.8 6.2-13.4 13.2-26.8 20.7-39.9 7.8-13.5 15.8-26.3 24.1-38.2 14.9-1.3 30-2 45.2-2 15.1 0 30.2.7 45 1.9 8.3 11.9 16.4 24.6 24.2 38 7.6 13.1 14.5 26.4 20.8 39.8-6.3 13.4-13.2 26.8-20.7 39.9zm32.3-13c5.4 13.4 10 26.8 13.8 39.8-13.1 3.2-26.9 5.9-41.2 8 4.9-7.7 9.8-15.6 14.4-23.7 4.6-8 8.9-16.1 13-24.1zM421.2 430c-9.3-9.6-18.6-20.3-27.8-32 9 .4 18.2.7 27.5.7 9.4 0 18.7-.2 27.8-.7-9 11.7-18.3 22.4-27.5 32zm-74.4-58.9c-14.2-2.1-27.9-4.7-41-7.9 3.7-12.9 8.3-26.2 13.5-39.5 4.1 8 8.4 16 13.1 24 4.7 8 9.5 15.8 14.4 23.4zM420.7 163c9.3 9.6 18.6 20.3 27.8 32-9-.4-18.2-.7-27.5-.7-9.4 0-18.7.2-27.8.7 9-11.7 18.3-22.4 27.5-32zm-74 58.9c-4.9 7.7-9.8 15.6-14.4 23.7-4.6 8-8.9 16-13 24-5.4-13.4-10-26.8-13.8-39.8 13.1-3.1 26.9-5.8 41.2-7.9zm-90.5 125.2c-35.4-15.1-58.3-34.9-58.3-50.6 0-15.7 22.9-35.6 58.3-50.6 8.6-3.7 18-7 27.7-10.1 5.7 19.6 13.2 40 22.5 60.9-9.2 20.8-16.6 41.1-22.2 60.6-9.9-3.1-19.3-6.5-28-10.2zM310 490c-13.6-7.8-19.5-37.5-14.9-75.7 1.1-9.4 2.9-19.3 5.1-29.4 19.6 4.8 41 8.5 63.5 10.9 13.5 18.5 27.5 35.3 41.6 50-32.6 30.3-63.2 46.9-84 46.9-4.5-.1-8.3-1-11.3-2.7zm237.2-76.2c4.7 38.2-1.1 67.9-14.6 75.8-3 1.8-6.9 2.6-11.5 2.6-20.7 0-51.4-16.5-84-46.6 14-14.7 28-31.4 41.3-49.9 22.6-2.4 44-6.1 63.6-11 2.3 10.1 4.1 19.8 5.2 29.1zm38.5-66.7c-8.6 3.7-18 7-27.7 10.1-5.7-19.6-13.2-40-22.5-60.9 9.2-20.8 16.6-41.1 22.2-60.6 9.9 3.1 19.3 6.5 28.1 10.2 35.4 15.1 58.3 34.9 58.3 50.6-.1 15.7-23 35.6-58.4 50.6zM320.8 78.4z"/><circle cx="420.9" cy="296.5" r="45.7"/><path d="M520.5 78.1z"/></g></svg></pf-v5-tab>
-          <pf-v5-tab-panel>{% renderFile "./docs/_snippets/accordion-jsx.md" %}</pf-v5-tab-panel>
+          <pf-v6-tab slot="tab">React<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 841.9 595.3"><g fill="#61DAFB"><path d="M666.3 296.5c0-32.5-40.7-63.3-103.1-82.4 14.4-63.6 8-114.2-20.2-130.4-6.5-3.8-14.1-5.6-22.4-5.6v22.3c4.6 0 8.3.9 11.4 2.6 13.6 7.8 19.5 37.5 14.9 75.7-1.1 9.4-2.9 19.3-5.1 29.4-19.6-4.8-41-8.5-63.5-10.9-13.5-18.5-27.5-35.3-41.6-50 32.6-30.3 63.2-46.9 84-46.9V78c-27.5 0-63.5 19.6-99.9 53.6-36.4-33.8-72.4-53.2-99.9-53.2v22.3c20.7 0 51.4 16.5 84 46.6-14 14.7-28 31.4-41.3 49.9-22.6 2.4-44 6.1-63.6 11-2.3-10-4-19.7-5.2-29-4.7-38.2 1.1-67.9 14.6-75.8 3-1.8 6.9-2.6 11.5-2.6V78.5c-8.4 0-16 1.8-22.6 5.6-28.1 16.2-34.4 66.7-19.9 130.1-62.2 19.2-102.7 49.9-102.7 82.3 0 32.5 40.7 63.3 103.1 82.4-14.4 63.6-8 114.2 20.2 130.4 6.5 3.8 14.1 5.6 22.5 5.6 27.5 0 63.5-19.6 99.9-53.6 36.4 33.8 72.4 53.2 99.9 53.2 8.4 0 16-1.8 22.6-5.6 28.1-16.2 34.4-66.7 19.9-130.1 62-19.1 102.5-49.9 102.5-82.3zm-130.2-66.7c-3.7 12.9-8.3 26.2-13.5 39.5-4.1-8-8.4-16-13.1-24-4.6-8-9.5-15.8-14.4-23.4 14.2 2.1 27.9 4.7 41 7.9zm-45.8 106.5c-7.8 13.5-15.8 26.3-24.1 38.2-14.9 1.3-30 2-45.2 2-15.1 0-30.2-.7-45-1.9-8.3-11.9-16.4-24.6-24.2-38-7.6-13.1-14.5-26.4-20.8-39.8 6.2-13.4 13.2-26.8 20.7-39.9 7.8-13.5 15.8-26.3 24.1-38.2 14.9-1.3 30-2 45.2-2 15.1 0 30.2.7 45 1.9 8.3 11.9 16.4 24.6 24.2 38 7.6 13.1 14.5 26.4 20.8 39.8-6.3 13.4-13.2 26.8-20.7 39.9zm32.3-13c5.4 13.4 10 26.8 13.8 39.8-13.1 3.2-26.9 5.9-41.2 8 4.9-7.7 9.8-15.6 14.4-23.7 4.6-8 8.9-16.1 13-24.1zM421.2 430c-9.3-9.6-18.6-20.3-27.8-32 9 .4 18.2.7 27.5.7 9.4 0 18.7-.2 27.8-.7-9 11.7-18.3 22.4-27.5 32zm-74.4-58.9c-14.2-2.1-27.9-4.7-41-7.9 3.7-12.9 8.3-26.2 13.5-39.5 4.1 8 8.4 16 13.1 24 4.7 8 9.5 15.8 14.4 23.4zM420.7 163c9.3 9.6 18.6 20.3 27.8 32-9-.4-18.2-.7-27.5-.7-9.4 0-18.7.2-27.8.7 9-11.7 18.3-22.4 27.5-32zm-74 58.9c-4.9 7.7-9.8 15.6-14.4 23.7-4.6 8-8.9 16-13 24-5.4-13.4-10-26.8-13.8-39.8 13.1-3.1 26.9-5.8 41.2-7.9zm-90.5 125.2c-35.4-15.1-58.3-34.9-58.3-50.6 0-15.7 22.9-35.6 58.3-50.6 8.6-3.7 18-7 27.7-10.1 5.7 19.6 13.2 40 22.5 60.9-9.2 20.8-16.6 41.1-22.2 60.6-9.9-3.1-19.3-6.5-28-10.2zM310 490c-13.6-7.8-19.5-37.5-14.9-75.7 1.1-9.4 2.9-19.3 5.1-29.4 19.6 4.8 41 8.5 63.5 10.9 13.5 18.5 27.5 35.3 41.6 50-32.6 30.3-63.2 46.9-84 46.9-4.5-.1-8.3-1-11.3-2.7zm237.2-76.2c4.7 38.2-1.1 67.9-14.6 75.8-3 1.8-6.9 2.6-11.5 2.6-20.7 0-51.4-16.5-84-46.6 14-14.7 28-31.4 41.3-49.9 22.6-2.4 44-6.1 63.6-11 2.3 10.1 4.1 19.8 5.2 29.1zm38.5-66.7c-8.6 3.7-18 7-27.7 10.1-5.7-19.6-13.2-40-22.5-60.9 9.2-20.8 16.6-41.1 22.2-60.6 9.9 3.1 19.3 6.5 28.1 10.2 35.4 15.1 58.3 34.9 58.3 50.6-.1 15.7-23 35.6-58.4 50.6zM320.8 78.4z"/><circle cx="420.9" cy="296.5" r="45.7"/><path d="M520.5 78.1z"/></g></svg></pf-v6-tab>
+          <pf-v6-tab-panel>{% renderFile "./docs/_snippets/accordion-jsx.md" %}</pf-v6-tab-panel>
 
-          <pf-v5-tab slot="tab">Vue<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 261.76 226.69"><path fill="#41b883" d="m161.096.001-30.224 52.35L100.647.002H-.005L130.872 226.69 261.749 0z"/><path fill="#34495e" d="m161.096.001-30.224 52.35L100.647.002H52.346l78.526 136.01L209.398.001z"/></svg></pf-v5-tab>
-          <pf-v5-tab-panel>{% renderFile "./docs/_snippets/accordion-vue.md" %}</pf-v5-tab-panel>
+          <pf-v6-tab slot="tab">Vue<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 261.76 226.69"><path fill="#41b883" d="m161.096.001-30.224 52.35L100.647.002H-.005L130.872 226.69 261.749 0z"/><path fill="#34495e" d="m161.096.001-30.224 52.35L100.647.002H52.346l78.526 136.01L209.398.001z"/></svg></pf-v6-tab>
+          <pf-v6-tab-panel>{% renderFile "./docs/_snippets/accordion-vue.md" %}</pf-v6-tab-panel>
 
-          <pf-v5-tab slot="tab">Angular<svg slot="icon" xmlns="http://www.w3.org/2000/svg" style="enable-background:new 0 0 250 250" viewBox="0 0 250 250"><path d="M125 30 31.9 63.2l14.2 123.1L125 230l78.9-43.7 14.2-123.1z" style="fill:#dd0031"/><path d="M125 30v22.2-.1V230l78.9-43.7 14.2-123.1L125 30z" style="fill:#c3002f"/><path d="M125 52.1 66.8 182.6h21.7l11.7-29.2h49.4l11.7 29.2H183L125 52.1zm17 83.3h-34l17-40.9 17 40.9z" style="fill:#fff"/></svg></pf-v5-tab>
-          <pf-v5-tab-panel>{% renderFile "./docs/_snippets/accordion-ng.md" %}</pf-v5-tab-panel>
+          <pf-v6-tab slot="tab">Angular<svg slot="icon" xmlns="http://www.w3.org/2000/svg" style="enable-background:new 0 0 250 250" viewBox="0 0 250 250"><path d="M125 30 31.9 63.2l14.2 123.1L125 230l78.9-43.7 14.2-123.1z" style="fill:#dd0031"/><path d="M125 30v22.2-.1V230l78.9-43.7 14.2-123.1L125 30z" style="fill:#c3002f"/><path d="M125 52.1 66.8 182.6h21.7l11.7-29.2h49.4l11.7 29.2H183L125 52.1zm17 83.3h-34l17-40.9 17 40.9z" style="fill:#fff"/></svg></pf-v6-tab>
+          <pf-v6-tab-panel>{% renderFile "./docs/_snippets/accordion-ng.md" %}</pf-v6-tab-panel>
 
-          <pf-v5-tab slot="tab">Svelte<svg slot="icon" xmlns="http://www.w3.org/2000/svg" style="enable-background:new 0 0 98.1 118" viewBox="0 0 98.1 118"><path d="M91.8 15.6C80.9-.1 59.2-4.7 43.6 5.2L16.1 22.8C8.6 27.5 3.4 35.2 1.9 43.9c-1.3 7.3-.2 14.8 3.3 21.3-2.4 3.6-4 7.6-4.7 11.8-1.6 8.9.5 18.1 5.7 25.4 11 15.7 32.6 20.3 48.2 10.4l27.5-17.5c7.5-4.7 12.7-12.4 14.2-21.1 1.3-7.3.2-14.8-3.3-21.3 2.4-3.6 4-7.6 4.7-11.8 1.7-9-.4-18.2-5.7-25.5" style="fill:#ff3e00"/><path d="M40.9 103.9c-8.9 2.3-18.2-1.2-23.4-8.7-3.2-4.4-4.4-9.9-3.5-15.3.2-.9.4-1.7.6-2.6l.5-1.6 1.4 1c3.3 2.4 6.9 4.2 10.8 5.4l1 .3-.1 1c-.1 1.4.3 2.9 1.1 4.1 1.6 2.3 4.4 3.4 7.1 2.7.6-.2 1.2-.4 1.7-.7L65.5 72c1.4-.9 2.3-2.2 2.6-3.8.3-1.6-.1-3.3-1-4.6-1.6-2.3-4.4-3.3-7.1-2.6-.6.2-1.2.4-1.7.7l-10.5 6.7c-1.7 1.1-3.6 1.9-5.6 2.4-8.9 2.3-18.2-1.2-23.4-8.7-3.1-4.4-4.4-9.9-3.4-15.3.9-5.2 4.1-9.9 8.6-12.7l27.5-17.5c1.7-1.1 3.6-1.9 5.6-2.5 8.9-2.3 18.2 1.2 23.4 8.7 3.2 4.4 4.4 9.9 3.5 15.3-.2.9-.4 1.7-.7 2.6l-.5 1.6-1.4-1c-3.3-2.4-6.9-4.2-10.8-5.4l-1-.3.1-1c.1-1.4-.3-2.9-1.1-4.1-1.6-2.3-4.4-3.3-7.1-2.6-.6.2-1.2.4-1.7.7L32.4 46.1c-1.4.9-2.3 2.2-2.6 3.8s.1 3.3 1 4.6c1.6 2.3 4.4 3.3 7.1 2.6.6-.2 1.2-.4 1.7-.7l10.5-6.7c1.7-1.1 3.6-1.9 5.6-2.5 8.9-2.3 18.2 1.2 23.4 8.7 3.2 4.4 4.4 9.9 3.5 15.3-.9 5.2-4.1 9.9-8.6 12.7l-27.5 17.5c-1.7 1.1-3.6 1.9-5.6 2.5" style="fill:#fff"/></svg></pf-v5-tab>
-          <pf-v5-tab-panel>{% renderFile "./docs/_snippets/accordion-svelte.md" %}</pf-v5-tab-panel>
-        </pf-v5-tabs>
+          <pf-v6-tab slot="tab">Svelte<svg slot="icon" xmlns="http://www.w3.org/2000/svg" style="enable-background:new 0 0 98.1 118" viewBox="0 0 98.1 118"><path d="M91.8 15.6C80.9-.1 59.2-4.7 43.6 5.2L16.1 22.8C8.6 27.5 3.4 35.2 1.9 43.9c-1.3 7.3-.2 14.8 3.3 21.3-2.4 3.6-4 7.6-4.7 11.8-1.6 8.9.5 18.1 5.7 25.4 11 15.7 32.6 20.3 48.2 10.4l27.5-17.5c7.5-4.7 12.7-12.4 14.2-21.1 1.3-7.3.2-14.8-3.3-21.3 2.4-3.6 4-7.6 4.7-11.8 1.7-9-.4-18.2-5.7-25.5" style="fill:#ff3e00"/><path d="M40.9 103.9c-8.9 2.3-18.2-1.2-23.4-8.7-3.2-4.4-4.4-9.9-3.5-15.3.2-.9.4-1.7.6-2.6l.5-1.6 1.4 1c3.3 2.4 6.9 4.2 10.8 5.4l1 .3-.1 1c-.1 1.4.3 2.9 1.1 4.1 1.6 2.3 4.4 3.4 7.1 2.7.6-.2 1.2-.4 1.7-.7L65.5 72c1.4-.9 2.3-2.2 2.6-3.8.3-1.6-.1-3.3-1-4.6-1.6-2.3-4.4-3.3-7.1-2.6-.6.2-1.2.4-1.7.7l-10.5 6.7c-1.7 1.1-3.6 1.9-5.6 2.4-8.9 2.3-18.2-1.2-23.4-8.7-3.1-4.4-4.4-9.9-3.4-15.3.9-5.2 4.1-9.9 8.6-12.7l27.5-17.5c1.7-1.1 3.6-1.9 5.6-2.5 8.9-2.3 18.2 1.2 23.4 8.7 3.2 4.4 4.4 9.9 3.5 15.3-.2.9-.4 1.7-.7 2.6l-.5 1.6-1.4-1c-3.3-2.4-6.9-4.2-10.8-5.4l-1-.3.1-1c.1-1.4-.3-2.9-1.1-4.1-1.6-2.3-4.4-3.3-7.1-2.6-.6.2-1.2.4-1.7.7L32.4 46.1c-1.4.9-2.3 2.2-2.6 3.8s.1 3.3 1 4.6c1.6 2.3 4.4 3.3 7.1 2.6.6-.2 1.2-.4 1.7-.7l10.5-6.7c1.7-1.1 3.6-1.9 5.6-2.5 8.9-2.3 18.2 1.2 23.4 8.7 3.2 4.4 4.4 9.9 3.5 15.3-.9 5.2-4.1 9.9-8.6 12.7l-27.5 17.5c-1.7 1.1-3.6 1.9-5.6 2.5" style="fill:#fff"/></svg></pf-v6-tab>
+          <pf-v6-tab-panel>{% renderFile "./docs/_snippets/accordion-svelte.md" %}</pf-v6-tab-panel>
+        </pf-v6-tabs>
 
-        <pf-v5-accordion>
-          <pf-v5-accordion-header expanded>
+        <pf-v6-accordion>
+          <pf-v6-accordion-header expanded>
             <h3>Getting Started</h3>
-          </pf-v5-accordion-header>
-          <pf-v5-accordion-panel>
+          </pf-v6-accordion-header>
+          <pf-v6-accordion-panel>
             <p>Read our <a href="/get-started/">Getting started</a> page to learn how to install and use PatternFly Elements.</p>
-          </pf-v5-accordion-panel>
-          <pf-v5-accordion-header>
+          </pf-v6-accordion-panel>
+          <pf-v6-accordion-header>
             <h3>HTML APIs</h3>
-          </pf-v5-accordion-header>
-          <pf-v5-accordion-panel>
+          </pf-v6-accordion-header>
+          <pf-v6-accordion-panel>
             <p>For more information on how to use each PatternFly element, read the <a href="/components/">component docs</a>.</p>
-          </pf-v5-accordion-panel>
-        </pf-v5-accordion>
+          </pf-v6-accordion-panel>
+        </pf-v6-accordion>
 
         <a class="cta" href="{{ '/framework-integration/' | url }}">Learn how to integrate PatternFly Elements in your application</a>
       </div>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -58,69 +58,69 @@ production.
   <main>
     <section class="band">
       <h2>Card components</h2>
-      <pf-v5-card>
+      <pf-v6-card>
         <h3 slot="header">Card 1</h3>
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis laboriosam eum saepe eius tempora sequi eligendi repudiandae aspernatur beatae totam voluptatum facere unde, vitae inventore eveniet accusamus nulla recusandae aliquam.</p>
         <a slot="footer" class="cta primary" href="https://patternflyelements.org">More about PatternFly Elements</a>
-      </pf-v5-card>
-      <pf-v5-card>
+      </pf-v6-card>
+      <pf-v6-card>
         <h3 slot="header">Card 2</h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque necessitatibus sapiente aliquam recusandae maxime consectetur magnam ipsa veniam expedita molestiae. Quis officia minima libero repellat laboriosam sit nemo porro laborum.</p>
         <a class="cta" slot="footer" href="https://patternflyelements.org/get-started">Get started</a>
-      </pf-v5-card>
-      <pf-v5-card>
+      </pf-v6-card>
+      <pf-v6-card>
         <h3 slot="header">Card 3</h3>
         <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Voluptate iusto laboriosam molestias, quidem ab voluptates nihil earum sed! Esse repellat quo ut numquam mollitia quis saepe aspernatur fuga error in!</p>
         <a class="cta" slot="footer" href="https://developer.mozilla.org/en-US/docs/Web/Web_Components">About web components</a>
-      </pf-v5-card>
+      </pf-v6-card>
       <a class="cta" slot="footer" href="https://patternflyelements.org/components">View all of the components</a>
     </section>
     <section>
       <h2>Accordion component</h2>
-      <pf-v5-accordion>
-        <pf-v5-accordion-header>
+      <pf-v6-accordion>
+        <pf-v6-accordion-header>
           <h3>Why do wizards need money if they could just create it?</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p>There is legislation that decides what you can conjure and what you can not. Because things that you conjure out of thin air will not last, it is illegal in the wizarding world.</p>
-        </pf-v5-accordion-panel>
-        <pf-v5-accordion-header>
+        </pf-v6-accordion-panel>
+        <pf-v6-accordion-header>
           <h3>Why doesn't Harry have a portrait of his parents?</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p><a href="#">The characters in the portraits</a> are not actually ghosts. They mainly are there just to repeat common phrases or serve as a general <a href="foobarbaz.com">representation of the individual</a> they depict. A portrait of his parents would not be of much help to Harry.</p>
-        </pf-v5-accordion-panel>
-        <pf-v5-accordion-header>
+        </pf-v6-accordion-panel>
+        <pf-v6-accordion-header>
           <h3>Why is Harry considered a half-blood if both of his parents could use magic?</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p>Because Harry's grandparents were not able to do magic. This is generally frowned upon by those who consider themselves pure, such as the Malfoy's or other antagonists.</p>
-        </pf-v5-accordion-panel>
-        <pf-v5-accordion-header>
+        </pf-v6-accordion-panel>
+        <pf-v6-accordion-header>
           <h3>Is Hogwarts the only wizarding school?</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p>No! It has been revealed that there are actually 11 long established and prestigious schools around the globe. These include Castelobruxo in the rainforest of Brazil, Durmstrang Institute (whereas nobody is certain of it’s whereabouts), and Ilvermorny, right here in the United States.</p>
-        </pf-v5-accordion-panel>
-        <pf-v5-accordion-header>
+        </pf-v6-accordion-panel>
+        <pf-v6-accordion-header>
           <h3>Where do the main characters work as adults?</h3>
-        </pf-v5-accordion-header>
-        <pf-v5-accordion-panel>
+        </pf-v6-accordion-header>
+        <pf-v6-accordion-panel>
           <p>Harry and Hermione are at the Ministry: he ends up leading the Auror department. Ron helps George at the joke shop and does very well. Ginny becomes a professional Quidditch player and then sportswriter for the Daily Prophet.</p>
           <p><a href="https://www.pottermore.com/collection/characters" target="blank">Read more about the characters</a></p>
-        </pf-v5-accordion-panel>
-      </pf-v5-accordion>
+        </pf-v6-accordion-panel>
+      </pf-v6-accordion>
     </section>
     <section>
       <h2>Tabs component</h2>
-      <pf-v5-tabs>
-        <pf-v5-tab slot="tab">Users</pf-v5-tab>
-        <pf-v5-tab-panel>Users</pf-v5-tab-panel>
-        <pf-v5-tab slot="tab" active>Containers</pf-v5-tab>
-        <pf-v5-tab-panel>Containers</pf-v5-tab-panel>
-        <pf-v5-tab slot="tab">Database</pf-v5-tab>
-        <pf-v5-tab-panel>Database</pf-v5-tab-panel>
-      </pf-v5-tabs>
+      <pf-v6-tabs>
+        <pf-v6-tab slot="tab">Users</pf-v6-tab>
+        <pf-v6-tab-panel>Users</pf-v6-tab-panel>
+        <pf-v6-tab slot="tab" active>Containers</pf-v6-tab>
+        <pf-v6-tab-panel>Containers</pf-v6-tab-panel>
+        <pf-v6-tab slot="tab">Database</pf-v6-tab>
+        <pf-v6-tab-panel>Database</pf-v6-tab-panel>
+      </pf-v6-tabs>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary

### Phase 0.3

- Replace all `pf-v5-*` element references with `pf-v6-*` across the docs site
- Updated 26 files: HTML templates, framework integration guides, developer docs, and code snippets
- Zero remaining `pf-v5` or `PfV5` references in the docs directory

Closes #3131