### PR TITLE
fix(pfe-tools): end-anchor TS redirect regex to avoid rewriting .js.map

### DIFF
--- a/tools/pfe-tools/dev-server/config.ts
+++ b/tools/pfe-tools/dev-server/config.ts
@@ -88,19 +88,11 @@ async function cacheBusterMiddleware(ctx: Context, next: () => Promise<any>) {
 function liveReloadTsChangesMiddleware(
   config: ReturnType<typeof normalizeOptions>,
 ): Middleware {
-  /**
-   * capture group 1:
-   *   Either config.elementsDir or `pfe-core`
-   * `/`
-   * **ANY** (_>= 0x_)
-   * `.js`
-   */
-  const TYPESCRIPT_SOURCES_RE = new RegExp(`(${config.elementsDir}|pfe-core)/.*\\.js`);
-
+  const TYPESCRIPT_SOURCES_RE = new RegExp(`(${config.elementsDir}|pfe-core)/.*\\.js$`);
   return function(ctx, next) {
-    if (!ctx.path.includes('node_modules') && ctx.path
-        .match(TYPESCRIPT_SOURCES_RE)) {
-      ctx.redirect(ctx.path.replace('.js', '.ts'));
+    if (!ctx.path.includes('node_modules')
+        && TYPESCRIPT_SOURCES_RE.test(ctx.path)) {
+      ctx.redirect(ctx.path.replace(/\.js$/, '.ts'));
     } else {
       return next();
     }


### PR DESCRIPTION
## Summary

- The `.js` regex in `liveReloadTsChangesMiddleware` was not end-anchored, so requests for `.js.map` (source maps) were matched and rewritten to `.ts.map`, breaking source maps
- End-anchor the regex (`\.js$`) and use regex replacement so only the final `.js` extension is rewritten

## Test plan

- [ ] `npm run dev` serves elements correctly
- [ ] Source maps (`.js.map`) load without 404 or redirect