### PR TITLE
chore(deps): bump @pwrs/cem to 0.10.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@lit/react": "^1.0.8",
         "@octokit/core": "^6.1.2",
         "@patternfly/patternfly": "^4.224.5",
-        "@pwrs/cem": "^0.10.4",
+        "@pwrs/cem": "^0.10.5",
         "@pwrs/mappa": "^0.0.6",
         "@rhds/elements": "^4.0.1",
         "@types/koa__router": "^12.0.5",
@@ -50,10 +50,10 @@
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "^0.27.2",
         "@esbuild/linux-x64": "^0.27.2",
-        "@pwrs/cem-darwin-arm64": "^0.10.3",
-        "@pwrs/cem-darwin-x64": "^0.10.3",
-        "@pwrs/cem-linux-arm64": "^0.10.3",
-        "@pwrs/cem-linux-x64": "^0.10.3",
+        "@pwrs/cem-darwin-arm64": "^0.10.5",
+        "@pwrs/cem-darwin-x64": "^0.10.5",
+        "@pwrs/cem-linux-arm64": "^0.10.5",
+        "@pwrs/cem-linux-x64": "^0.10.5",
         "@rollup/rollup-darwin-arm64": "^4.54.0"
       }
     },
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/@pwrs/cem": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.10.4.tgz",
-      "integrity": "sha512-bvG7eg+YwAhUZBt/Yff8sGirAhaxIZ63IMytvynzj47cTHbM6Uka5ySVsoyATLBvNaHLQhb3Uz7APijK5qvqiw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem/-/cem-0.10.5.tgz",
+      "integrity": "sha512-RHyHN+CbzyoUJ6ruAKGY1AYTmRvoPvp2TOSLLdiOpDaPEEazNNhXOoR6i5vNxgQqd2eSdqgUGXY32thdL1CdTA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2424,18 +2424,18 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@pwrs/cem-darwin-arm64": "0.10.4",
-        "@pwrs/cem-darwin-x64": "0.10.4",
-        "@pwrs/cem-linux-arm64": "0.10.4",
-        "@pwrs/cem-linux-x64": "0.10.4",
-        "@pwrs/cem-win32-arm64": "0.10.4",
-        "@pwrs/cem-win32-x64": "0.10.4"
+        "@pwrs/cem-darwin-arm64": "0.10.5",
+        "@pwrs/cem-darwin-x64": "0.10.5",
+        "@pwrs/cem-linux-arm64": "0.10.5",
+        "@pwrs/cem-linux-x64": "0.10.5",
+        "@pwrs/cem-win32-arm64": "0.10.5",
+        "@pwrs/cem-win32-x64": "0.10.5"
       }
     },
     "node_modules/@pwrs/cem-darwin-arm64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.10.4.tgz",
-      "integrity": "sha512-OUTRJwAZbmo9IEYo7gEODf5QgG3jWqroFa57OzTc6ANULJFEQzXB1bGSCmR0on75ciK80m9FR0vjHzaUDStlyQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-arm64/-/cem-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-R6vqjqgGq31C1LL834LWibPwDZbHi5X0+hhtn8iJX5sv+MLib1G7Fmsu1TYOZ4Bhqd7qI0B8Qn3Vq5QAYi1RtA==",
       "cpu": [
         "arm64"
       ],
@@ -2446,9 +2446,9 @@
       ]
     },
     "node_modules/@pwrs/cem-darwin-x64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.10.4.tgz",
-      "integrity": "sha512-Sh2x/7wEdPLdcrniRTjH5BLbB74aCef7WYY2bnGlmMYRvSUJvwUhzP5H6dYERePBDNHgL3vcx6aj/ShV6YQvVA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-darwin-x64/-/cem-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-6i/XkhRl/jGVeB/KiLB8geDfMa4K2UpliMOb4EESnw8RqnjpY7MpFIrsmfaxbFyGTEVdrh3VScXi7FKhnCi8Sw==",
       "cpu": [
         "x64"
       ],
@@ -2459,9 +2459,9 @@
       ]
     },
     "node_modules/@pwrs/cem-linux-arm64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.10.4.tgz",
