### PR TITLE
docs(create-element): add README phase to element skills

### DIFF
--- a/.claude/skills/create-element/SKILL.md
+++ b/.claude/skills/create-element/SKILL.md
@@ -274,7 +274,43 @@ Write all tests from scratch:
 
 See `.claude/skills/review-api/SKILL.md` Phase 4 for full test checklist.
 
-### Phase 8: Audit
+### Phase 8: Write README
+
+Create `elements/pf-v6-{name}/README.md` documenting divergences from
+the React component API. Structure:
+
+1. **Title and summary** -- element tag, one-line description
+2. **Usage** -- 2-3 HTML snippets showing common patterns
+3. **Divergences from React `{Name}`** -- three tables:
+
+#### "Not implemented" table (2 columns: React prop | Notes)
+React props with no web component equivalent and no workaround.
+Only truly absent features belong here.
+
+#### "Changed API" table (3 columns: React prop | Web component | Difference)
+React props that have a web component equivalent but with different API shape.
+Include props where:
+- Name changed (e.g. `enableFlip` -> `no-flip`)
+- Type changed (e.g. boolean -> enum, prop -> CSS custom property)
+- Mechanism changed (e.g. callback -> DOM event, declarative -> imperative)
+- Not configurable but has a fixed internal value (note "Not supported" or
+  "Hardcoded to X")
+
+**Omit** props that map 1:1 as camelCase properties with dash-case attributes
+and identical semantics (e.g. React `entryDelay` -> attribute `entry-delay`).
+These are standard web component conventions, not divergences.
+
+#### "Added" table (2 columns: Web component API | Notes)
+Web-component-only APIs not present in React (events, methods, slots, CSS
+custom properties).
+
+**Accuracy rule:** verify each claim against the actual CSS and TS source.
+Don't claim CSS properties on the host affect shadow DOM internals. Check
+whether values are actually configurable or hardcoded.
+
+See `elements/pf-v6-tooltip/README.md` for a reference example.
+
+### Phase 9: Audit
 
 Prompt the user to activate /review-api, /review-demos, and /review-a11y
 

--- a/.claude/skills/update-element/SKILL.md
+++ b/.claude/skills/update-element/SKILL.md
@@ -255,7 +255,43 @@ Update existing tests -- don't rewrite from scratch:
 
 See `.claude/skills/review-api/SKILL.md` Phase 4 for full test checklist.
 
-### Phase 8: Audit
+### Phase 8: Write README
+
+Create `elements/pf-v6-{name}/README.md` documenting divergences from
+the React component API. Structure:
+
+1. **Title and summary** -- element tag, one-line description
+2. **Usage** -- 2-3 HTML snippets showing common patterns
+3. **Divergences from React `{Name}`** -- three tables:
+
+#### "Not implemented" table (2 columns: React prop | Notes)
+React props with no web component equivalent and no workaround.
+Only truly absent features belong here.
+
+#### "Changed API" table (3 columns: React prop | Web component | Difference)
+React props that have a web component equivalent but with different API shape.
+Include props where:
+- Name changed (e.g. `enableFlip` -> `no-flip`)
+- Type changed (e.g. boolean -> enum, prop -> CSS custom property)
+- Mechanism changed (e.g. callback -> DOM event, declarative -> imperative)
+- Not configurable but has a fixed internal value (note "Not supported" or
+  "Hardcoded to X")
+
+**Omit** props that map 1:1 as camelCase properties with dash-case attributes
+and identical semantics (e.g. React `entryDelay` -> attribute `entry-delay`).
+These are standard web component conventions, not divergences.
+
+#### "Added" table (2 columns: Web component API | Notes)
+Web-component-only APIs not present in React (events, methods, slots, CSS
+custom properties).
+
+**Accuracy rule:** verify each claim against the actual CSS and TS source.
+Don't claim CSS properties on the host affect shadow DOM internals. Check
+whether values are actually configurable or hardcoded.
+
+See `elements/pf-v6-tooltip/README.md` for a reference example.
+
+### Phase 9: Audit
 
 Prompt the user to activate /review-api, /review-demos, and /review-a11y
 


### PR DESCRIPTION
## Summary

- Adds Phase 8 (README) to both `create-element` and `update-element` skills
- Instructs agents to produce `elements/pf-v6-{name}/README.md` documenting divergences from the React component API
- Three tables: "Not implemented", "Changed API", "Added"
- Includes accuracy rules (verify against actual CSS/TS source, don't claim host CSS affects shadow DOM internals)
- References `elements/pf-v6-tooltip/README.md` as a worked example

## Test plan

- [ ] Run `/create-element` on a new element and verify README is produced
- [ ] Run `/update-element` on an existing element and verify README is produced
- [ ] Verify README accuracy rules catch false claims about shadow DOM styling