-      "integrity": "sha512-rGVWI4o63h5DSMBofJI/31UwGtB9Jo4Rt2+LDB99ckTJDHegkOeuE0VXHLtx+uV08udNyFp3Cpml4WoDIy3cIQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-arm64/-/cem-linux-arm64-0.10.5.tgz",
+      "integrity": "sha512-UTXBYzFrmLv8820hm84wWN2/thrAPVGwWCijvLfrSIawwzwnIw2GbGTAFLJscaX37Soy22dZ4wRsDOAUzvgc1Q==",
       "cpu": [
         "arm64"
       ],
@@ -2472,9 +2472,9 @@
       ]
     },
     "node_modules/@pwrs/cem-linux-x64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.10.4.tgz",
-      "integrity": "sha512-wtXNm+/sXyqCJ7j9pMGO7VZ7LCo2W5b5nAz/vE1dW5Ejc/uDmne8wDrqikI87EgrxbSKOY+UfYeCnMKCOQlV3Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-linux-x64/-/cem-linux-x64-0.10.5.tgz",
+      "integrity": "sha512-l9/nvKsqkeCVvQlzatpTGYJ7ToXHSP0k9gp7LoK+J9JMuAZ9q9CJLM+6qn5owTICZzqgHt4YQeC92GUHuH5bnw==",
       "cpu": [
         "x64"
       ],
@@ -2485,9 +2485,9 @@
       ]
     },
     "node_modules/@pwrs/cem-win32-arm64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.10.4.tgz",
-      "integrity": "sha512-nsL+LG1YhhCnoTAuhOcnwU9raEfv4B0M9LzlcRT064A3gQvshD/U50P4Nn3nJS39YIV+TrJaftqopKnIPt9hJQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-arm64/-/cem-win32-arm64-0.10.5.tgz",
+      "integrity": "sha512-4pRmhzxuvBJOiNzpOTBsajYnkbSietpjarawERph/qqZDetv+Jzl/G9WRsCakX8/LeSn/pvTooR6VTein7xokA==",
       "cpu": [
         "arm64"
       ],
@@ -2499,9 +2499,9 @@
       ]
     },
     "node_modules/@pwrs/cem-win32-x64": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.10.4.tgz",
-      "integrity": "sha512-LpIGvu2OqmbPBY2Dux3npbv9N8EPwGIxOdwFeizEOFHBf2N/jLtNFDLoS/28MbIJU5zWrhh5w1ETJCRx4V8sIw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@pwrs/cem-win32-x64/-/cem-win32-x64-0.10.5.tgz",
+      "integrity": "sha512-oKRhEVymhAe3I/dSvpNSy46L5QJr/tqGGcByJtAfIDaAw2ZQUe1trpafPfLNJMif1jhP42fbpHnbHJRUCNIWiw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "@lit/react": "^1.0.8",
     "@octokit/core": "^6.1.2",
     "@patternfly/patternfly": "^4.224.5",
-    "@pwrs/cem": "^0.10.4",
+    "@pwrs/cem": "^0.10.5",
     "@pwrs/mappa": "^0.0.6",
     "@rhds/elements": "^4.0.1",
     "@types/koa__router": "^12.0.5",
@@ -297,10 +297,10 @@
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "^0.27.2",
     "@esbuild/linux-x64": "^0.27.2",
-    "@pwrs/cem-darwin-arm64": "^0.10.3",
-    "@pwrs/cem-darwin-x64": "^0.10.3",
-    "@pwrs/cem-linux-arm64": "^0.10.3",
-    "@pwrs/cem-linux-x64": "^0.10.3",
+    "@pwrs/cem-darwin-arm64": "^0.10.5",
+    "@pwrs/cem-darwin-x64": "^0.10.5",
+    "@pwrs/cem-linux-arm64": "^0.10.5",
+    "@pwrs/cem-linux-x64": "^0.10.5",
     "@rollup/rollup-darwin-arm64": "^4.54.0"
   },
   "workspaces": [


### PR DESCRIPTION
## Summary

- Bump `@pwrs/cem` from ^0.10.4 to ^0.10.5
- Bump platform-specific optional deps from ^0.10.3 to ^0.10.5

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>